### PR TITLE
fix(downloads): aggregate concurrent model download progress in the macOS Dock

### DIFF
--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -716,9 +716,10 @@ interface TaskbarDownload extends DownloadProgress {
   id: string
 }
 
-/** A taskbar batch retains terminal jobs until the last job finishes. Without
+/** A taskbar batch retains completed jobs until the last job finishes. Without
  *  that retention, completing one of two downloads would remove its bytes
- *  from the denominator and make the aggregate bar jump backwards. */
+ *  from the denominator and make the aggregate bar jump backwards. Cancelled
+ *  and failed jobs are removed because they no longer belong to the workload. */
 const taskbarBatches = new Map<BrowserWindow, Map<string, TaskbarDownload>>()
 
 function mergeTaskbarDownload(
@@ -739,17 +740,17 @@ function mergeTaskbarDownload(
   return merged
 }
 
-/** Aggregate known byte totals. An active job without a known size makes the
- *  native bar indeterminate (> 1 per Electron) rather than showing a false
- *  percentage. Terminal unknown-size jobs do not hide progress for work that
- *  is still measurable. */
+/** Aggregate known byte totals. Keep the bar empty until every active job has
+ *  reported its size: Electron's indeterminate value (> 1) briefly renders as
+ *  a full Dock bar on macOS. Completed unknown-size jobs do not hide progress
+ *  for work that is still measurable. */
 function aggregateTaskbarProgress(downloads: Iterable<TaskbarDownload>): number {
   const jobs = [...downloads]
   if (!jobs.some((job) => !isTerminalStatus(job.status))) return -1
   if (
     jobs.some((job) => !isTerminalStatus(job.status) && !(job.totalBytes && job.totalBytes > 0))
   ) {
-    return 2
+    return 0
   }
 
   let receivedBytes = 0
@@ -763,7 +764,7 @@ function aggregateTaskbarProgress(downloads: Iterable<TaskbarDownload>): number 
         : (job.receivedBytes ?? job.progress * job.totalBytes)
     receivedBytes += Math.max(0, Math.min(job.totalBytes, received))
   }
-  return totalBytes > 0 ? Math.max(0, Math.min(1, receivedBytes / totalBytes)) : 2
+  return totalBytes > 0 ? Math.max(0, Math.min(1, receivedBytes / totalBytes)) : 0
 }
 
 function liveTaskbarBatches(): Array<[BrowserWindow, Map<string, TaskbarDownload>]> {
@@ -779,7 +780,11 @@ function setTaskbarProgress(win: BrowserWindow, progress: DownloadProgress & { i
   if (win.isDestroyed()) return
   let batch = taskbarBatches.get(win)
   if (!batch) taskbarBatches.set(win, (batch = new Map()))
-  batch.set(progress.id, mergeTaskbarDownload(batch.get(progress.id), progress))
+  if (progress.status === 'cancelled' || progress.status === 'error') {
+    batch.delete(progress.id)
+  } else {
+    batch.set(progress.id, mergeTaskbarDownload(batch.get(progress.id), progress))
+  }
 
   // macOS exposes one Dock progress bar for the whole application, so every
   // window-backed download must contribute to the same value. Other platforms

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -712,17 +712,101 @@ function broadcastProgress(progress: DownloadProgress): void {
   downloadEvents.emit('tray-state-changed')
 }
 
-function setTaskbarProgress(win: BrowserWindow, progress: DownloadProgress): void {
-  if (win.isDestroyed()) return
-  if (progress.status === 'downloading') {
-    win.setProgressBar(progress.progress)
-  } else if (
-    progress.status === 'completed' ||
-    progress.status === 'error' ||
-    progress.status === 'cancelled'
-  ) {
-    win.setProgressBar(-1)
+interface TaskbarDownload extends DownloadProgress {
+  id: string
+}
+
+/** A taskbar batch retains terminal jobs until the last job finishes. Without
+ *  that retention, completing one of two downloads would remove its bytes
+ *  from the denominator and make the aggregate bar jump backwards. */
+const taskbarBatches = new Map<BrowserWindow, Map<string, TaskbarDownload>>()
+
+function mergeTaskbarDownload(
+  previous: TaskbarDownload | undefined,
+  progress: DownloadProgress & { id: string }
+): TaskbarDownload {
+  const merged = {
+    ...previous,
+    ...progress,
+    receivedBytes: progress.receivedBytes ?? previous?.receivedBytes,
+    totalBytes: progress.totalBytes ?? previous?.totalBytes
   }
+  // A transport may complete between throttled progress ticks. Its terminal
+  // report is authoritative even when the last sampled byte count was lower.
+  if (merged.status === 'completed' && merged.totalBytes && merged.totalBytes > 0) {
+    merged.receivedBytes = merged.totalBytes
+  }
+  return merged
+}
+
+/** Aggregate known byte totals. An active job without a known size makes the
+ *  native bar indeterminate (> 1 per Electron) rather than showing a false
+ *  percentage. Terminal unknown-size jobs do not hide progress for work that
+ *  is still measurable. */
+function aggregateTaskbarProgress(downloads: Iterable<TaskbarDownload>): number {
+  const jobs = [...downloads]
+  if (!jobs.some((job) => !isTerminalStatus(job.status))) return -1
+  if (
+    jobs.some((job) => !isTerminalStatus(job.status) && !(job.totalBytes && job.totalBytes > 0))
+  ) {
+    return 2
+  }
+
+  let receivedBytes = 0
+  let totalBytes = 0
+  for (const job of jobs) {
+    if (!(job.totalBytes && job.totalBytes > 0)) continue
+    totalBytes += job.totalBytes
+    const received =
+      job.status === 'completed'
+        ? job.totalBytes
+        : (job.receivedBytes ?? job.progress * job.totalBytes)
+    receivedBytes += Math.max(0, Math.min(job.totalBytes, received))
+  }
+  return totalBytes > 0 ? Math.max(0, Math.min(1, receivedBytes / totalBytes)) : 2
+}
+
+function liveTaskbarBatches(): Array<[BrowserWindow, Map<string, TaskbarDownload>]> {
+  const live: Array<[BrowserWindow, Map<string, TaskbarDownload>]> = []
+  for (const [win, batch] of taskbarBatches) {
+    if (win.isDestroyed()) taskbarBatches.delete(win)
+    else live.push([win, batch])
+  }
+  return live
+}
+
+function setTaskbarProgress(win: BrowserWindow, progress: DownloadProgress & { id: string }): void {
+  if (win.isDestroyed()) return
+  let batch = taskbarBatches.get(win)
+  if (!batch) taskbarBatches.set(win, (batch = new Map()))
+  batch.set(progress.id, mergeTaskbarDownload(batch.get(progress.id), progress))
+
+  // macOS exposes one Dock progress bar for the whole application, so every
+  // window-backed download must contribute to the same value. Other platforms
+  // retain their native per-window taskbar behavior.
+  const batches = liveTaskbarBatches()
+  const scopedBatches =
+    process.platform === 'darwin' ? batches : batches.filter(([candidate]) => candidate === win)
+  const aggregate = aggregateTaskbarProgress(
+    scopedBatches.flatMap(([, jobs]) => [...jobs.values()])
+  )
+
+  for (const [target] of scopedBatches) target.setProgressBar(aggregate)
+  if (aggregate < 0) {
+    for (const [target] of scopedBatches) taskbarBatches.delete(target)
+  }
+}
+
+function detachTaskbarProgress(win: BrowserWindow): void {
+  taskbarBatches.delete(win)
+  if (!win.isDestroyed()) win.setProgressBar(-1)
+  if (process.platform !== 'darwin') return
+
+  const batches = liveTaskbarBatches()
+  if (batches.length === 0) return
+  const aggregate = aggregateTaskbarProgress(batches.flatMap(([, jobs]) => [...jobs.values()]))
+  for (const [target] of batches) target.setProgressBar(aggregate)
+  if (aggregate < 0) taskbarBatches.clear()
 }
 
 /** First-seen timestamp per job id, preserved across status transitions and
@@ -2230,6 +2314,7 @@ export function clearFinishedDownloads(): number {
  *  retained reference would pin the closed BrowserWindow forever. */
 export function detachWindowDownloads(win: BrowserWindow): void {
   const contents = win.isDestroyed() ? undefined : win.webContents
+  detachTaskbarProgress(win)
   // The initiating sender is usually a ComfyUI WebContentsView hosted by the
   // window, not the window's own webContents - match by owner (or by already
   // being destroyed), not only by identity with `win.webContents`.
@@ -2245,7 +2330,6 @@ export function detachWindowDownloads(win: BrowserWindow): void {
   }
   for (const pending of pendingDownloads.values()) {
     if (pending.window === win) {
-      if (!win.isDestroyed()) win.setProgressBar(-1)
       pending.window = undefined
     }
     pending.subscriberWindows.delete(win)

--- a/src/main/lib/comfyDownloadManagerModelJobs.test.ts
+++ b/src/main/lib/comfyDownloadManagerModelJobs.test.ts
@@ -1384,6 +1384,94 @@ describe('destination-keyed retry (issue #1322)', () => {
   })
 })
 
+describe('taskbar download progress', () => {
+  it('shows byte-weighted batch progress and clears only after every download finishes', async () => {
+    const nameA = uniqueName()
+    const nameB = uniqueName()
+    const before = transfers.length
+    const makeWindow = () => {
+      const setProgressBar = vi.fn()
+      return {
+        setProgressBar,
+        window: {
+          isDestroyed: () => false,
+          setProgressBar,
+          webContents: {
+            isDestroyed: () => false,
+            send: vi.fn(),
+            session: {}
+          }
+        }
+      }
+    }
+    const winA = makeWindow()
+    const winB = makeWindow()
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { ...platformDescriptor, value: 'darwin' })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    let h1: ComfyDownloadManager.ModelJobHandle | undefined
+    let h2: ComfyDownloadManager.ModelJobHandle | undefined
+
+    try {
+      h1 = await mod.startManagedModelJob({
+        url: `https://host.example/${nameA}`,
+        filename: nameA,
+        directory: 'checkpoints',
+        window: winA.window as never
+      })
+      h2 = await mod.startManagedModelJob({
+        url: `https://host.example/${nameB}`,
+        filename: nameB,
+        directory: 'checkpoints',
+        window: winB.window as never
+      })
+      await waitForTransfers(before + 2)
+      winA.setProgressBar.mockClear()
+      winB.setProgressBar.mockClear()
+
+      now.mockReturnValue(2_000)
+      transfers[before]!.opts.onProgress?.({ receivedBytes: 50, totalBytes: 100 })
+      // The second job has not reported its size yet, so Electron receives an
+      // indeterminate value instead of a misleading single-file percentage.
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(2)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(2)
+
+      now.mockReturnValue(3_000)
+      transfers[before + 1]!.opts.onProgress?.({ receivedBytes: 25, totalBytes: 300 })
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(75 / 400)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(75 / 400)
+
+      winA.setProgressBar.mockClear()
+      winB.setProgressBar.mockClear()
+      transfers[before]!.resolve({ outcome: 'completed', savePath: h1.savePath })
+      await expect(h1.completion).resolves.toMatchObject({ status: 'completed' })
+      // Completed bytes remain in the batch denominator while h2 is active;
+      // finishing h1 must neither clear the Dock bar nor make it jump back.
+      expect(winA.setProgressBar).not.toHaveBeenCalledWith(-1)
+      expect(winB.setProgressBar).not.toHaveBeenCalledWith(-1)
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(125 / 400)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(125 / 400)
+
+      now.mockReturnValue(4_000)
+      transfers[before + 1]!.opts.onProgress?.({ receivedBytes: 150, totalBytes: 300 })
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(250 / 400)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(250 / 400)
+
+      transfers[before + 1]!.resolve({ outcome: 'completed', savePath: h2.savePath })
+      await expect(h2.completion).resolves.toMatchObject({ status: 'completed' })
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(-1)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(-1)
+    } finally {
+      now.mockRestore()
+      if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor)
+      if (h1) mod.cancelModelDownload(h1.id)
+      if (h2) mod.cancelModelDownload(h2.id)
+      await Promise.allSettled([h1?.completion, h2?.completion])
+      await flush()
+    }
+  })
+})
+
 describe('owner-window detach (issue #1322)', () => {
   it('detaching an owner window clears a hosted WebContentsView sender', async () => {
     const name = uniqueName()

--- a/src/main/lib/comfyDownloadManagerModelJobs.test.ts
+++ b/src/main/lib/comfyDownloadManagerModelJobs.test.ts
@@ -1385,29 +1385,37 @@ describe('destination-keyed retry (issue #1322)', () => {
 })
 
 describe('taskbar download progress', () => {
+  const makeWindow = () => {
+    const setProgressBar = vi.fn()
+    return {
+      setProgressBar,
+      window: {
+        isDestroyed: () => false,
+        setProgressBar,
+        webContents: {
+          isDestroyed: () => false,
+          send: vi.fn(),
+          session: {}
+        }
+      }
+    }
+  }
+
+  const forceDarwin = (): (() => void) => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { ...descriptor, value: 'darwin' })
+    return () => {
+      if (descriptor) Object.defineProperty(process, 'platform', descriptor)
+    }
+  }
+
   it('shows byte-weighted batch progress and clears only after every download finishes', async () => {
     const nameA = uniqueName()
     const nameB = uniqueName()
     const before = transfers.length
-    const makeWindow = () => {
-      const setProgressBar = vi.fn()
-      return {
-        setProgressBar,
-        window: {
-          isDestroyed: () => false,
-          setProgressBar,
-          webContents: {
-            isDestroyed: () => false,
-            send: vi.fn(),
-            session: {}
-          }
-        }
-      }
-    }
     const winA = makeWindow()
     const winB = makeWindow()
-    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { ...platformDescriptor, value: 'darwin' })
+    const restorePlatform = forceDarwin()
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
     let h1: ComfyDownloadManager.ModelJobHandle | undefined
     let h2: ComfyDownloadManager.ModelJobHandle | undefined
@@ -1431,10 +1439,10 @@ describe('taskbar download progress', () => {
 
       now.mockReturnValue(2_000)
       transfers[before]!.opts.onProgress?.({ receivedBytes: 50, totalBytes: 100 })
-      // The second job has not reported its size yet, so Electron receives an
-      // indeterminate value instead of a misleading single-file percentage.
-      expect(winA.setProgressBar).toHaveBeenLastCalledWith(2)
-      expect(winB.setProgressBar).toHaveBeenLastCalledWith(2)
+      // Keep the bar empty until every active job has reported its size.
+      // Electron's indeterminate value (> 1) flashes as a full Dock bar.
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(0)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(0)
 
       now.mockReturnValue(3_000)
       transfers[before + 1]!.opts.onProgress?.({ receivedBytes: 25, totalBytes: 300 })
@@ -1463,7 +1471,66 @@ describe('taskbar download progress', () => {
       expect(winB.setProgressBar).toHaveBeenLastCalledWith(-1)
     } finally {
       now.mockRestore()
-      if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor)
+      restorePlatform()
+      if (h1) mod.cancelModelDownload(h1.id)
+      if (h2) mod.cancelModelDownload(h2.id)
+      await Promise.allSettled([h1?.completion, h2?.completion])
+      await flush()
+    }
+  })
+
+  it('removes a cancelled download from the aggregate immediately', async () => {
+    const nameA = uniqueName()
+    const nameB = uniqueName()
+    const before = transfers.length
+    const winA = makeWindow()
+    const winB = makeWindow()
+    const restorePlatform = forceDarwin()
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    let h1: ComfyDownloadManager.ModelJobHandle | undefined
+    let h2: ComfyDownloadManager.ModelJobHandle | undefined
+
+    try {
+      h1 = await mod.startManagedModelJob({
+        url: `https://host.example/${nameA}`,
+        filename: nameA,
+        directory: 'checkpoints',
+        window: winA.window as never
+      })
+      h2 = await mod.startManagedModelJob({
+        url: `https://host.example/${nameB}`,
+        filename: nameB,
+        directory: 'checkpoints',
+        window: winB.window as never
+      })
+      await waitForTransfers(before + 2)
+
+      now.mockReturnValue(2_000)
+      transfers[before]!.opts.onProgress?.({ receivedBytes: 50, totalBytes: 100 })
+      now.mockReturnValue(3_000)
+      transfers[before + 1]!.opts.onProgress?.({ receivedBytes: 25, totalBytes: 300 })
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(75 / 400)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(75 / 400)
+
+      winA.setProgressBar.mockClear()
+      winB.setProgressBar.mockClear()
+      expect(mod.cancelModelDownload(h1.id)).toBe(true)
+      await expect(h1.completion).resolves.toEqual({ status: 'cancelled' })
+
+      // Cancelling h1 removes both its received bytes and its total from the
+      // batch, leaving only h2's 25 / 300 progress.
+      expect(winA.setProgressBar).not.toHaveBeenCalledWith(-1)
+      expect(winB.setProgressBar).not.toHaveBeenCalledWith(-1)
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(25 / 300)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(25 / 300)
+
+      transfers[before + 1]!.resolve({ outcome: 'completed', savePath: h2.savePath })
+      await expect(h2.completion).resolves.toMatchObject({ status: 'completed' })
+      expect(winA.setProgressBar).toHaveBeenLastCalledWith(-1)
+      expect(winB.setProgressBar).toHaveBeenLastCalledWith(-1)
+    } finally {
+      now.mockRestore()
+      restorePlatform()
       if (h1) mod.cancelModelDownload(h1.id)
       if (h2) mod.cancelModelDownload(h2.id)
       await Promise.allSettled([h1?.completion, h2?.completion])


### PR DESCRIPTION
## Summary

- Aggregate concurrent model downloads into one byte-weighted Dock progress value on macOS.
- Preserve native per-window taskbar progress behavior on other platforms.
- Handle downloads with unknown sizes, completed jobs, cancellations, failures, and detached windows.
- Add regression coverage for concurrent progress aggregation and cancellation.

## Problem

Each model download currently reports its own progress directly to Electron's `setProgressBar()` API.

On macOS, the application has one shared Dock progress indicator. Concurrent downloads therefore overwrite each other's values, causing the Dock progress to jump forwards and backwards instead of representing the complete download workload.

Fixes #1421.

## Root Cause

Taskbar progress was tracked as a property of an individual download update. There was no persistent batch keyed by download ID and no aggregation across windows on macOS.

As a result, whichever download reported most recently controlled the Dock indicator.

## Changes

- Track taskbar download state by stable download ID.
- Aggregate macOS Dock progress across all live application windows.
- Calculate aggregate progress using total received bytes divided by total expected bytes.
- Keep completed downloads in the batch until the remaining downloads finish, preventing the aggregate from jumping backwards.
- Remove cancelled and failed downloads immediately and recalculate progress from the remaining workload.
- Keep the Dock progress empty while an active download has not reported its total size, avoiding a brief full-progress flash on macOS.
- Clear the native progress indicator only after the active batch finishes.
- Remove taskbar state when its owner window is detached or destroyed.
- Retain per-window progress behavior on non-macOS platforms.

## Validation

### Automated

- `pnpm exec vitest run src/main/lib/comfyDownloadManagerModelJobs.test.ts`
  - 61 tests passed
- `pnpm test`
  - 255 test files passed
  - 4,343 tests passed
  - 2 existing tests skipped
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`

### Manual macOS Testing

Tested with a locally packaged Comfy Desktop 1.0.39 build on macOS 15.7.7, Apple Silicon (`arm64`).

1. Started multiple large model downloads concurrently with different file sizes and download speeds.
2. Compared the individual percentages in the download list with the progress displayed on the Dock icon.
3. Verified that concurrent downloads are represented by one aggregate Dock progress value instead of alternating between individual percentages.
4. During the first validation pass, identified two aggregation edge cases:
   - Starting a download could briefly display a full Dock progress bar before its total size was known.
   - Cancelling one concurrent download did not immediately update the aggregate.
5. After addressing both edge cases, repeated the same concurrent-download scenario.
6. Verified that the Dock no longer flashes as complete when a download starts.
7. Cancelled one download while another remained active and verified that the Dock progress was recalculated from the remaining workload.
8. Continued downloading multiple models and observed normal aggregate progress behavior.

## Compatibility

This change does not modify public APIs, download identifiers, file layout, or model download behavior. Non-macOS platforms retain per-window native taskbar progress.
