### PR TITLE
feat(templates): support trusted input asset downloads

### DIFF
--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -15,6 +15,47 @@ export interface ComfyDownloadProgress {
   error?: string
   isImage?: boolean
 }
+export interface ComfyTemplateInputReference {
+  templateId: string
+  assetId: string
+}
+export interface ComfyTemplateInputAssetDownload {
+  downloadId: string
+  filename: string
+  progress: number
+  receivedBytes?: number
+  totalBytes?: number
+  status: ComfyDownloadProgress['status']
+  error?: string
+}
+export interface ComfyTemplateInputDownloadProgress extends ComfyTemplateInputAssetDownload {
+  /** Every template asset currently sharing this managed download job. */
+  templateInputs: ComfyTemplateInputReference[]
+}
+export interface ComfyTemplateInputAsset {
+  /** Opaque, template-scoped identifier accepted by `downloadTemplateInputAsset`. */
+  assetId: string
+  filename: string
+  mediaType: 'image' | 'video' | 'audio'
+  /** Desktop-resolved public URL for previewing this declared template asset. */
+  previewUrl: string
+  availability: 'present' | 'missing' | 'unknown'
+  /** Present when this exact asset destination already has a managed job. */
+  activeDownload?: ComfyTemplateInputAssetDownload
+}
+export type ComfyTemplateInputAssetDownloadResult =
+  | {
+      status: 'already-present'
+    }
+  | {
+      status: 'accepted' | 'joined'
+      /** Admission snapshot seeds UI state even if the first IPC event raced ahead. */
+      download: ComfyTemplateInputAssetDownload
+    }
+  | {
+      status: 'not-started'
+      reason: 'invalid-request' | 'not-declared' | 'unavailable'
+    }
 export interface TerminalRestore {
   buffer: string[]
   size: {
@@ -80,6 +121,18 @@ export interface ComfyDesktop2Bridge {
   openModelAccessPage?: (url: string) => Promise<boolean>
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
   downloadAsset?: (url: string, filename: string, authToken?: string) => Promise<boolean>
+  /** Resolve only assets declared by this template. `null` means Desktop cannot
+   *  authorize the current renderer/installation; `[]` means none are declared. */
+  getTemplateInputAssets?: (templateId: string) => Promise<ComfyTemplateInputAsset[] | null>
+  /** Start or join the managed download for one declared template asset. */
+  downloadTemplateInputAsset?: (
+    templateId: string,
+    assetId: string
+  ) => Promise<ComfyTemplateInputAssetDownloadResult>
+  /** Download events decorated with the template asset identities that own the job. */
+  onTemplateInputDownloadProgress?: (
+    callback: (data: ComfyTemplateInputDownloadProgress) => void
+  ) => () => void
   pauseDownload?: (url: string) => Promise<boolean>
   resumeDownload?: (url: string) => Promise<boolean>
   cancelDownload?: (url: string) => Promise<boolean>

--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -122,7 +122,8 @@ export interface ComfyDesktop2Bridge {
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
   downloadAsset?: (url: string, filename: string, authToken?: string) => Promise<boolean>
   /** Resolve only assets declared by this template. `null` means Desktop cannot
-   *  authorize the current renderer/installation; `[]` means none are declared. */
+   *  authorize the caller or resolve the metadata; `[]` means the resolved
+   *  template declares none. */
   getTemplateInputAssets?: (templateId: string) => Promise<ComfyTemplateInputAsset[] | null>
   /** Start or join the managed download for one declared template asset. */
   downloadTemplateInputAsset?: (

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "type": "module",
   "main": "./index.js",

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "type": "module",
   "main": "./index.js",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2169,7 +2169,10 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     registerPickerSettingsIpc({ quitForRelaunch: quitApp })
     registerDownloadHandlers()
     registerAssetDownloadHandlers({ findInstallationIdForWindow })
-    registerTemplateInputAssetHandlers({ findInstallationIdForWindow })
+    registerTemplateInputAssetHandlers({
+      findInstallationIdForWindow,
+      isLocalInstallation: (installation) => sourceMap[installation.sourceId]?.category === 'local'
+    })
     cleanupTempDownloads()
     await ipc.register({
       onLaunch,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -64,6 +64,7 @@ import {
 import { isTerminal as isTemplateDownloadTerminal } from './sources/standalone/templateDownloadCore'
 import { registerAssetDownloadHandlers } from './lib/ipc/registerAssetDownloadHandlers'
 import { registerDownloadHandlers } from './lib/ipc/registerDownloadHandlers'
+import { registerTemplateInputAssetHandlers } from './lib/ipc/registerTemplateInputAssetHandlers'
 import { emitInstanceStartedTelemetry } from './lib/ipc/sessionStartTelemetry'
 import { emitStorageTelemetry } from './lib/ipc/storageTelemetry'
 import {
@@ -2168,6 +2169,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     registerPickerSettingsIpc({ quitForRelaunch: quitApp })
     registerDownloadHandlers()
     registerAssetDownloadHandlers({ findInstallationIdForWindow })
+    registerTemplateInputAssetHandlers({ findInstallationIdForWindow })
     cleanupTempDownloads()
     await ipc.register({
       onLaunch,

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -750,6 +750,34 @@ describe('asset download retries', () => {
     }
   })
 
+  it('does not join an exact request to a deduplicating job at the same destination', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      const deduplicating = await mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir)
+      const exact = await startExactAssetDownload(h, url, outputDir)
+
+      expect(deduplicating).toMatchObject({ status: 'accepted' })
+      expect(exact).toMatchObject({ status: 'accepted' })
+      if (deduplicating.status !== 'accepted' || exact.status !== 'accepted') {
+        throw new Error('Expected two accepted asset downloads')
+      }
+      expect(exact.downloadId).not.toBe(deduplicating.downloadId)
+      expect(h.session.downloadURL).toHaveBeenCalledTimes(2)
+
+      const first = bindAssetItem(h, url)
+      const second = bindAssetItem(h, url)
+      await fs.promises.writeFile(first.tempPath, 'deduplicating')
+      await fs.promises.writeFile(second.tempPath, 'exact')
+      first.getDone()!({}, 'completed')
+      second.getDone()!({}, 'completed')
+    } finally {
+      await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
   it('snapshots only the active download for the exact destination', async () => {
     const firstDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-first-'))
     const secondDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-second-'))

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -841,6 +841,51 @@ describe('asset download retries', () => {
     }
   })
 
+  it('preserves exact-destination semantics when a failed download is retried', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      const admission = await startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        outputDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+      if (admission.status !== 'accepted') {
+        throw new Error('Expected an accepted asset download')
+      }
+
+      const first = h.createItem(url)
+      h.getWillDownload()!({}, first.item, null)
+      const firstTempPath = first.setSavePath.mock.calls[0]?.[0]
+      expect(firstTempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(firstTempPath!, 'partial')
+      first.getDone()!({}, 'interrupted')
+
+      expect(mod.retryDownload(admission.downloadId)).toBe(true)
+      await vi.waitFor(() => expect(h.session.downloadURL).toHaveBeenCalledTimes(2))
+
+      const retry = h.createItem(url, 'attachment; filename="renamed-by-server.png"')
+      h.getWillDownload()!({}, retry.item, null)
+      const retryTempPath = retry.setSavePath.mock.calls[0]?.[0]
+      expect(retryTempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(retryTempPath!, 'complete')
+      retry.getDone()!({}, 'completed')
+
+      await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
+      await expect(fs.promises.readFile(path.join(outputDir, 'sample.png'), 'utf8')).resolves.toBe(
+        'complete'
+      )
+    } finally {
+      await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
   it('discards the download when an identical file already sits at the requested path', async () => {
     // The "remote" server may be a local ComfyUI writing outputs into the
     // same directory the auto-download saves to (desktop launches installs

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -677,6 +677,34 @@ describe('asset download retries', () => {
     return { win, session, send, getWillDownload: () => willDownload, createItem }
   }
 
+  function startExactAssetDownload(
+    harness: ReturnType<typeof makeAssetHarness>,
+    url: string,
+    outputDir: string
+  ) {
+    return mod.startManagedAssetDownload(
+      harness.win,
+      url,
+      'sample.png',
+      outputDir,
+      undefined,
+      undefined,
+      { existingFilePolicy: 'skip' }
+    )
+  }
+
+  function bindAssetItem(
+    harness: ReturnType<typeof makeAssetHarness>,
+    url: string,
+    contentDisposition: string | null = null
+  ) {
+    const item = harness.createItem(url, contentDisposition)
+    harness.getWillDownload()!({}, item.item, null)
+    const tempPath = item.setSavePath.mock.calls[0]?.[0]
+    expect(tempPath).toBeTypeOf('string')
+    return { ...item, tempPath: tempPath! }
+  }
+
   it('joins only the same URL and exact destination under one download identity', async () => {
     const firstDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-first-'))
     const secondDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-second-'))
@@ -684,33 +712,9 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const first = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        firstDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
-      const joined = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        firstDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
-      const otherDestination = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        secondDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
+      const first = await startExactAssetDownload(h, url, firstDir)
+      const joined = await startExactAssetDownload(h, url, firstDir)
+      const otherDestination = await startExactAssetDownload(h, url, secondDir)
 
       expect(first).toMatchObject({ status: 'accepted' })
       expect(joined).toEqual({
@@ -725,14 +729,10 @@ describe('asset download retries', () => {
       expect(h.session.downloadURL).toHaveBeenCalledTimes(2)
 
       const downloads = [firstDir, secondDir].map((outputDir) => {
-        const item = h.createItem(url)
-        h.getWillDownload()!({}, item.item, null)
-        const tempPath = item.setSavePath.mock.calls[0]?.[0]
-        expect(tempPath).toBeTypeOf('string')
-        return { item, outputDir, tempPath: tempPath! }
+        return { item: bindAssetItem(h, url), outputDir }
       })
-      for (const { outputDir, tempPath } of downloads) {
-        await fs.promises.writeFile(tempPath, outputDir)
+      for (const { item, outputDir } of downloads) {
+        await fs.promises.writeFile(item.tempPath, outputDir)
       }
       for (const { item } of downloads) {
         item.getDone()!({}, 'completed')
@@ -757,15 +757,7 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const admission = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        firstDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
+      const admission = await startExactAssetDownload(h, url, firstDir)
       if (admission.status !== 'accepted') {
         throw new Error('Expected an accepted asset download')
       }
@@ -776,11 +768,8 @@ describe('asset download retries', () => {
       })
       expect(mod.getActiveAssetDownload(url, 'sample.png', secondDir)).toBeUndefined()
 
-      const item = h.createItem(url)
-      h.getWillDownload()!({}, item.item, null)
-      const tempPath = item.setSavePath.mock.calls[0]?.[0]
-      expect(tempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(tempPath!, 'content')
+      const item = bindAssetItem(h, url)
+      await fs.promises.writeFile(item.tempPath, 'content')
       item.getDone()!({}, 'completed')
 
       expect(mod.getActiveAssetDownload(url, 'sample.png', firstDir)).toBeUndefined()
@@ -798,11 +787,9 @@ describe('asset download retries', () => {
     try {
       await fs.promises.writeFile(path.join(outputDir, 'sample.png'), 'existing')
 
-      await expect(
-        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
-          existingFilePolicy: 'skip'
-        })
-      ).resolves.toEqual({ status: 'already-present' })
+      await expect(startExactAssetDownload(h, url, outputDir)).resolves.toEqual({
+        status: 'already-present'
+      })
       expect(h.session.downloadURL).not.toHaveBeenCalled()
       await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
     } finally {
@@ -816,17 +803,12 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      await expect(
-        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
-          existingFilePolicy: 'skip'
-        })
-      ).resolves.toMatchObject({ status: 'accepted' })
+      await expect(startExactAssetDownload(h, url, outputDir)).resolves.toMatchObject({
+        status: 'accepted'
+      })
 
-      const item = h.createItem(url, 'attachment; filename="renamed-by-server.png"')
-      h.getWillDownload()!({}, item.item, null)
-      const tempPath = item.setSavePath.mock.calls[0]?.[0]
-      expect(tempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(tempPath!, 'content')
+      const item = bindAssetItem(h, url, 'attachment; filename="renamed-by-server.png"')
+      await fs.promises.writeFile(item.tempPath, 'content')
       item.getDone()!({}, 'completed')
 
       await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
@@ -845,24 +827,19 @@ describe('asset download retries', () => {
     const destination = path.join(outputDir, 'sample.png')
 
     try {
-      await expect(
-        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
-          existingFilePolicy: 'skip'
-        })
-      ).resolves.toMatchObject({ status: 'accepted' })
+      await expect(startExactAssetDownload(h, url, outputDir)).resolves.toMatchObject({
+        status: 'accepted'
+      })
 
-      const item = h.createItem(url)
-      h.getWillDownload()!({}, item.item, null)
-      const tempPath = item.setSavePath.mock.calls[0]?.[0]
-      expect(tempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(tempPath!, 'downloaded')
+      const item = bindAssetItem(h, url)
+      await fs.promises.writeFile(item.tempPath, 'downloaded')
       await fs.promises.writeFile(destination, 'created-during-download')
       item.getDone()!({}, 'completed')
 
       await expect(fs.promises.readFile(destination, 'utf8')).resolves.toBe(
         'created-during-download'
       )
-      await expect(fs.promises.stat(tempPath!)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(fs.promises.stat(item.tempPath)).rejects.toMatchObject({ code: 'ENOENT' })
     } finally {
       await fs.promises.rm(outputDir, { recursive: true, force: true })
     }
@@ -874,34 +851,20 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const admission = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        outputDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
+      const admission = await startExactAssetDownload(h, url, outputDir)
       if (admission.status !== 'accepted') {
         throw new Error('Expected an accepted asset download')
       }
 
-      const first = h.createItem(url)
-      h.getWillDownload()!({}, first.item, null)
-      const firstTempPath = first.setSavePath.mock.calls[0]?.[0]
-      expect(firstTempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(firstTempPath!, 'partial')
+      const first = bindAssetItem(h, url)
+      await fs.promises.writeFile(first.tempPath, 'partial')
       first.getDone()!({}, 'interrupted')
 
       expect(mod.retryDownload(admission.downloadId)).toBe(true)
       await vi.waitFor(() => expect(h.session.downloadURL).toHaveBeenCalledTimes(2))
 
-      const retry = h.createItem(url, 'attachment; filename="renamed-by-server.png"')
-      h.getWillDownload()!({}, retry.item, null)
-      const retryTempPath = retry.setSavePath.mock.calls[0]?.[0]
-      expect(retryTempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(retryTempPath!, 'complete')
+      const retry = bindAssetItem(h, url, 'attachment; filename="renamed-by-server.png"')
+      await fs.promises.writeFile(retry.tempPath, 'complete')
       retry.getDone()!({}, 'completed')
 
       await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
@@ -920,44 +883,27 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const failedAdmission = await mod.startManagedAssetDownload(
-        h.win,
-        url,
-        'sample.png',
-        firstDir,
-        undefined,
-        undefined,
-        { existingFilePolicy: 'skip' }
-      )
+      const failedAdmission = await startExactAssetDownload(h, url, firstDir)
       if (failedAdmission.status !== 'accepted') {
         throw new Error('Expected an accepted asset download')
       }
 
-      const failed = h.createItem(url)
-      h.getWillDownload()!({}, failed.item, null)
-      const failedTempPath = failed.setSavePath.mock.calls[0]?.[0]
-      expect(failedTempPath).toBeTypeOf('string')
-      await fs.promises.writeFile(failedTempPath!, 'partial')
+      const failed = bindAssetItem(h, url)
+      await fs.promises.writeFile(failed.tempPath, 'partial')
       failed.getDone()!({}, 'interrupted')
 
-      await expect(
-        mod.startManagedAssetDownload(h.win, url, 'sample.png', secondDir, undefined, undefined, {
-          existingFilePolicy: 'skip'
-        })
-      ).resolves.toMatchObject({ status: 'accepted' })
+      await expect(startExactAssetDownload(h, url, secondDir)).resolves.toMatchObject({
+        status: 'accepted'
+      })
 
       expect(mod.retryDownload(failedAdmission.downloadId)).toBe(true)
       await vi.waitFor(() => expect(h.session.downloadURL).toHaveBeenCalledTimes(3))
 
       const downloads = [secondDir, firstDir].map((outputDir) => {
-        const item = h.createItem(url)
-        h.getWillDownload()!({}, item.item, null)
-        const tempPath = item.setSavePath.mock.calls[0]?.[0]
-        expect(tempPath).toBeTypeOf('string')
-        return { item, outputDir, tempPath: tempPath! }
+        return { item: bindAssetItem(h, url), outputDir }
       })
-      for (const { outputDir, tempPath } of downloads) {
-        await fs.promises.writeFile(tempPath, outputDir)
+      for (const { item, outputDir } of downloads) {
+        await fs.promises.writeFile(item.tempPath, outputDir)
       }
       for (const { item } of downloads) {
         item.getDone()!({}, 'completed')

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -394,47 +394,6 @@ describe('resolveAssetSavePath', () => {
 })
 
 describe('asset download retries', () => {
-  type ManagedAssetAdmission =
-    | { status: 'already-present' | 'not-started' }
-    | { status: 'accepted' | 'joined'; downloadId: string }
-
-  type StartManagedAssetDownload = (
-    win: Electron.BrowserWindow,
-    url: string,
-    filename: string,
-    outputDir: string,
-    authToken?: string,
-    senderContents?: Electron.WebContents,
-    options?: { existingFilePolicy?: 'deduplicate' | 'skip' }
-  ) => Promise<ManagedAssetAdmission>
-
-  function startManagedAssetDownload(
-    ...args: Parameters<StartManagedAssetDownload>
-  ): Promise<ManagedAssetAdmission> {
-    const start = (
-      mod as typeof mod & {
-        startManagedAssetDownload?: StartManagedAssetDownload
-      }
-    ).startManagedAssetDownload
-    return start?.(...args) ?? Promise.resolve({ status: 'not-started' })
-  }
-
-  function getActiveAssetDownload(
-    url: string,
-    filename: string,
-    outputDir: string
-  ): ComfyDownloadManager.DownloadProgress | undefined {
-    return (
-      mod as typeof mod & {
-        getActiveAssetDownload?: (
-          url: string,
-          filename: string,
-          outputDir: string
-        ) => ComfyDownloadManager.DownloadProgress | undefined
-      }
-    ).getActiveAssetDownload?.(url, filename, outputDir)
-  }
-
   it('preserves a deduplicated nested path resolved from Content-Disposition', async () => {
     const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-output-'))
     const url = 'https://remote.example/api/view?filename=hash.mp4'
@@ -725,7 +684,7 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const first = await startManagedAssetDownload(
+      const first = await mod.startManagedAssetDownload(
         h.win,
         url,
         'sample.png',
@@ -734,7 +693,7 @@ describe('asset download retries', () => {
         undefined,
         { existingFilePolicy: 'skip' }
       )
-      const joined = await startManagedAssetDownload(
+      const joined = await mod.startManagedAssetDownload(
         h.win,
         url,
         'sample.png',
@@ -743,7 +702,7 @@ describe('asset download retries', () => {
         undefined,
         { existingFilePolicy: 'skip' }
       )
-      const otherDestination = await startManagedAssetDownload(
+      const otherDestination = await mod.startManagedAssetDownload(
         h.win,
         url,
         'sample.png',
@@ -786,7 +745,7 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const admission = await startManagedAssetDownload(
+      const admission = await mod.startManagedAssetDownload(
         h.win,
         url,
         'sample.png',
@@ -799,11 +758,11 @@ describe('asset download retries', () => {
         throw new Error('Expected an accepted asset download')
       }
 
-      expect(getActiveAssetDownload(url, 'sample.png', firstDir)).toMatchObject({
+      expect(mod.getActiveAssetDownload(url, 'sample.png', firstDir)).toMatchObject({
         id: admission.downloadId,
         status: 'pending'
       })
-      expect(getActiveAssetDownload(url, 'sample.png', secondDir)).toBeUndefined()
+      expect(mod.getActiveAssetDownload(url, 'sample.png', secondDir)).toBeUndefined()
 
       const item = h.createItem(url)
       h.getWillDownload()!({}, item.item, null)
@@ -812,7 +771,7 @@ describe('asset download retries', () => {
       await fs.promises.writeFile(tempPath!, 'content')
       item.getDone()!({}, 'completed')
 
-      expect(getActiveAssetDownload(url, 'sample.png', firstDir)).toBeUndefined()
+      expect(mod.getActiveAssetDownload(url, 'sample.png', firstDir)).toBeUndefined()
     } finally {
       await fs.promises.rm(firstDir, { recursive: true, force: true })
       await fs.promises.rm(secondDir, { recursive: true, force: true })
@@ -828,7 +787,7 @@ describe('asset download retries', () => {
       await fs.promises.writeFile(path.join(outputDir, 'sample.png'), 'existing')
 
       await expect(
-        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
           existingFilePolicy: 'skip'
         })
       ).resolves.toEqual({ status: 'already-present' })
@@ -846,7 +805,7 @@ describe('asset download retries', () => {
 
     try {
       await expect(
-        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
           existingFilePolicy: 'skip'
         })
       ).resolves.toMatchObject({ status: 'accepted' })
@@ -875,7 +834,7 @@ describe('asset download retries', () => {
 
     try {
       await expect(
-        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+        mod.startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
           existingFilePolicy: 'skip'
         })
       ).resolves.toMatchObject({ status: 'accepted' })
@@ -903,7 +862,7 @@ describe('asset download retries', () => {
     const h = makeAssetHarness()
 
     try {
-      const admission = await startManagedAssetDownload(
+      const admission = await mod.startManagedAssetDownload(
         h.win,
         url,
         'sample.png',

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -394,6 +394,31 @@ describe('resolveAssetSavePath', () => {
 })
 
 describe('asset download retries', () => {
+  type ManagedAssetAdmission =
+    | { status: 'already-present' | 'not-started' }
+    | { status: 'accepted' | 'joined'; downloadId: string }
+
+  type StartManagedAssetDownload = (
+    win: Electron.BrowserWindow,
+    url: string,
+    filename: string,
+    outputDir: string,
+    authToken?: string,
+    senderContents?: Electron.WebContents,
+    options?: { existingFilePolicy?: 'deduplicate' | 'skip' }
+  ) => Promise<ManagedAssetAdmission>
+
+  function startManagedAssetDownload(
+    ...args: Parameters<StartManagedAssetDownload>
+  ): Promise<ManagedAssetAdmission> {
+    const start = (
+      mod as typeof mod & {
+        startManagedAssetDownload?: StartManagedAssetDownload
+      }
+    ).startManagedAssetDownload
+    return start?.(...args) ?? Promise.resolve({ status: 'not-started' })
+  }
+
   it('preserves a deduplicated nested path resolved from Content-Disposition', async () => {
     const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-output-'))
     const url = 'https://remote.example/api/view?filename=hash.mp4'
@@ -653,7 +678,7 @@ describe('asset download retries', () => {
       webContents
     } as unknown as Electron.BrowserWindow
 
-    function createItem(itemUrl: string) {
+    function createItem(itemUrl: string, contentDisposition: string | null = null) {
       let done:
         | ((event: unknown, state: 'completed' | 'cancelled' | 'interrupted') => void)
         | undefined
@@ -661,7 +686,7 @@ describe('asset download retries', () => {
       const item = {
         getURLChain: () => [itemUrl],
         getURL: () => itemUrl,
-        getContentDisposition: () => null,
+        getContentDisposition: () => contentDisposition,
         setSavePath,
         on: vi.fn(),
         once: vi.fn((event: string, handler: typeof done) => {
@@ -676,6 +701,145 @@ describe('asset download retries', () => {
 
     return { win, session, send, getWillDownload: () => willDownload, createItem }
   }
+
+  it('joins only the same URL and exact destination under one download identity', async () => {
+    const firstDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-first-'))
+    const secondDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-second-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      const first = await startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        firstDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+      const joined = await startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        firstDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+      const otherDestination = await startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        secondDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+
+      expect(first).toMatchObject({ status: 'accepted' })
+      expect(joined).toEqual({
+        status: 'joined',
+        downloadId: first.status === 'accepted' ? first.downloadId : 'missing-download-id'
+      })
+      expect(otherDestination).toMatchObject({ status: 'accepted' })
+      if (first.status !== 'accepted' || otherDestination.status !== 'accepted') {
+        throw new Error('Expected two accepted asset downloads')
+      }
+      expect(otherDestination.downloadId).not.toBe(first.downloadId)
+      expect(h.session.downloadURL).toHaveBeenCalledTimes(2)
+
+      for (const outputDir of [firstDir, secondDir]) {
+        const item = h.createItem(url)
+        h.getWillDownload()!({}, item.item, null)
+        const tempPath = item.setSavePath.mock.calls[0]?.[0]
+        expect(tempPath).toBeTypeOf('string')
+        await fs.promises.writeFile(tempPath!, outputDir)
+        item.getDone()!({}, 'completed')
+      }
+    } finally {
+      await fs.promises.rm(firstDir, { recursive: true, force: true })
+      await fs.promises.rm(secondDir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips an exact destination that is already present', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      await fs.promises.writeFile(path.join(outputDir, 'sample.png'), 'existing')
+
+      await expect(
+        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+          existingFilePolicy: 'skip'
+        })
+      ).resolves.toEqual({ status: 'already-present' })
+      expect(h.session.downloadURL).not.toHaveBeenCalled()
+      await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
+    } finally {
+      await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves the requested filename instead of accepting Content-Disposition', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      await expect(
+        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+          existingFilePolicy: 'skip'
+        })
+      ).resolves.toMatchObject({ status: 'accepted' })
+
+      const item = h.createItem(url, 'attachment; filename="renamed-by-server.png"')
+      h.getWillDownload()!({}, item.item, null)
+      const tempPath = item.setSavePath.mock.calls[0]?.[0]
+      expect(tempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(tempPath!, 'content')
+      item.getDone()!({}, 'completed')
+
+      await expect(fs.promises.readdir(outputDir)).resolves.toEqual(['sample.png'])
+      await expect(fs.promises.readFile(path.join(outputDir, 'sample.png'), 'utf8')).resolves.toBe(
+        'content'
+      )
+    } finally {
+      await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not overwrite an exact destination created while the download is in flight', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+    const destination = path.join(outputDir, 'sample.png')
+
+    try {
+      await expect(
+        startManagedAssetDownload(h.win, url, 'sample.png', outputDir, undefined, undefined, {
+          existingFilePolicy: 'skip'
+        })
+      ).resolves.toMatchObject({ status: 'accepted' })
+
+      const item = h.createItem(url)
+      h.getWillDownload()!({}, item.item, null)
+      const tempPath = item.setSavePath.mock.calls[0]?.[0]
+      expect(tempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(tempPath!, 'downloaded')
+      await fs.promises.writeFile(destination, 'created-during-download')
+      item.getDone()!({}, 'completed')
+
+      await expect(fs.promises.readFile(destination, 'utf8')).resolves.toBe(
+        'created-during-download'
+      )
+      await expect(fs.promises.stat(tempPath!)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
 
   it('discards the download when an identical file already sits at the requested path', async () => {
     // The "remote" server may be a local ComfyUI writing outputs into the

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -724,12 +724,17 @@ describe('asset download retries', () => {
       expect(otherDestination.downloadId).not.toBe(first.downloadId)
       expect(h.session.downloadURL).toHaveBeenCalledTimes(2)
 
-      for (const outputDir of [firstDir, secondDir]) {
+      const downloads = [firstDir, secondDir].map((outputDir) => {
         const item = h.createItem(url)
         h.getWillDownload()!({}, item.item, null)
         const tempPath = item.setSavePath.mock.calls[0]?.[0]
         expect(tempPath).toBeTypeOf('string')
-        await fs.promises.writeFile(tempPath!, outputDir)
+        return { item, outputDir, tempPath: tempPath! }
+      })
+      for (const { outputDir, tempPath } of downloads) {
+        await fs.promises.writeFile(tempPath, outputDir)
+      }
+      for (const { item } of downloads) {
         item.getDone()!({}, 'completed')
       }
     } finally {

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -419,6 +419,22 @@ describe('asset download retries', () => {
     return start?.(...args) ?? Promise.resolve({ status: 'not-started' })
   }
 
+  function getActiveAssetDownload(
+    url: string,
+    filename: string,
+    outputDir: string
+  ): ComfyDownloadManager.DownloadProgress | undefined {
+    return (
+      mod as typeof mod & {
+        getActiveAssetDownload?: (
+          url: string,
+          filename: string,
+          outputDir: string
+        ) => ComfyDownloadManager.DownloadProgress | undefined
+      }
+    ).getActiveAssetDownload?.(url, filename, outputDir)
+  }
+
   it('preserves a deduplicated nested path resolved from Content-Disposition', async () => {
     const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-output-'))
     const url = 'https://remote.example/api/view?filename=hash.mp4'
@@ -757,6 +773,46 @@ describe('asset download retries', () => {
         await fs.promises.writeFile(tempPath!, outputDir)
         item.getDone()!({}, 'completed')
       }
+    } finally {
+      await fs.promises.rm(firstDir, { recursive: true, force: true })
+      await fs.promises.rm(secondDir, { recursive: true, force: true })
+    }
+  })
+
+  it('snapshots only the active download for the exact destination', async () => {
+    const firstDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-first-'))
+    const secondDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-second-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      const admission = await startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        firstDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+      if (admission.status !== 'accepted') {
+        throw new Error('Expected an accepted asset download')
+      }
+
+      expect(getActiveAssetDownload(url, 'sample.png', firstDir)).toMatchObject({
+        id: admission.downloadId,
+        status: 'pending'
+      })
+      expect(getActiveAssetDownload(url, 'sample.png', secondDir)).toBeUndefined()
+
+      const item = h.createItem(url)
+      h.getWillDownload()!({}, item.item, null)
+      const tempPath = item.setSavePath.mock.calls[0]?.[0]
+      expect(tempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(tempPath!, 'content')
+      item.getDone()!({}, 'completed')
+
+      expect(getActiveAssetDownload(url, 'sample.png', firstDir)).toBeUndefined()
     } finally {
       await fs.promises.rm(firstDir, { recursive: true, force: true })
       await fs.promises.rm(secondDir, { recursive: true, force: true })

--- a/src/main/lib/comfyDownloadManager.test.ts
+++ b/src/main/lib/comfyDownloadManager.test.ts
@@ -737,6 +737,13 @@ describe('asset download retries', () => {
       for (const { item } of downloads) {
         item.getDone()!({}, 'completed')
       }
+      await expect(
+        Promise.all(
+          [firstDir, secondDir].map((outputDir) =>
+            fs.promises.readFile(path.join(outputDir, 'sample.png'), 'utf8')
+          )
+        )
+      ).resolves.toEqual([firstDir, secondDir])
     } finally {
       await fs.promises.rm(firstDir, { recursive: true, force: true })
       await fs.promises.rm(secondDir, { recursive: true, force: true })
@@ -903,6 +910,61 @@ describe('asset download retries', () => {
       )
     } finally {
       await fs.promises.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('allows retry while the same URL is active for a different exact destination', async () => {
+    const firstDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-first-'))
+    const secondDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'comfy-input-second-'))
+    const url = 'https://remote.example/input/sample.png'
+    const h = makeAssetHarness()
+
+    try {
+      const failedAdmission = await mod.startManagedAssetDownload(
+        h.win,
+        url,
+        'sample.png',
+        firstDir,
+        undefined,
+        undefined,
+        { existingFilePolicy: 'skip' }
+      )
+      if (failedAdmission.status !== 'accepted') {
+        throw new Error('Expected an accepted asset download')
+      }
+
+      const failed = h.createItem(url)
+      h.getWillDownload()!({}, failed.item, null)
+      const failedTempPath = failed.setSavePath.mock.calls[0]?.[0]
+      expect(failedTempPath).toBeTypeOf('string')
+      await fs.promises.writeFile(failedTempPath!, 'partial')
+      failed.getDone()!({}, 'interrupted')
+
+      await expect(
+        mod.startManagedAssetDownload(h.win, url, 'sample.png', secondDir, undefined, undefined, {
+          existingFilePolicy: 'skip'
+        })
+      ).resolves.toMatchObject({ status: 'accepted' })
+
+      expect(mod.retryDownload(failedAdmission.downloadId)).toBe(true)
+      await vi.waitFor(() => expect(h.session.downloadURL).toHaveBeenCalledTimes(3))
+
+      const downloads = [secondDir, firstDir].map((outputDir) => {
+        const item = h.createItem(url)
+        h.getWillDownload()!({}, item.item, null)
+        const tempPath = item.setSavePath.mock.calls[0]?.[0]
+        expect(tempPath).toBeTypeOf('string')
+        return { item, outputDir, tempPath: tempPath! }
+      })
+      for (const { outputDir, tempPath } of downloads) {
+        await fs.promises.writeFile(tempPath, outputDir)
+      }
+      for (const { item } of downloads) {
+        item.getDone()!({}, 'completed')
+      }
+    } finally {
+      await fs.promises.rm(firstDir, { recursive: true, force: true })
+      await fs.promises.rm(secondDir, { recursive: true, force: true })
     }
   })
 

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -1673,6 +1673,25 @@ export async function startAssetDownload(
   return admission.status !== 'not-started'
 }
 
+/** Return a read-only progress snapshot only when this exact asset destination
+ *  is currently owned by a managed job. URL alone is intentionally
+ *  insufficient because one source may be downloading into multiple installs. */
+export function getActiveAssetDownload(
+  url: string,
+  filename: string,
+  outputDir: string
+): DownloadProgress | undefined {
+  const safeFilename = sanitizeAssetFilename(filename, outputDir)
+  if (!safeFilename) return undefined
+  const requestedDestKey = canonicalDestKey(path.join(outputDir, safeFilename))
+  const pending = activeJobsForUrl(url).find(
+    (candidate) =>
+      candidate.kind === 'asset' &&
+      canonicalDestKey(candidate.requestedSavePath ?? candidate.savePath) === requestedDestKey
+  )
+  return pending ? { ...pending.lastProgress } : undefined
+}
+
 async function deduplicatePath(filePath: string): Promise<string> {
   if (!(await fileExists(filePath))) return filePath
   const dir = path.dirname(filePath)

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -1498,7 +1498,9 @@ function joinActiveAssetDownload(
     (pending) =>
       pending.kind !== 'model' &&
       (!requireExactDestination ||
-        canonicalDestKey(pending.requestedSavePath ?? pending.savePath) === requestedDestKey)
+        (pending.kind === 'asset' &&
+          pending.preserveRequestedFilename === true &&
+          canonicalDestKey(pending.requestedSavePath ?? pending.savePath) === requestedDestKey))
   )
   if (!existing) return undefined
 

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -422,9 +422,8 @@ interface RetryParams {
   /** Install that initiated the download, so a retry resolves the same
    *  destination even after the originating comfy view is gone. */
   installationId?: string | null
-  /** Model jobs: the RESOLVED final destination of the original attempt.
-   *  Retry dedupe compares canonical destinations, never URL + directory -
-   *  two installs can share both while writing different files. */
+  /** Resolved final destination of the original attempt. Exact-destination
+   *  retries compare this path rather than the source URL. */
   savePath?: string
   /** Model jobs: expected sha256, so a retry keeps verifying integrity. */
   sha256?: string
@@ -1636,6 +1635,7 @@ export async function startManagedAssetDownload(
     authToken,
     window: win,
     senderContents,
+    savePath: requestedSavePath,
     existingFilePolicy
   })
 
@@ -2174,6 +2174,16 @@ export function retryDownload(ref: string): boolean {
     const destKey = canonicalDestKey(params.savePath)
     for (const active of pendingDownloads.values()) {
       if (active.kind === 'model' && canonicalDestKey(active.savePath) === destKey) return false
+    }
+  } else if (params.kind === 'asset' && params.existingFilePolicy === 'skip' && params.savePath) {
+    const destKey = canonicalDestKey(params.savePath)
+    for (const active of activeJobsForUrl(params.url)) {
+      if (
+        active.kind === 'asset' &&
+        canonicalDestKey(active.requestedSavePath ?? active.savePath) === destKey
+      ) {
+        return false
+      }
     }
   } else {
     for (const active of activeJobsForUrl(params.url)) {

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -110,6 +110,9 @@ interface PendingDownload {
    *  "name (1)" dedup. When the completed download is byte-identical to a
    *  file already at this path, the download is discarded in its favor. */
   requestedSavePath?: string
+  /** Exact-destination owners keep their requested filename and never replace
+   *  a file that appears there while the transfer is in flight. */
+  preserveRequestedFilename?: boolean
   tempPath?: string
   outputDir?: string
   /** Presentation window. Optional: managed model jobs can run headless
@@ -428,6 +431,8 @@ interface RetryParams {
   /** Model jobs: explicit destination root of the original attempt, so a
    *  retry resolves the same final path. */
   destinationBaseDir?: string
+  /** Asset jobs: preserve the original admission semantics on retry. */
+  existingFilePolicy?: 'deduplicate' | 'skip'
 }
 const retryParamsById = new Map<string, RetryParams>()
 
@@ -1473,29 +1478,74 @@ export async function startModelDownload(
   return settled.status === 'completed'
 }
 
-export async function startAssetDownload(
+export interface AssetDownloadOptions {
+  /** Keep the requested filename stable and treat an existing exact path as success. */
+  existingFilePolicy?: 'deduplicate' | 'skip'
+}
+
+export type AssetDownloadAdmission =
+  | { status: 'already-present' }
+  | { status: 'accepted' | 'joined'; downloadId: string }
+  | { status: 'not-started' }
+
+function joinActiveAssetDownload(
+  win: BrowserWindow,
+  url: string,
+  requestedSavePath: string,
+  requireExactDestination: boolean
+): PendingDownload | undefined {
+  const requestedDestKey = canonicalDestKey(requestedSavePath)
+  const existing = activeJobsForUrl(url).find(
+    (pending) =>
+      pending.kind !== 'model' &&
+      (!requireExactDestination ||
+        canonicalDestKey(pending.requestedSavePath ?? pending.savePath) === requestedDestKey)
+  )
+  if (!existing) return undefined
+
+  if (win !== existing.window) {
+    existing.subscriberWindows.add(win)
+  }
+  if (!win.isDestroyed()) {
+    win.webContents.send('desktop2-download-progress', existing.lastProgress)
+  }
+  return existing
+}
+
+export async function startManagedAssetDownload(
   win: BrowserWindow,
   url: string,
   filename: string,
   outputDir: string,
   authToken?: string,
-  senderContents?: Electron.WebContents
-): Promise<boolean> {
+  senderContents?: Electron.WebContents,
+  { existingFilePolicy = 'deduplicate' }: AssetDownloadOptions = {}
+): Promise<AssetDownloadAdmission> {
   const safeFilename = sanitizeAssetFilename(filename, outputDir)
-  if (!safeFilename) return false
+  if (!safeFilename) return { status: 'not-started' }
+  const requestedSavePath = path.join(outputDir, safeFilename)
 
-  // Join an active asset/general download of the same URL. Managed model jobs
-  // sharing the URL are independent (different destination class entirely).
-  const existing = activeJobsForUrl(url).find((p) => p.kind !== 'model')
-  if (existing) {
-    if (win !== existing.window) {
-      existing.subscriberWindows.add(win)
-    }
-    if (!win.isDestroyed()) {
-      win.webContents.send('desktop2-download-progress', existing.lastProgress)
-    }
-    return true
+  const existing = joinActiveAssetDownload(
+    win,
+    url,
+    requestedSavePath,
+    existingFilePolicy === 'skip'
+  )
+  if (existing) return { status: 'joined', downloadId: existing.id }
+
+  if (existingFilePolicy === 'skip' && (await fileExists(requestedSavePath))) {
+    return { status: 'already-present' }
   }
+
+  // The existence probe above yields. Recheck the registry before reserving so
+  // concurrent requests for the same exact destination still share one job.
+  const reserved = joinActiveAssetDownload(
+    win,
+    url,
+    requestedSavePath,
+    existingFilePolicy === 'skip'
+  )
+  if (reserved) return { status: 'joined', downloadId: reserved.id }
 
   // Reserve the URL before the first await: the same URL can be requested
   // again while the async setup below is still in flight (e.g. an output
@@ -1509,8 +1559,9 @@ export async function startAssetDownload(
     url,
     filename: path.basename(safeFilename),
     directory: '',
-    savePath: path.join(outputDir, safeFilename),
-    requestedSavePath: path.join(outputDir, safeFilename),
+    savePath: requestedSavePath,
+    requestedSavePath,
+    preserveRequestedFilename: existingFilePolicy === 'skip',
     outputDir,
     window: win,
     senderContents: senderContents !== win.webContents ? senderContents : undefined,
@@ -1534,7 +1585,8 @@ export async function startAssetDownload(
   // than an error row, unlike `startModelDownload`'s failure paths.
   let savePath: string
   try {
-    savePath = await deduplicatePath(path.join(outputDir, safeFilename))
+    savePath =
+      existingFilePolicy === 'skip' ? requestedSavePath : await deduplicatePath(requestedSavePath)
   } catch (err) {
     reportProgress({
       ...pending.lastProgress,
@@ -1542,7 +1594,7 @@ export async function startAssetDownload(
       error: `Failed to prepare save path: ${err instanceof Error ? err.message : String(err)}`
     })
     unregisterPending(pending)
-    return false
+    return { status: 'not-started' }
   }
   const savedFilename = path.basename(savePath)
   // Temp dir is a sibling of the output dir - same filesystem for atomic rename,
@@ -1565,12 +1617,12 @@ export async function startAssetDownload(
       error: `Failed to create download directory: ${err instanceof Error ? err.message : String(err)}`
     })
     unregisterPending(pending)
-    return false
+    return { status: 'not-started' }
   }
 
   if (win.isDestroyed()) {
     unregisterPending(pending)
-    return false
+    return { status: 'not-started' }
   }
 
   // Register retry params only once the download is viable: an earlier
@@ -1583,7 +1635,8 @@ export async function startAssetDownload(
     outputDir,
     authToken,
     window: win,
-    senderContents
+    senderContents,
+    existingFilePolicy
   })
 
   const sess = (senderContents || win.webContents).session
@@ -1596,7 +1649,28 @@ export async function startAssetDownload(
   sess.downloadURL(url, downloadOptions)
 
   reportProgress(pending.lastProgress)
-  return true
+  return { status: 'accepted', downloadId: pending.id }
+}
+
+export async function startAssetDownload(
+  win: BrowserWindow,
+  url: string,
+  filename: string,
+  outputDir: string,
+  authToken?: string,
+  senderContents?: Electron.WebContents,
+  options?: AssetDownloadOptions
+): Promise<boolean> {
+  const admission = await startManagedAssetDownload(
+    win,
+    url,
+    filename,
+    outputDir,
+    authToken,
+    senderContents,
+    options
+  )
+  return admission.status !== 'not-started'
 }
 
 async function deduplicatePath(filePath: string): Promise<string> {
@@ -1653,6 +1727,23 @@ function attachDownloadListeners(item: Electron.DownloadItem, pending: PendingDo
 
   item.once('done', (_ev, state) => {
     if (state === 'completed') {
+      // An exact-destination owner treats a file that appeared after admission
+      // as authoritative. Discard the staged bytes instead of replacing it
+      // (rename would overwrite on POSIX and fail inconsistently on Windows).
+      if (
+        pending.preserveRequestedFilename &&
+        pending.tempPath &&
+        fs.existsSync(pending.savePath)
+      ) {
+        try {
+          fs.unlinkSync(pending.tempPath)
+        } catch {}
+        try {
+          fs.rmdirSync(path.dirname(pending.tempPath))
+        } catch {}
+        pending.tempPath = undefined
+      }
+
       // If a byte-identical file already sits at the originally requested
       // destination, keep it and discard the temp copy instead of saving a
       // duplicate "name (1)" file. This is the normal case when the "remote"
@@ -1767,7 +1858,7 @@ export function attachSessionDownloadHandler(sess: Electron.Session): void {
       // Resolve a better asset filename from the server response: cloud uses
       // content hashes in the WebSocket message, so the human-readable name is
       // only available from the HTTP Content-Disposition.
-      if (pending.tempPath && pending.outputDir) {
+      if (pending.tempPath && pending.outputDir && !pending.preserveRequestedFilename) {
         const serverName = resolveServerFilename(item)
         if (serverName) {
           const baseDir = pending.outputDir
@@ -2101,7 +2192,8 @@ export function retryDownload(ref: string): boolean {
       params.filename,
       params.outputDir!,
       params.authToken,
-      sender
+      sender,
+      { existingFilePolicy: params.existingFilePolicy ?? 'deduplicate' }
     )
   } else {
     void startManagedModelJob({

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
@@ -55,8 +55,16 @@ describe('registerTemplateInputAssetHandlers', () => {
     return handler('desktop2-get-template-input-assets')({ sender }, { templateId })
   }
 
-  function downloadAsset(assetId = declaredAsset.assetId, templateId = 'template-1') {
+  function downloadAsset(
+    assetId: unknown = declaredAsset.assetId,
+    templateId: unknown = 'template-1'
+  ) {
     return handler('desktop2-download-template-input-asset')({ sender }, { templateId, assetId })
+  }
+
+  function mockMissingAsset() {
+    mocks.resolveSnapshot.mockResolvedValue([declaredAsset])
+    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
   }
 
   beforeEach(() => {
@@ -86,7 +94,8 @@ describe('registerTemplateInputAssetHandlers', () => {
         filename: 'sample.png',
         mediaType: 'image',
         previewUrl: 'https://example.com/sample.png',
-        url: 'https://example.com/sample.png'
+        url: 'https://example.com/sample.png',
+        internalPath: '/private/comfy/input/sample.png'
       }
     ])
     mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
@@ -128,6 +137,17 @@ describe('registerTemplateInputAssetHandlers', () => {
 
   it('rejects invalid template metadata requests before resolving files', async () => {
     await expect(getAssets('../template-1')).resolves.toBeNull()
+    expect(mocks.resolveSnapshot).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['an invalid template id', 'sample-asset', '../template-1'],
+    ['a non-string asset id', 42, 'template-1']
+  ])('rejects %s before resolving download metadata', async (_label, assetId, templateId) => {
+    await expect(downloadAsset(assetId, templateId)).resolves.toEqual({
+      status: 'not-started',
+      reason: 'invalid-request'
+    })
     expect(mocks.resolveSnapshot).not.toHaveBeenCalled()
   })
 
@@ -189,8 +209,7 @@ describe('registerTemplateInputAssetHandlers', () => {
   })
 
   it('hands a missing declared asset to the exact input-dir download owner', async () => {
-    mocks.resolveSnapshot.mockResolvedValue([declaredAsset])
-    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
+    mockMissingAsset()
     mocks.startManagedAssetDownload.mockResolvedValue({
       status: 'accepted',
       downloadId: 'download-1'
@@ -221,6 +240,35 @@ describe('registerTemplateInputAssetHandlers', () => {
       sender,
       { existingFilePolicy: 'skip' }
     )
+  })
+
+  it('normalizes a rejected managed-download admission as unavailable', async () => {
+    mockMissingAsset()
+    mocks.startManagedAssetDownload.mockResolvedValue({ status: 'not-started' })
+
+    await expect(downloadAsset()).resolves.toEqual({
+      status: 'not-started',
+      reason: 'unavailable'
+    })
+  })
+
+  it('falls back to the admission identity before active progress is observable', async () => {
+    mockMissingAsset()
+    mocks.startManagedAssetDownload.mockResolvedValue({
+      status: 'accepted',
+      downloadId: 'download-1'
+    })
+    mocks.getActiveAssetDownload.mockReturnValue(undefined)
+
+    await expect(downloadAsset()).resolves.toEqual({
+      status: 'accepted',
+      download: {
+        downloadId: 'download-1',
+        filename: 'sample.png',
+        progress: 0,
+        status: 'pending'
+      }
+    })
   })
 
   it('does not dispatch when filesystem availability is unknown', async () => {

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
@@ -47,16 +47,19 @@ function handler(channel: string): IpcHandler {
 describe('registerTemplateInputAssetHandlers', () => {
   const sender = {}
   const win = { webContents: sender }
-  const installation = { id: 'install-1' }
+  const installation = { id: 'install-1', sourceId: 'standalone' }
 
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.fromWebContents.mockReturnValue(win)
     mocks.getInstallation.mockResolvedValue(installation)
     mocks.resolveInputDir.mockReturnValue('/comfy/input')
-    handlerModule.registerTemplateInputAssetHandlers({
-      findInstallationIdForWindow: () => 'install-1'
-    })
+    const options = {
+      findInstallationIdForWindow: () => 'install-1',
+      isLocalInstallation: (candidate: { sourceId?: unknown }) =>
+        candidate.sourceId === 'standalone'
+    }
+    handlerModule.registerTemplateInputAssetHandlers(options)
   })
 
   it('registers only template-scoped metadata and download channels', () => {
@@ -134,6 +137,21 @@ describe('registerTemplateInputAssetHandlers', () => {
         { templateId: 'template-1', assetId: 'sample.png' }
       )
     ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+  })
+
+  it('fails closed for a remote installation even when the sender is bound', async () => {
+    mocks.getInstallation.mockResolvedValue({ id: 'cloud', sourceId: 'cloud' })
+
+    await expect(
+      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
+    ).resolves.toBeNull()
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'sample.png' }
+      )
+    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    expect(mocks.resolveAssets).not.toHaveBeenCalled()
   })
 
   it('does not accept an asset id that the template does not declare', async () => {

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
@@ -5,7 +5,6 @@ const mocks = vi.hoisted(() => ({
   getInstallation: vi.fn(),
   handle: vi.fn(),
   resolveAvailability: vi.fn(),
-  resolveAssets: vi.fn(),
   resolveSnapshot: vi.fn(),
   resolveInputDir: vi.fn(),
   getActiveAssetDownload: vi.fn(),
@@ -23,7 +22,6 @@ vi.mock('../../installations', () => ({
 
 vi.mock('../../sources/standalone/templateInputAssets', () => ({
   resolveTemplateInputAssetAvailability: mocks.resolveAvailability,
-  resolveTemplateInputAssets: mocks.resolveAssets,
   resolveTemplateInputAssetSnapshot: mocks.resolveSnapshot,
   resolveInputDir: mocks.resolveInputDir
 }))
@@ -33,10 +31,7 @@ vi.mock('../comfyDownloadManager', () => ({
   startManagedAssetDownload: mocks.startManagedAssetDownload
 }))
 
-const modulePath = './registerTemplateInputAssetHandlers'
-const handlerModule = await import(/* @vite-ignore */ modulePath).catch(() => ({
-  registerTemplateInputAssetHandlers: () => undefined
-}))
+import { registerTemplateInputAssetHandlers } from './registerTemplateInputAssetHandlers'
 
 type IpcHandler = (event: { sender: object }, payload: Record<string, unknown>) => Promise<unknown>
 
@@ -50,19 +45,31 @@ describe('registerTemplateInputAssetHandlers', () => {
   const sender = {}
   const win = { webContents: sender }
   const installation = { id: 'install-1', sourceId: 'standalone' }
+  const declaredAsset = {
+    assetId: 'sample-asset',
+    filename: 'sample.png',
+    url: 'https://example.com/sample.png'
+  }
+
+  function getAssets(templateId = 'template-1') {
+    return handler('desktop2-get-template-input-assets')({ sender }, { templateId })
+  }
+
+  function downloadAsset(assetId = declaredAsset.assetId, templateId = 'template-1') {
+    return handler('desktop2-download-template-input-asset')({ sender }, { templateId, assetId })
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.fromWebContents.mockReturnValue(win)
     mocks.getInstallation.mockResolvedValue(installation)
     mocks.resolveInputDir.mockReturnValue('/comfy/input')
-    mocks.resolveSnapshot.mockImplementation((...args) => mocks.resolveAssets(...args))
     const options = {
       findInstallationIdForWindow: () => 'install-1',
       isLocalInstallation: (candidate: { sourceId?: unknown }) =>
         candidate.sourceId === 'standalone'
     }
-    handlerModule.registerTemplateInputAssetHandlers(options)
+    registerTemplateInputAssetHandlers(options)
   })
 
   it('registers only template-scoped metadata and download channels', () => {
@@ -73,7 +80,7 @@ describe('registerTemplateInputAssetHandlers', () => {
   })
 
   it('returns template-scoped preview metadata, local availability, and active state', async () => {
-    mocks.resolveAssets.mockResolvedValue([
+    mocks.resolveSnapshot.mockResolvedValue([
       {
         assetId: 'sample.png',
         filename: 'sample.png',
@@ -93,9 +100,7 @@ describe('registerTemplateInputAssetHandlers', () => {
       status: 'downloading'
     })
 
-    await expect(
-      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
-    ).resolves.toEqual([
+    await expect(getAssets()).resolves.toEqual([
       {
         assetId: 'sample.png',
         filename: 'sample.png',
@@ -112,7 +117,7 @@ describe('registerTemplateInputAssetHandlers', () => {
         }
       }
     ])
-    expect(mocks.resolveAssets).toHaveBeenCalledWith(installation, 'template-1')
+    expect(mocks.resolveSnapshot).toHaveBeenCalledWith(installation, 'template-1')
     expect(mocks.resolveAvailability).toHaveBeenCalledWith(installation, ['sample.png'])
     expect(mocks.getActiveAssetDownload).toHaveBeenCalledWith(
       'https://example.com/sample.png',
@@ -122,24 +127,18 @@ describe('registerTemplateInputAssetHandlers', () => {
   })
 
   it('rejects invalid template metadata requests before resolving files', async () => {
-    await expect(
-      handler('desktop2-get-template-input-assets')({ sender }, { templateId: '../template-1' })
-    ).resolves.toBeNull()
-    expect(mocks.resolveAssets).not.toHaveBeenCalled()
+    await expect(getAssets('../template-1')).resolves.toBeNull()
+    expect(mocks.resolveSnapshot).not.toHaveBeenCalled()
   })
 
   it('does not claim there are no inputs when template metadata is unavailable', async () => {
-    mocks.resolveAssets.mockResolvedValue(null)
+    mocks.resolveSnapshot.mockResolvedValue(null)
 
-    await expect(
-      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
-    ).resolves.toBeNull()
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'sample.png' }
-      )
-    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    await expect(getAssets()).resolves.toBeNull()
+    await expect(downloadAsset()).resolves.toEqual({
+      status: 'not-started',
+      reason: 'unavailable'
+    })
     expect(mocks.resolveAvailability).not.toHaveBeenCalled()
     expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
   })
@@ -147,34 +146,26 @@ describe('registerTemplateInputAssetHandlers', () => {
   it('fails closed when the sender is not bound to an installation', async () => {
     mocks.fromWebContents.mockReturnValue(null)
 
-    await expect(
-      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
-    ).resolves.toBeNull()
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'sample.png' }
-      )
-    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    await expect(getAssets()).resolves.toBeNull()
+    await expect(downloadAsset()).resolves.toEqual({
+      status: 'not-started',
+      reason: 'unavailable'
+    })
   })
 
   it('fails closed for a remote installation even when the sender is bound', async () => {
     mocks.getInstallation.mockResolvedValue({ id: 'cloud', sourceId: 'cloud' })
 
-    await expect(
-      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
-    ).resolves.toBeNull()
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'sample.png' }
-      )
-    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
-    expect(mocks.resolveAssets).not.toHaveBeenCalled()
+    await expect(getAssets()).resolves.toBeNull()
+    await expect(downloadAsset()).resolves.toEqual({
+      status: 'not-started',
+      reason: 'unavailable'
+    })
+    expect(mocks.resolveSnapshot).not.toHaveBeenCalled()
   })
 
   it('does not accept an asset id that the template does not declare', async () => {
-    mocks.resolveAssets.mockResolvedValue([
+    mocks.resolveSnapshot.mockResolvedValue([
       {
         assetId: 'declared-asset',
         filename: 'declared.png',
@@ -182,41 +173,23 @@ describe('registerTemplateInputAssetHandlers', () => {
       }
     ])
 
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'other-asset' }
-      )
-    ).resolves.toEqual({ status: 'not-started', reason: 'not-declared' })
+    await expect(downloadAsset('other-asset')).resolves.toEqual({
+      status: 'not-started',
+      reason: 'not-declared'
+    })
     expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
   })
 
   it('reports an exact file already present without creating a duplicate', async () => {
-    mocks.resolveAssets.mockResolvedValue([
-      {
-        assetId: 'sample-asset',
-        filename: 'sample.png',
-        url: 'https://example.com/sample.png'
-      }
-    ])
+    mocks.resolveSnapshot.mockResolvedValue([declaredAsset])
     mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'present' }])
 
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'sample-asset' }
-      )
-    ).resolves.toEqual({ status: 'already-present' })
+    await expect(downloadAsset()).resolves.toEqual({ status: 'already-present' })
     expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
   })
 
   it('hands a missing declared asset to the exact input-dir download owner', async () => {
-    const asset = {
-      assetId: 'opaque-asset-id',
-      filename: 'sample.png',
-      url: 'https://example.com/sample.png'
-    }
-    mocks.resolveAssets.mockResolvedValue([asset])
+    mocks.resolveSnapshot.mockResolvedValue([declaredAsset])
     mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
     mocks.startManagedAssetDownload.mockResolvedValue({
       status: 'accepted',
@@ -230,12 +203,7 @@ describe('registerTemplateInputAssetHandlers', () => {
       status: 'pending'
     })
 
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'opaque-asset-id' }
-      )
-    ).resolves.toEqual({
+    await expect(downloadAsset()).resolves.toEqual({
       status: 'accepted',
       download: {
         downloadId: 'download-1',
@@ -246,8 +214,8 @@ describe('registerTemplateInputAssetHandlers', () => {
     })
     expect(mocks.startManagedAssetDownload).toHaveBeenCalledWith(
       win,
-      asset.url,
-      asset.filename,
+      declaredAsset.url,
+      declaredAsset.filename,
       '/comfy/input',
       undefined,
       sender,
@@ -256,21 +224,10 @@ describe('registerTemplateInputAssetHandlers', () => {
   })
 
   it('does not dispatch when filesystem availability is unknown', async () => {
-    mocks.resolveAssets.mockResolvedValue([
-      {
-        assetId: 'sample-asset',
-        filename: 'sample.png',
-        url: 'https://example.com/sample.png'
-      }
-    ])
+    mocks.resolveSnapshot.mockResolvedValue([declaredAsset])
     mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'unknown' }])
 
-    await expect(
-      handler('desktop2-download-template-input-asset')(
-        { sender },
-        { templateId: 'template-1', assetId: 'sample-asset' }
-      )
-    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    await expect(downloadAsset()).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
     expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
   })
 })

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   handle: vi.fn(),
   resolveAvailability: vi.fn(),
   resolveAssets: vi.fn(),
+  resolveSnapshot: vi.fn(),
   resolveInputDir: vi.fn(),
   getActiveAssetDownload: vi.fn(),
   startManagedAssetDownload: vi.fn()
@@ -23,6 +24,7 @@ vi.mock('../../installations', () => ({
 vi.mock('../../sources/standalone/templateInputAssets', () => ({
   resolveTemplateInputAssetAvailability: mocks.resolveAvailability,
   resolveTemplateInputAssets: mocks.resolveAssets,
+  resolveTemplateInputAssetSnapshot: mocks.resolveSnapshot,
   resolveInputDir: mocks.resolveInputDir
 }))
 
@@ -54,6 +56,7 @@ describe('registerTemplateInputAssetHandlers', () => {
     mocks.fromWebContents.mockReturnValue(win)
     mocks.getInstallation.mockResolvedValue(installation)
     mocks.resolveInputDir.mockReturnValue('/comfy/input')
+    mocks.resolveSnapshot.mockImplementation((...args) => mocks.resolveAssets(...args))
     const options = {
       findInstallationIdForWindow: () => 'install-1',
       isLocalInstallation: (candidate: { sourceId?: unknown }) =>
@@ -123,6 +126,22 @@ describe('registerTemplateInputAssetHandlers', () => {
       handler('desktop2-get-template-input-assets')({ sender }, { templateId: '../template-1' })
     ).resolves.toBeNull()
     expect(mocks.resolveAssets).not.toHaveBeenCalled()
+  })
+
+  it('does not claim there are no inputs when template metadata is unavailable', async () => {
+    mocks.resolveAssets.mockResolvedValue(null)
+
+    await expect(
+      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
+    ).resolves.toBeNull()
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'sample.png' }
+      )
+    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    expect(mocks.resolveAvailability).not.toHaveBeenCalled()
+    expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
   })
 
   it('fails closed when the sender is not bound to an installation', async () => {
@@ -205,6 +224,7 @@ describe('registerTemplateInputAssetHandlers', () => {
     })
     mocks.getActiveAssetDownload.mockReturnValue({
       id: 'download-1',
+      url: 'https://example.com/sample.png',
       filename: 'sample.png',
       progress: 0,
       status: 'pending'

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fromWebContents: vi.fn(),
+  getInstallation: vi.fn(),
+  handle: vi.fn(),
+  resolveAvailability: vi.fn(),
+  resolveAssets: vi.fn(),
+  resolveInputDir: vi.fn(),
+  getActiveAssetDownload: vi.fn(),
+  startManagedAssetDownload: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: mocks.fromWebContents },
+  ipcMain: { handle: mocks.handle }
+}))
+
+vi.mock('../../installations', () => ({
+  get: mocks.getInstallation
+}))
+
+vi.mock('../../sources/standalone/templateInputAssets', () => ({
+  resolveTemplateInputAssetAvailability: mocks.resolveAvailability,
+  resolveTemplateInputAssets: mocks.resolveAssets,
+  resolveInputDir: mocks.resolveInputDir
+}))
+
+vi.mock('../comfyDownloadManager', () => ({
+  getActiveAssetDownload: mocks.getActiveAssetDownload,
+  startManagedAssetDownload: mocks.startManagedAssetDownload
+}))
+
+const modulePath = './registerTemplateInputAssetHandlers'
+const handlerModule = await import(/* @vite-ignore */ modulePath).catch(() => ({
+  registerTemplateInputAssetHandlers: () => undefined
+}))
+
+type IpcHandler = (event: { sender: object }, payload: Record<string, unknown>) => Promise<unknown>
+
+function handler(channel: string): IpcHandler {
+  const call = mocks.handle.mock.calls.find(([name]) => name === channel)
+  expect(call).toBeDefined()
+  return call![1] as IpcHandler
+}
+
+describe('registerTemplateInputAssetHandlers', () => {
+  const sender = {}
+  const win = { webContents: sender }
+  const installation = { id: 'install-1' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.fromWebContents.mockReturnValue(win)
+    mocks.getInstallation.mockResolvedValue(installation)
+    mocks.resolveInputDir.mockReturnValue('/comfy/input')
+    handlerModule.registerTemplateInputAssetHandlers({
+      findInstallationIdForWindow: () => 'install-1'
+    })
+  })
+
+  it('registers only template-scoped metadata and download channels', () => {
+    expect(mocks.handle.mock.calls.map(([name]) => name)).toEqual([
+      'desktop2-get-template-input-assets',
+      'desktop2-download-template-input-asset'
+    ])
+  })
+
+  it('returns template-scoped preview metadata, local availability, and active state', async () => {
+    mocks.resolveAssets.mockResolvedValue([
+      {
+        assetId: 'sample.png',
+        filename: 'sample.png',
+        mediaType: 'image',
+        previewUrl: 'https://example.com/sample.png',
+        url: 'https://example.com/sample.png'
+      }
+    ])
+    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
+    mocks.getActiveAssetDownload.mockReturnValue({
+      id: 'download-1',
+      url: 'https://example.com/sample.png',
+      filename: 'sample.png',
+      progress: 0.25,
+      receivedBytes: 25,
+      totalBytes: 100,
+      status: 'downloading'
+    })
+
+    await expect(
+      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
+    ).resolves.toEqual([
+      {
+        assetId: 'sample.png',
+        filename: 'sample.png',
+        mediaType: 'image',
+        previewUrl: 'https://example.com/sample.png',
+        availability: 'missing',
+        activeDownload: {
+          downloadId: 'download-1',
+          filename: 'sample.png',
+          progress: 0.25,
+          receivedBytes: 25,
+          totalBytes: 100,
+          status: 'downloading'
+        }
+      }
+    ])
+    expect(mocks.resolveAssets).toHaveBeenCalledWith(installation, 'template-1')
+    expect(mocks.resolveAvailability).toHaveBeenCalledWith(installation, ['sample.png'])
+    expect(mocks.getActiveAssetDownload).toHaveBeenCalledWith(
+      'https://example.com/sample.png',
+      'sample.png',
+      '/comfy/input'
+    )
+  })
+
+  it('rejects invalid template metadata requests before resolving files', async () => {
+    await expect(
+      handler('desktop2-get-template-input-assets')({ sender }, { templateId: '../template-1' })
+    ).resolves.toBeNull()
+    expect(mocks.resolveAssets).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the sender is not bound to an installation', async () => {
+    mocks.fromWebContents.mockReturnValue(null)
+
+    await expect(
+      handler('desktop2-get-template-input-assets')({ sender }, { templateId: 'template-1' })
+    ).resolves.toBeNull()
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'sample.png' }
+      )
+    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+  })
+
+  it('does not accept an asset id that the template does not declare', async () => {
+    mocks.resolveAssets.mockResolvedValue([
+      {
+        assetId: 'declared-asset',
+        filename: 'declared.png',
+        url: 'https://example.com/declared.png'
+      }
+    ])
+
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'other-asset' }
+      )
+    ).resolves.toEqual({ status: 'not-started', reason: 'not-declared' })
+    expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
+  })
+
+  it('reports an exact file already present without creating a duplicate', async () => {
+    mocks.resolveAssets.mockResolvedValue([
+      {
+        assetId: 'sample-asset',
+        filename: 'sample.png',
+        url: 'https://example.com/sample.png'
+      }
+    ])
+    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'present' }])
+
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'sample-asset' }
+      )
+    ).resolves.toEqual({ status: 'already-present' })
+    expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
+  })
+
+  it('hands a missing declared asset to the exact input-dir download owner', async () => {
+    const asset = {
+      assetId: 'opaque-asset-id',
+      filename: 'sample.png',
+      url: 'https://example.com/sample.png'
+    }
+    mocks.resolveAssets.mockResolvedValue([asset])
+    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'missing' }])
+    mocks.startManagedAssetDownload.mockResolvedValue({
+      status: 'accepted',
+      downloadId: 'download-1'
+    })
+    mocks.getActiveAssetDownload.mockReturnValue({
+      id: 'download-1',
+      filename: 'sample.png',
+      progress: 0,
+      status: 'pending'
+    })
+
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'opaque-asset-id' }
+      )
+    ).resolves.toEqual({
+      status: 'accepted',
+      download: {
+        downloadId: 'download-1',
+        filename: 'sample.png',
+        progress: 0,
+        status: 'pending'
+      }
+    })
+    expect(mocks.startManagedAssetDownload).toHaveBeenCalledWith(
+      win,
+      asset.url,
+      asset.filename,
+      '/comfy/input',
+      undefined,
+      sender,
+      { existingFilePolicy: 'skip' }
+    )
+  })
+
+  it('does not dispatch when filesystem availability is unknown', async () => {
+    mocks.resolveAssets.mockResolvedValue([
+      {
+        assetId: 'sample-asset',
+        filename: 'sample.png',
+        url: 'https://example.com/sample.png'
+      }
+    ])
+    mocks.resolveAvailability.mockResolvedValue([{ filename: 'sample.png', status: 'unknown' }])
+
+    await expect(
+      handler('desktop2-download-template-input-asset')(
+        { sender },
+        { templateId: 'template-1', assetId: 'sample-asset' }
+      )
+    ).resolves.toEqual({ status: 'not-started', reason: 'unavailable' })
+    expect(mocks.startManagedAssetDownload).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
@@ -11,7 +11,11 @@ import {
   startManagedAssetDownload,
   type DownloadProgress
 } from '../comfyDownloadManager'
-import type { ComfyTemplateInputAssetDownload } from '../../../types/comfyDesktopBridge'
+import type {
+  ComfyTemplateInputAsset,
+  ComfyTemplateInputAssetDownload,
+  ComfyTemplateInputAssetDownloadResult
+} from '../../../types/comfyDesktopBridge'
 
 interface TemplateInputAssetHandlerOptions {
   findInstallationIdForWindow: (win: BrowserWindow) => string | undefined
@@ -53,7 +57,10 @@ export function registerTemplateInputAssetHandlers({
 
   ipcMain.handle(
     'desktop2-get-template-input-assets',
-    async (event, { templateId }: { templateId: unknown }) => {
+    async (
+      event,
+      { templateId }: { templateId: unknown }
+    ): Promise<ComfyTemplateInputAsset[] | null> => {
       if (!isPersistableTemplateId(templateId)) return null
       const context = await resolveRequestContext(event.sender)
       if (!context) return null
@@ -69,13 +76,14 @@ export function registerTemplateInputAssetHandlers({
       )
       const inputDir = resolveInputDir(context.installation)
 
-      return assets.map(({ url, ...asset }) => {
-        const activeDownload = toDownloadSnapshot(
-          getActiveAssetDownload(url, asset.filename, inputDir)
-        )
+      return assets.map(({ assetId, filename, mediaType, previewUrl, url }) => {
+        const activeDownload = toDownloadSnapshot(getActiveAssetDownload(url, filename, inputDir))
         return {
-          ...asset,
-          availability: availabilityByFilename.get(asset.filename) ?? 'unknown',
+          assetId,
+          filename,
+          mediaType,
+          previewUrl,
+          availability: availabilityByFilename.get(filename) ?? 'unknown',
           ...(activeDownload ? { activeDownload } : {})
         }
       })
@@ -84,7 +92,10 @@ export function registerTemplateInputAssetHandlers({
 
   ipcMain.handle(
     'desktop2-download-template-input-asset',
-    async (event, { templateId, assetId }: { templateId: unknown; assetId: unknown }) => {
+    async (
+      event,
+      { templateId, assetId }: { templateId: unknown; assetId: unknown }
+    ): Promise<ComfyTemplateInputAssetDownloadResult> => {
       if (!isPersistableTemplateId(templateId) || typeof assetId !== 'string') {
         return { status: 'not-started' as const, reason: 'invalid-request' as const }
       }

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
@@ -3,7 +3,7 @@ import { get as getInstallation, type InstallationRecord } from '../../installat
 import {
   resolveInputDir,
   resolveTemplateInputAssetAvailability,
-  resolveTemplateInputAssets
+  resolveTemplateInputAssetSnapshot
 } from '../../sources/standalone/templateInputAssets'
 import { isPersistableTemplateId } from '../../sources/standalone/curatedTemplates'
 import {
@@ -58,7 +58,8 @@ export function registerTemplateInputAssetHandlers({
       const context = await resolveRequestContext(event.sender)
       if (!context) return null
 
-      const assets = await resolveTemplateInputAssets(context.installation, templateId)
+      const assets = await resolveTemplateInputAssetSnapshot(context.installation, templateId)
+      if (!assets) return null
       const availability = await resolveTemplateInputAssetAvailability(
         context.installation,
         assets.map(({ filename }) => filename)
@@ -92,7 +93,10 @@ export function registerTemplateInputAssetHandlers({
         return { status: 'not-started' as const, reason: 'unavailable' as const }
       }
 
-      const assets = await resolveTemplateInputAssets(context.installation, templateId)
+      const assets = await resolveTemplateInputAssetSnapshot(context.installation, templateId)
+      if (!assets) {
+        return { status: 'not-started' as const, reason: 'unavailable' as const }
+      }
       const asset = assets.find((candidate) => candidate.assetId === assetId)
       if (!asset) {
         return { status: 'not-started' as const, reason: 'not-declared' as const }

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, ipcMain } from 'electron'
-import { get as getInstallation } from '../../installations'
+import { get as getInstallation, type InstallationRecord } from '../../installations'
 import {
   resolveInputDir,
   resolveTemplateInputAssetAvailability,
@@ -15,6 +15,7 @@ import type { ComfyTemplateInputAssetDownload } from '../../../types/comfyDeskto
 
 interface TemplateInputAssetHandlerOptions {
   findInstallationIdForWindow: (win: BrowserWindow) => string | undefined
+  isLocalInstallation: (installation: InstallationRecord) => boolean
 }
 
 function toDownloadSnapshot(
@@ -38,7 +39,8 @@ function toDownloadSnapshot(
 }
 
 export function registerTemplateInputAssetHandlers({
-  findInstallationIdForWindow
+  findInstallationIdForWindow,
+  isLocalInstallation
 }: TemplateInputAssetHandlerOptions): void {
   async function resolveRequestContext(sender: Electron.WebContents) {
     const win = BrowserWindow.fromWebContents(sender)
@@ -46,7 +48,7 @@ export function registerTemplateInputAssetHandlers({
     const installationId = findInstallationIdForWindow(win)
     if (!installationId) return null
     const installation = await getInstallation(installationId)
-    return installation ? { installation, win } : null
+    return installation && isLocalInstallation(installation) ? { installation, win } : null
   }
 
   ipcMain.handle(

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
@@ -1,0 +1,142 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import { get as getInstallation } from '../../installations'
+import {
+  resolveInputDir,
+  resolveTemplateInputAssetAvailability,
+  resolveTemplateInputAssets
+} from '../../sources/standalone/templateInputAssets'
+import { isPersistableTemplateId } from '../../sources/standalone/curatedTemplates'
+import {
+  getActiveAssetDownload,
+  startManagedAssetDownload,
+  type DownloadProgress
+} from '../comfyDownloadManager'
+
+interface TemplateInputAssetHandlerOptions {
+  findInstallationIdForWindow: (win: BrowserWindow) => string | undefined
+}
+
+interface TemplateInputDownloadSnapshot {
+  downloadId: string
+  filename: string
+  progress: number
+  receivedBytes?: number
+  totalBytes?: number
+  status: DownloadProgress['status']
+  error?: string
+}
+
+function toDownloadSnapshot(
+  progress: DownloadProgress | undefined,
+  downloadId?: string,
+  filename?: string
+): TemplateInputDownloadSnapshot | undefined {
+  const resolvedId = progress?.id ?? downloadId
+  const resolvedFilename = progress?.filename ?? filename
+  if (!resolvedId || !resolvedFilename) return undefined
+
+  return {
+    downloadId: resolvedId,
+    filename: resolvedFilename,
+    progress: progress?.progress ?? 0,
+    ...(progress?.receivedBytes === undefined ? {} : { receivedBytes: progress.receivedBytes }),
+    ...(progress?.totalBytes === undefined ? {} : { totalBytes: progress.totalBytes }),
+    status: progress?.status ?? 'pending',
+    ...(progress?.error === undefined ? {} : { error: progress.error })
+  }
+}
+
+export function registerTemplateInputAssetHandlers({
+  findInstallationIdForWindow
+}: TemplateInputAssetHandlerOptions): void {
+  async function resolveRequestContext(sender: Electron.WebContents) {
+    const win = BrowserWindow.fromWebContents(sender)
+    if (!win) return null
+    const installationId = findInstallationIdForWindow(win)
+    if (!installationId) return null
+    const installation = await getInstallation(installationId)
+    return installation ? { installation, win } : null
+  }
+
+  ipcMain.handle(
+    'desktop2-get-template-input-assets',
+    async (event, { templateId }: { templateId: unknown }) => {
+      if (!isPersistableTemplateId(templateId)) return null
+      const context = await resolveRequestContext(event.sender)
+      if (!context) return null
+
+      const assets = await resolveTemplateInputAssets(context.installation, templateId)
+      const availability = await resolveTemplateInputAssetAvailability(
+        context.installation,
+        assets.map(({ filename }) => filename)
+      )
+      const availabilityByFilename = new Map(
+        availability.map(({ filename, status }) => [filename, status])
+      )
+      const inputDir = resolveInputDir(context.installation)
+
+      return assets.map(({ url, ...asset }) => {
+        const activeDownload = toDownloadSnapshot(
+          getActiveAssetDownload(url, asset.filename, inputDir)
+        )
+        return {
+          ...asset,
+          availability: availabilityByFilename.get(asset.filename) ?? 'unknown',
+          ...(activeDownload ? { activeDownload } : {})
+        }
+      })
+    }
+  )
+
+  ipcMain.handle(
+    'desktop2-download-template-input-asset',
+    async (event, { templateId, assetId }: { templateId: unknown; assetId: unknown }) => {
+      if (!isPersistableTemplateId(templateId) || typeof assetId !== 'string') {
+        return { status: 'not-started' as const, reason: 'invalid-request' as const }
+      }
+      const context = await resolveRequestContext(event.sender)
+      if (!context) {
+        return { status: 'not-started' as const, reason: 'unavailable' as const }
+      }
+
+      const assets = await resolveTemplateInputAssets(context.installation, templateId)
+      const asset = assets.find((candidate) => candidate.assetId === assetId)
+      if (!asset) {
+        return { status: 'not-started' as const, reason: 'not-declared' as const }
+      }
+
+      const [availability] = await resolveTemplateInputAssetAvailability(context.installation, [
+        asset.filename
+      ])
+      if (availability?.status === 'present') return { status: 'already-present' as const }
+      if (availability?.status !== 'missing') {
+        return { status: 'not-started' as const, reason: 'unavailable' as const }
+      }
+
+      const inputDir = resolveInputDir(context.installation)
+      const admission = await startManagedAssetDownload(
+        context.win,
+        asset.url,
+        asset.filename,
+        inputDir,
+        undefined,
+        event.sender,
+        { existingFilePolicy: 'skip' }
+      )
+      if (admission.status === 'already-present') return admission
+      if (admission.status === 'not-started') {
+        return { status: 'not-started' as const, reason: 'unavailable' as const }
+      }
+
+      const download = toDownloadSnapshot(
+        getActiveAssetDownload(asset.url, asset.filename, inputDir),
+        admission.downloadId,
+        asset.filename
+      )
+      if (!download) {
+        return { status: 'not-started' as const, reason: 'unavailable' as const }
+      }
+      return { status: admission.status, download }
+    }
+  )
+}

--- a/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
+++ b/src/main/lib/ipc/registerTemplateInputAssetHandlers.ts
@@ -11,26 +11,17 @@ import {
   startManagedAssetDownload,
   type DownloadProgress
 } from '../comfyDownloadManager'
+import type { ComfyTemplateInputAssetDownload } from '../../../types/comfyDesktopBridge'
 
 interface TemplateInputAssetHandlerOptions {
   findInstallationIdForWindow: (win: BrowserWindow) => string | undefined
-}
-
-interface TemplateInputDownloadSnapshot {
-  downloadId: string
-  filename: string
-  progress: number
-  receivedBytes?: number
-  totalBytes?: number
-  status: DownloadProgress['status']
-  error?: string
 }
 
 function toDownloadSnapshot(
   progress: DownloadProgress | undefined,
   downloadId?: string,
   filename?: string
-): TemplateInputDownloadSnapshot | undefined {
+): ComfyTemplateInputAssetDownload | undefined {
   const resolvedId = progress?.id ?? downloadId
   const resolvedFilename = progress?.filename ?? filename
   if (!resolvedId || !resolvedFilename) return undefined

--- a/src/main/sources/standalone/templateInputAssets.test.ts
+++ b/src/main/sources/standalone/templateInputAssets.test.ts
@@ -12,9 +12,21 @@ vi.mock('./templateModels', () => ({
   loadTemplateJson: (...a: unknown[]) => loadTemplateJson(...a)
 }))
 
-import { resolveTemplateInputAssets, resolveInputDir } from './templateInputAssets'
+import * as templateInputAssets from './templateInputAssets'
 import { TEMPLATE_INPUT_BASE } from './curatedTemplates'
 import type { InstallationRecord } from '../../installations'
+
+const { resolveTemplateInputAssets, resolveInputDir } = templateInputAssets
+const resolveTemplateInputAssetAvailability =
+  (
+    templateInputAssets as typeof templateInputAssets & {
+      resolveTemplateInputAssetAvailability?: (
+        installation: InstallationRecord,
+        filenames: readonly string[],
+        dependencies: { access: (filePath: string) => Promise<void> }
+      ) => Promise<unknown>
+    }
+  ).resolveTemplateInputAssetAvailability ?? (async () => [])
 
 const inst = { id: 'i1', bundledTemplateId: 't' } as unknown as InstallationRecord
 
@@ -23,14 +35,17 @@ const loadNode = (type: string, filename: unknown) => ({ type, widgets_values: [
 beforeEach(() => loadTemplateJson.mockReset())
 
 describe('resolveTemplateInputAssets', () => {
-  it('derives the input filename from a LoadImage node and points at the repo input dir', async () => {
+  it('derives trusted preview metadata from a declared LoadImage input', async () => {
     loadTemplateJson.mockResolvedValue({
       nodes: [loadNode('LoadImage', 'white-hotel-on-rocky-island.png')]
     })
     const assets = await resolveTemplateInputAssets(inst, 't')
     expect(assets).toEqual([
       {
+        assetId: 'white-hotel-on-rocky-island.png',
         filename: 'white-hotel-on-rocky-island.png',
+        mediaType: 'image',
+        previewUrl: `${TEMPLATE_INPUT_BASE}/white-hotel-on-rocky-island.png`,
         url: `${TEMPLATE_INPUT_BASE}/white-hotel-on-rocky-island.png`
       }
     ])
@@ -49,9 +64,9 @@ describe('resolveTemplateInputAssets', () => {
     loadTemplateJson.mockResolvedValue({
       nodes: [loadNode('LoadVideo', 'clip.mp4'), loadNode('LoadAudio', 'voice.mp3')]
     })
-    expect((await resolveTemplateInputAssets(inst, 't')).map((a) => a.filename)).toEqual([
-      'clip.mp4',
-      'voice.mp3'
+    expect(await resolveTemplateInputAssets(inst, 't')).toMatchObject([
+      { filename: 'clip.mp4', mediaType: 'video' },
+      { filename: 'voice.mp3', mediaType: 'audio' }
     ])
   })
 
@@ -113,5 +128,65 @@ describe('resolveInputDir', () => {
       installPath: '/apps/c'
     } as unknown as InstallationRecord
     expect(resolveInputDir(rec)).toMatch(/[/\\]apps[/\\]c[/\\]ComfyUI[/\\]input$/)
+  })
+})
+
+describe('resolveTemplateInputAssetAvailability', () => {
+  it('distinguishes exact files already present in the active input directory', async () => {
+    const access = vi.fn(async (filePath: string) => {
+      if (filePath.endsWith('present.png')) return
+      const error = new Error('missing') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    })
+
+    await expect(
+      resolveTemplateInputAssetAvailability(
+        {
+          useSharedInput: false,
+          inputDir: '/inputs'
+        } as unknown as InstallationRecord,
+        ['present.png', 'missing.png'],
+        { access }
+      )
+    ).resolves.toEqual([
+      { filename: 'present.png', status: 'present' },
+      { filename: 'missing.png', status: 'missing' }
+    ])
+  })
+
+  it('rejects unsafe and duplicate declarations without probing outside input', async () => {
+    const access = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    await expect(
+      resolveTemplateInputAssetAvailability(
+        {
+          useSharedInput: false,
+          inputDir: '/inputs'
+        } as unknown as InstallationRecord,
+        ['safe.png', '../escape.png', 'safe.png', 'weights.safetensors'],
+        { access }
+      )
+    ).resolves.toEqual([{ filename: 'safe.png', status: 'missing' }])
+    expect(access).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps non-ENOENT filesystem failures unknown instead of claiming missing', async () => {
+    const access = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+
+    await expect(
+      resolveTemplateInputAssetAvailability(
+        {
+          useSharedInput: false,
+          inputDir: '/inputs'
+        } as unknown as InstallationRecord,
+        ['private.png'],
+        { access }
+      )
+    ).resolves.toEqual([{ filename: 'private.png', status: 'unknown' }])
   })
 })

--- a/src/main/sources/standalone/templateInputAssets.test.ts
+++ b/src/main/sources/standalone/templateInputAssets.test.ts
@@ -63,6 +63,22 @@ describe('resolveTemplateInputAssets', () => {
     ])
   })
 
+  it('uses the safe filename extension when a loader type and media disagree', async () => {
+    loadTemplateJson.mockResolvedValue({
+      nodes: [
+        loadNode('LoadImage', 'clip.mp4'),
+        loadNode('LoadVideo', 'still.webp'),
+        loadNode('LoadAudio', 'voice.wav')
+      ]
+    })
+
+    expect(await resolveTemplateInputAssets(inst, 't')).toMatchObject([
+      { filename: 'clip.mp4', mediaType: 'video' },
+      { filename: 'still.webp', mediaType: 'image' },
+      { filename: 'voice.wav', mediaType: 'audio' }
+    ])
+  })
+
   it('de-duplicates a filename referenced by multiple nodes', async () => {
     loadTemplateJson.mockResolvedValue({
       nodes: [loadNode('LoadImage', 'dup.png'), loadNode('LoadImage', 'dup.png')]

--- a/src/main/sources/standalone/templateInputAssets.test.ts
+++ b/src/main/sources/standalone/templateInputAssets.test.ts
@@ -12,30 +12,14 @@ vi.mock('./templateModels', () => ({
   loadTemplateJson: (...a: unknown[]) => loadTemplateJson(...a)
 }))
 
-import * as templateInputAssets from './templateInputAssets'
+import {
+  resolveInputDir,
+  resolveTemplateInputAssetAvailability,
+  resolveTemplateInputAssets,
+  resolveTemplateInputAssetSnapshot
+} from './templateInputAssets'
 import { TEMPLATE_INPUT_BASE } from './curatedTemplates'
 import type { InstallationRecord } from '../../installations'
-
-const { resolveTemplateInputAssets, resolveInputDir } = templateInputAssets
-const resolveTemplateInputAssetSnapshot =
-  (
-    templateInputAssets as typeof templateInputAssets & {
-      resolveTemplateInputAssetSnapshot?: (
-        installation: InstallationRecord,
-        templateId: string
-      ) => Promise<unknown>
-    }
-  ).resolveTemplateInputAssetSnapshot ?? resolveTemplateInputAssets
-const resolveTemplateInputAssetAvailability =
-  (
-    templateInputAssets as typeof templateInputAssets & {
-      resolveTemplateInputAssetAvailability?: (
-        installation: InstallationRecord,
-        filenames: readonly string[],
-        dependencies: { access: (filePath: string) => Promise<void> }
-      ) => Promise<unknown>
-    }
-  ).resolveTemplateInputAssetAvailability ?? (async () => [])
 
 const inst = { id: 'i1', bundledTemplateId: 't' } as unknown as InstallationRecord
 

--- a/src/main/sources/standalone/templateInputAssets.test.ts
+++ b/src/main/sources/standalone/templateInputAssets.test.ts
@@ -17,6 +17,15 @@ import { TEMPLATE_INPUT_BASE } from './curatedTemplates'
 import type { InstallationRecord } from '../../installations'
 
 const { resolveTemplateInputAssets, resolveInputDir } = templateInputAssets
+const resolveTemplateInputAssetSnapshot =
+  (
+    templateInputAssets as typeof templateInputAssets & {
+      resolveTemplateInputAssetSnapshot?: (
+        installation: InstallationRecord,
+        templateId: string
+      ) => Promise<unknown>
+    }
+  ).resolveTemplateInputAssetSnapshot ?? resolveTemplateInputAssets
 const resolveTemplateInputAssetAvailability =
   (
     templateInputAssets as typeof templateInputAssets & {
@@ -110,6 +119,13 @@ describe('resolveTemplateInputAssets', () => {
   it('returns [] when the workflow JSON cannot be resolved', async () => {
     loadTemplateJson.mockResolvedValue(null)
     expect(await resolveTemplateInputAssets(inst, 't')).toEqual([])
+  })
+
+  it('keeps unresolved metadata distinct from a resolved template with no inputs', async () => {
+    loadTemplateJson.mockResolvedValue(null)
+
+    await expect(resolveTemplateInputAssetSnapshot(inst, 't')).resolves.toBeNull()
+    await expect(resolveTemplateInputAssets(inst, 't')).resolves.toEqual([])
   })
 })
 

--- a/src/main/sources/standalone/templateInputAssets.ts
+++ b/src/main/sources/standalone/templateInputAssets.ts
@@ -17,8 +17,14 @@ import type { InstallationRecord } from '../../installations'
  * tracking any binary.
  */
 export interface TemplateInputAsset {
+  /** Template-scoped identifier accepted by the privileged download bridge. */
+  assetId: string
   /** Bare on-disk filename, placed at `<inputDir>/<filename>`. */
   filename: string
+  mediaType: 'image' | 'video' | 'audio'
+  /** Host-generated public preview URL. Its existence is not guaranteed when
+   *  an installed template package and the live templates repo have drifted. */
+  previewUrl: string
   /** Source URL under the repo's `input/` dir. */
   url: string
 }
@@ -52,6 +58,19 @@ const ALLOWED_INPUT_EXTENSIONS = [
   '.m4a'
 ]
 
+type TemplateInputMediaType = TemplateInputAsset['mediaType']
+
+interface DeclaredInputAsset {
+  filename: string
+  mediaType: TemplateInputMediaType
+}
+
+function mediaTypeForNode(nodeType: string): TemplateInputMediaType {
+  if (nodeType === 'LoadAudio') return 'audio'
+  if (nodeType === 'LoadVideo' || nodeType === 'VHS_LoadVideo') return 'video'
+  return 'image'
+}
+
 /** A template-declared input filename must be a bare name (no separator, no
  *  `..`) with an allowed media extension, so it can't escape the input dir or
  *  pull a non-media payload. */
@@ -62,7 +81,7 @@ function isSafeInputAsset(name: string): boolean {
 }
 
 /** Collect the first widget value (the filename) of every Load* node. */
-function walkLoadNodes(nodes: unknown, out: string[]): void {
+function walkLoadNodes(nodes: unknown, out: DeclaredInputAsset[]): void {
   if (!Array.isArray(nodes)) return
   for (const node of nodes) {
     if (!node || typeof node !== 'object') continue
@@ -73,7 +92,9 @@ function walkLoadNodes(nodes: unknown, out: string[]): void {
       Array.isArray(n.widgets_values)
     ) {
       const first = n.widgets_values[0]
-      if (typeof first === 'string') out.push(first)
+      if (typeof first === 'string') {
+        out.push({ filename: first, mediaType: mediaTypeForNode(n.type) })
+      }
     }
     if (Array.isArray(n.nodes)) walkLoadNodes(n.nodes, out)
   }
@@ -93,22 +114,31 @@ export async function resolveTemplateInputAssets(
   if (!json || typeof json !== 'object') return []
 
   const doc = json as { nodes?: unknown; definitions?: { subgraphs?: unknown } }
-  const names: string[] = []
-  walkLoadNodes(doc.nodes, names)
+  const declarations: DeclaredInputAsset[] = []
+  walkLoadNodes(doc.nodes, declarations)
   const subgraphs = doc.definitions?.subgraphs
   if (Array.isArray(subgraphs)) {
     for (const sg of subgraphs) {
-      if (sg && typeof sg === 'object') walkLoadNodes((sg as { nodes?: unknown }).nodes, names)
+      if (sg && typeof sg === 'object') {
+        walkLoadNodes((sg as { nodes?: unknown }).nodes, declarations)
+      }
     }
   }
 
   const seen = new Set<string>()
   const result: TemplateInputAsset[] = []
-  for (const raw of names) {
-    const filename = stripQueryParams(raw)
+  for (const declaration of declarations) {
+    const filename = stripQueryParams(declaration.filename)
     if (!isSafeInputAsset(filename) || seen.has(filename)) continue
     seen.add(filename)
-    result.push({ filename, url: `${TEMPLATE_INPUT_BASE}/${encodeURIComponent(filename)}` })
+    const url = `${TEMPLATE_INPUT_BASE}/${encodeURIComponent(filename)}`
+    result.push({
+      assetId: filename,
+      filename,
+      mediaType: declaration.mediaType,
+      previewUrl: url,
+      url
+    })
   }
   return result
 }
@@ -123,6 +153,45 @@ export function resolveInputDir(installation: InstallationRecord): string {
     return settings.get('inputDir') || settings.defaults.inputDir
   }
   return installation.inputDir || path.join(installation.installPath, 'ComfyUI', 'input')
+}
+
+export interface TemplateInputAssetAvailability {
+  filename: string
+  status: 'present' | 'missing' | 'unknown'
+}
+
+interface TemplateInputAssetAvailabilityDependencies {
+  access: (filePath: string) => Promise<void>
+}
+
+/** Resolve safe, exact filenames against the active installation. Only ENOENT
+ *  proves absence; permission and other filesystem failures remain unknown. */
+export async function resolveTemplateInputAssetAvailability(
+  installation: InstallationRecord,
+  filenames: readonly string[],
+  { access = fs.promises.access }: Partial<TemplateInputAssetAvailabilityDependencies> = {}
+): Promise<TemplateInputAssetAvailability[]> {
+  const inputDir = resolveInputDir(installation)
+  const seen = new Set<string>()
+  const result: TemplateInputAssetAvailability[] = []
+
+  for (const filename of filenames) {
+    if (!isSafeInputAsset(filename) || seen.has(filename)) continue
+    seen.add(filename)
+
+    try {
+      await access(path.join(inputDir, filename))
+      result.push({ filename, status: 'present' })
+    } catch (error) {
+      result.push({
+        filename,
+        status:
+          (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT' ? 'missing' : 'unknown'
+      })
+    }
+  }
+
+  return result
 }
 
 export interface PlacedInputAsset {

--- a/src/main/sources/standalone/templateInputAssets.ts
+++ b/src/main/sources/standalone/templateInputAssets.ts
@@ -39,36 +39,29 @@ const LOAD_NODE_TYPES = new Set([
   'VHS_LoadVideo'
 ])
 
-/** Media extensions we'll place in `input/`. Excludes model/script types so a
- *  crafted widget value can't pull an arbitrary payload through this path. */
-const ALLOWED_INPUT_EXTENSIONS = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.webp',
-  '.gif',
-  '.bmp',
-  '.mp4',
-  '.webm',
-  '.mov',
-  '.mp3',
-  '.wav',
-  '.flac',
-  '.ogg',
-  '.m4a'
-]
-
 type TemplateInputMediaType = TemplateInputAsset['mediaType']
 
-interface DeclaredInputAsset {
-  filename: string
-  mediaType: TemplateInputMediaType
+/** Media extensions we'll place in `input/`. Excludes model/script types so a
+ *  crafted widget value can't pull an arbitrary payload through this path. */
+const MEDIA_TYPE_BY_EXTENSION: Readonly<Record<string, TemplateInputMediaType>> = {
+  '.png': 'image',
+  '.jpg': 'image',
+  '.jpeg': 'image',
+  '.webp': 'image',
+  '.gif': 'image',
+  '.bmp': 'image',
+  '.mp4': 'video',
+  '.webm': 'video',
+  '.mov': 'video',
+  '.mp3': 'audio',
+  '.wav': 'audio',
+  '.flac': 'audio',
+  '.ogg': 'audio',
+  '.m4a': 'audio'
 }
 
-function mediaTypeForNode(nodeType: string): TemplateInputMediaType {
-  if (nodeType === 'LoadAudio') return 'audio'
-  if (nodeType === 'LoadVideo' || nodeType === 'VHS_LoadVideo') return 'video'
-  return 'image'
+function mediaTypeForFilename(filename: string): TemplateInputMediaType | undefined {
+  return MEDIA_TYPE_BY_EXTENSION[path.extname(filename).toLowerCase()]
 }
 
 /** A template-declared input filename must be a bare name (no separator, no
@@ -76,12 +69,11 @@ function mediaTypeForNode(nodeType: string): TemplateInputMediaType {
  *  pull a non-media payload. */
 function isSafeInputAsset(name: string): boolean {
   if (!name || name.includes('/') || name.includes('\\') || name.includes('..')) return false
-  const lower = name.toLowerCase()
-  return ALLOWED_INPUT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+  return mediaTypeForFilename(name) !== undefined
 }
 
 /** Collect the first widget value (the filename) of every Load* node. */
-function walkLoadNodes(nodes: unknown, out: DeclaredInputAsset[]): void {
+function walkLoadNodes(nodes: unknown, out: string[]): void {
   if (!Array.isArray(nodes)) return
   for (const node of nodes) {
     if (!node || typeof node !== 'object') continue
@@ -92,9 +84,7 @@ function walkLoadNodes(nodes: unknown, out: DeclaredInputAsset[]): void {
       Array.isArray(n.widgets_values)
     ) {
       const first = n.widgets_values[0]
-      if (typeof first === 'string') {
-        out.push({ filename: first, mediaType: mediaTypeForNode(n.type) })
-      }
+      if (typeof first === 'string') out.push(first)
     }
     if (Array.isArray(n.nodes)) walkLoadNodes(n.nodes, out)
   }
@@ -102,7 +92,7 @@ function walkLoadNodes(nodes: unknown, out: DeclaredInputAsset[]): void {
 
 function extractTemplateInputAssets(json: object): TemplateInputAsset[] {
   const doc = json as { nodes?: unknown; definitions?: { subgraphs?: unknown } }
-  const declarations: DeclaredInputAsset[] = []
+  const declarations: string[] = []
   walkLoadNodes(doc.nodes, declarations)
   const subgraphs = doc.definitions?.subgraphs
   if (Array.isArray(subgraphs)) {
@@ -116,14 +106,15 @@ function extractTemplateInputAssets(json: object): TemplateInputAsset[] {
   const seen = new Set<string>()
   const result: TemplateInputAsset[] = []
   for (const declaration of declarations) {
-    const filename = stripQueryParams(declaration.filename)
-    if (!isSafeInputAsset(filename) || seen.has(filename)) continue
+    const filename = stripQueryParams(declaration)
+    const mediaType = mediaTypeForFilename(filename)
+    if (!isSafeInputAsset(filename) || !mediaType || seen.has(filename)) continue
     seen.add(filename)
     const url = `${TEMPLATE_INPUT_BASE}/${encodeURIComponent(filename)}`
     result.push({
       assetId: filename,
       filename,
-      mediaType: declaration.mediaType,
+      mediaType,
       previewUrl: url,
       url
     })

--- a/src/main/sources/standalone/templateInputAssets.ts
+++ b/src/main/sources/standalone/templateInputAssets.ts
@@ -100,19 +100,7 @@ function walkLoadNodes(nodes: unknown, out: DeclaredInputAsset[]): void {
   }
 }
 
-/**
- * Extract the de-duplicated, validated set of sample input assets a template
- * needs. Scans every Load* node (including subgraph definitions), keeps only
- * bare media filenames, and points each at the repo's `input/` dir. Returns `[]`
- * for templates with no image/media input or when the JSON can't be resolved.
- */
-export async function resolveTemplateInputAssets(
-  installation: InstallationRecord,
-  templateId: string
-): Promise<TemplateInputAsset[]> {
-  const json = await loadTemplateJson(installation, templateId)
-  if (!json || typeof json !== 'object') return []
-
+function extractTemplateInputAssets(json: object): TemplateInputAsset[] {
   const doc = json as { nodes?: unknown; definitions?: { subgraphs?: unknown } }
   const declarations: DeclaredInputAsset[] = []
   walkLoadNodes(doc.nodes, declarations)
@@ -141,6 +129,33 @@ export async function resolveTemplateInputAssets(
     })
   }
   return result
+}
+
+/**
+ * Resolve the de-duplicated, validated set of sample input assets a template
+ * declares. `null` means the workflow metadata could not be resolved; `[]`
+ * means it resolved successfully and declares no supported input media. The
+ * distinction matters to inspection UIs, which must not present an unknown
+ * requirement set as an empty one.
+ */
+export async function resolveTemplateInputAssetSnapshot(
+  installation: InstallationRecord,
+  templateId: string
+): Promise<TemplateInputAsset[] | null> {
+  const json = await loadTemplateJson(installation, templateId)
+  return json && typeof json === 'object' ? extractTemplateInputAssets(json) : null
+}
+
+/**
+ * Compatibility helper for the best-effort install path. A metadata failure
+ * remains “nothing to place” there; template-scoped inspection should use the
+ * nullable snapshot above instead.
+ */
+export async function resolveTemplateInputAssets(
+  installation: InstallationRecord,
+  templateId: string
+): Promise<TemplateInputAsset[]> {
+  return (await resolveTemplateInputAssetSnapshot(installation, templateId)) ?? []
 }
 
 /**

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   ComfyDesktop2BridgeImplementation,
   ComfyDownloadProgress,
+  ComfyTemplateInputAssetDownload,
   TerminalRestore
 } from '../types/comfyDesktopBridge'
 
@@ -41,6 +42,32 @@ function downloadProgressHandler(): (event: unknown, progress: ComfyDownloadProg
   const call = mocks.on.mock.calls.find(([channel]) => channel === 'desktop2-download-progress')
   expect(call).toBeDefined()
   return call![1] as (event: unknown, progress: ComfyDownloadProgress) => void
+}
+
+const sampleUrl = 'https://example.com/sample.png'
+
+function downloadSnapshot(
+  downloadId: string,
+  status: ComfyDownloadProgress['status'] = 'pending',
+  progress = 0
+): ComfyTemplateInputAssetDownload {
+  return { downloadId, filename: 'sample.png', progress, status }
+}
+
+function downloadProgress(
+  id: string,
+  status: ComfyDownloadProgress['status'] = 'pending',
+  progress = 0,
+  error?: string
+): ComfyDownloadProgress {
+  return {
+    id,
+    url: sampleUrl,
+    filename: 'sample.png',
+    progress,
+    status,
+    ...(error === undefined ? {} : { error })
+  }
 }
 
 describe('comfyPreload model access bridge', () => {
@@ -105,24 +132,10 @@ describe('comfyPreload template input asset bridge', () => {
     const callback = vi.fn()
     const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
     mocks.invoke.mockImplementationOnce(async () => {
-      downloadProgressHandler()(
-        {},
-        {
-          id: 'download-1',
-          url: 'https://example.com/sample.png',
-          filename: 'sample.png',
-          progress: 0,
-          status: 'pending'
-        }
-      )
+      downloadProgressHandler()({}, downloadProgress('download-1'))
       return {
         status: 'accepted',
-        download: {
-          downloadId: 'download-1',
-          filename: 'sample.png',
-          progress: 0,
-          status: 'pending'
-        }
+        download: downloadSnapshot('download-1')
       }
     })
 
@@ -136,10 +149,7 @@ describe('comfyPreload template input asset bridge', () => {
     })
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenLastCalledWith({
-      downloadId: 'download-1',
-      filename: 'sample.png',
-      progress: 0,
-      status: 'pending',
+      ...downloadSnapshot('download-1'),
       templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
     })
     unsubscribe()
@@ -152,31 +162,18 @@ describe('comfyPreload template input asset bridge', () => {
     mocks.invoke
       .mockResolvedValueOnce({
         status: 'accepted',
-        download: {
-          downloadId: 'shared-download',
-          filename: 'sample.png',
-          progress: 0,
-          status: 'pending'
-        }
+        download: downloadSnapshot('shared-download')
       })
       .mockResolvedValueOnce({
         status: 'joined',
-        download: {
-          downloadId: 'shared-download',
-          filename: 'sample.png',
-          progress: 0.4,
-          status: 'downloading'
-        }
+        download: downloadSnapshot('shared-download', 'downloading', 0.4)
       })
 
     await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
     await bridge.downloadTemplateInputAsset('template-b', 'asset-b')
 
     expect(callback).toHaveBeenLastCalledWith({
-      downloadId: 'shared-download',
-      filename: 'sample.png',
-      progress: 0.4,
-      status: 'downloading',
+      ...downloadSnapshot('shared-download', 'downloading', 0.4),
       templateInputs: [
         { templateId: 'template-a', assetId: 'asset-a' },
         { templateId: 'template-b', assetId: 'asset-b' }
@@ -184,37 +181,16 @@ describe('comfyPreload template input asset bridge', () => {
     })
 
     const progress = downloadProgressHandler()
-    progress(
-      {},
-      {
-        id: 'shared-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 1,
-        status: 'completed'
-      }
-    )
+    progress({}, downloadProgress('shared-download', 'completed', 1))
     expect(callback).toHaveBeenLastCalledWith({
-      downloadId: 'shared-download',
-      filename: 'sample.png',
-      progress: 1,
-      status: 'completed',
+      ...downloadSnapshot('shared-download', 'completed', 1),
       templateInputs: [
         { templateId: 'template-a', assetId: 'asset-a' },
         { templateId: 'template-b', assetId: 'asset-b' }
       ]
     })
     const callsAfterCompletion = callback.mock.calls.length
-    progress(
-      {},
-      {
-        id: 'shared-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 0.5,
-        status: 'downloading'
-      }
-    )
+    progress({}, downloadProgress('shared-download', 'downloading', 0.5))
     expect(callback).toHaveBeenCalledTimes(callsAfterCompletion)
     unsubscribe()
   })
@@ -226,65 +202,24 @@ describe('comfyPreload template input asset bridge', () => {
     mocks.invoke
       .mockResolvedValueOnce({
         status: 'accepted',
-        download: {
-          downloadId: 'failed-download',
-          filename: 'sample.png',
-          progress: 0.6,
-          status: 'downloading'
-        }
+        download: downloadSnapshot('failed-download', 'downloading', 0.6)
       })
       .mockResolvedValueOnce({
         status: 'accepted',
-        download: {
-          downloadId: 'retry-download',
-          filename: 'sample.png',
-          progress: 0,
-          status: 'pending'
-        }
+        download: downloadSnapshot('retry-download')
       })
 
     await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
     const progress = downloadProgressHandler()
-    progress(
-      {},
-      {
-        id: 'failed-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 0.6,
-        status: 'error',
-        error: 'network error'
-      }
-    )
+    progress({}, downloadProgress('failed-download', 'error', 0.6, 'network error'))
     await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
     const callsAfterRetry = callback.mock.calls.length
-    progress(
-      {},
-      {
-        id: 'failed-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 1,
-        status: 'completed'
-      }
-    )
+    progress({}, downloadProgress('failed-download', 'completed', 1))
     expect(callback).toHaveBeenCalledTimes(callsAfterRetry)
 
-    progress(
-      {},
-      {
-        id: 'retry-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 0.25,
-        status: 'downloading'
-      }
-    )
+    progress({}, downloadProgress('retry-download', 'downloading', 0.25))
     expect(callback).toHaveBeenLastCalledWith({
-      downloadId: 'retry-download',
-      filename: 'sample.png',
-      progress: 0.25,
-      status: 'downloading',
+      ...downloadSnapshot('retry-download', 'downloading', 0.25),
       templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
     })
     unsubscribe()
@@ -302,10 +237,7 @@ describe('comfyPreload template input asset bridge', () => {
         previewUrl: 'https://example.com/sample.png',
         availability: 'missing',
         activeDownload: {
-          downloadId: 'active-download',
-          filename: 'sample.png',
-          progress: 0.2,
-          status: 'downloading'
+          ...downloadSnapshot('active-download', 'downloading', 0.2)
         }
       }
     ])
@@ -315,21 +247,9 @@ describe('comfyPreload template input asset bridge', () => {
       templateId: 'template-a'
     })
 
-    downloadProgressHandler()(
-      {},
-      {
-        id: 'active-download',
-        url: 'https://example.com/sample.png',
-        filename: 'sample.png',
-        progress: 0.5,
-        status: 'downloading'
-      }
-    )
+    downloadProgressHandler()({}, downloadProgress('active-download', 'downloading', 0.5))
     expect(callback).toHaveBeenLastCalledWith({
-      downloadId: 'active-download',
-      filename: 'sample.png',
-      progress: 0.5,
-      status: 'downloading',
+      ...downloadSnapshot('active-download', 'downloading', 0.5),
       templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
     })
     unsubscribe()

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -24,7 +24,39 @@ import './comfyPreload'
 import type { LegacyTerminalBridge } from './comfyPreload'
 import type { ComfyDesktop2BridgeImplementation } from '../types/comfyDesktopBridge'
 
+type TemplateInputRef = { templateId: string; assetId: string }
+type TemplateInputDownload = {
+  downloadId: string
+  filename: string
+  progress: number
+  status: 'pending' | 'downloading' | 'completed' | 'error'
+  error?: string
+}
+type TemplateInputProgress = TemplateInputDownload & {
+  templateInputs: TemplateInputRef[]
+}
+
 type HostedFrontendBridge = ComfyDesktop2BridgeImplementation & {
+  getTemplateInputAssets: (templateId: string) => Promise<
+    | {
+        assetId: string
+        filename: string
+        mediaType: 'image' | 'video' | 'audio'
+        previewUrl: string
+        availability: 'present' | 'missing' | 'unknown'
+        activeDownload?: TemplateInputDownload
+      }[]
+    | null
+  >
+  downloadTemplateInputAsset: (
+    templateId: string,
+    assetId: string
+  ) => Promise<
+    | { status: 'already-present' }
+    | { status: 'accepted' | 'joined'; download: TemplateInputDownload }
+    | { status: 'not-started'; reason: string }
+  >
+  onTemplateInputDownloadProgress: (callback: (data: TemplateInputProgress) => void) => () => void
   Terminal: LegacyTerminalBridge
 }
 
@@ -32,9 +64,17 @@ function hostedBridge(): HostedFrontendBridge {
   return mocks.exposeInMainWorld.mock.calls[0]![1] as HostedFrontendBridge
 }
 
+function downloadProgressHandler(): (event: unknown, progress: Record<string, unknown>) => void {
+  const call = mocks.on.mock.calls.find(([channel]) => channel === 'desktop2-download-progress')
+  expect(call).toBeDefined()
+  return call![1] as (event: unknown, progress: Record<string, unknown>) => void
+}
+
 describe('comfyPreload model access bridge', () => {
   beforeEach(() => {
     mocks.invoke.mockReset()
+    mocks.on.mockClear()
+    mocks.removeListener.mockClear()
   })
 
   it('forwards the repository URL through the desktop2 IPC contract', async () => {
@@ -77,5 +117,263 @@ describe('comfyPreload model access bridge', () => {
     expect(mocks.invoke).toHaveBeenCalledTimes(3)
     expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal')
     expect(mocks.invoke).toHaveBeenCalledWith('desktop2-open-terminal-popout')
+  })
+})
+
+describe('comfyPreload template input asset bridge', () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset()
+    mocks.on.mockClear()
+    mocks.removeListener.mockClear()
+  })
+
+  it('uses the admission snapshot when pending progress races ahead of the invoke response', async () => {
+    const bridge = hostedBridge()
+    const callback = vi.fn()
+    const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
+    mocks.invoke.mockImplementationOnce(async () => {
+      downloadProgressHandler()(
+        {},
+        {
+          id: 'download-1',
+          filename: 'sample.png',
+          progress: 0,
+          status: 'pending'
+        }
+      )
+      return {
+        status: 'accepted',
+        download: {
+          downloadId: 'download-1',
+          filename: 'sample.png',
+          progress: 0,
+          status: 'pending'
+        }
+      }
+    })
+
+    await expect(bridge.downloadTemplateInputAsset('template-a', 'asset-a')).resolves.toMatchObject(
+      { status: 'accepted' }
+    )
+
+    expect(mocks.invoke).toHaveBeenCalledWith('desktop2-download-template-input-asset', {
+      templateId: 'template-a',
+      assetId: 'asset-a'
+    })
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith({
+      downloadId: 'download-1',
+      filename: 'sample.png',
+      progress: 0,
+      status: 'pending',
+      templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
+    })
+    unsubscribe()
+  })
+
+  it('keeps every template consumer on a shared download through completion, then cleans it up', async () => {
+    const bridge = hostedBridge()
+    const callback = vi.fn()
+    const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
+    mocks.invoke
+      .mockResolvedValueOnce({
+        status: 'accepted',
+        download: {
+          downloadId: 'shared-download',
+          filename: 'sample.png',
+          progress: 0,
+          status: 'pending'
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 'joined',
+        download: {
+          downloadId: 'shared-download',
+          filename: 'sample.png',
+          progress: 0.4,
+          status: 'downloading'
+        }
+      })
+
+    await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
+    await bridge.downloadTemplateInputAsset('template-b', 'asset-b')
+
+    expect(callback).toHaveBeenLastCalledWith({
+      downloadId: 'shared-download',
+      filename: 'sample.png',
+      progress: 0.4,
+      status: 'downloading',
+      templateInputs: [
+        { templateId: 'template-a', assetId: 'asset-a' },
+        { templateId: 'template-b', assetId: 'asset-b' }
+      ]
+    })
+
+    const progress = downloadProgressHandler()
+    progress(
+      {},
+      {
+        id: 'shared-download',
+        url: 'https://example.com/sample.png',
+        filename: 'sample.png',
+        progress: 1,
+        status: 'completed'
+      }
+    )
+    expect(callback).toHaveBeenLastCalledWith({
+      downloadId: 'shared-download',
+      filename: 'sample.png',
+      progress: 1,
+      status: 'completed',
+      templateInputs: [
+        { templateId: 'template-a', assetId: 'asset-a' },
+        { templateId: 'template-b', assetId: 'asset-b' }
+      ]
+    })
+    const callsAfterCompletion = callback.mock.calls.length
+    progress(
+      {},
+      {
+        id: 'shared-download',
+        filename: 'sample.png',
+        progress: 0.5,
+        status: 'downloading'
+      }
+    )
+    expect(callback).toHaveBeenCalledTimes(callsAfterCompletion)
+    unsubscribe()
+  })
+
+  it('binds a domain retry to its new download id and ignores the completed attempt', async () => {
+    const bridge = hostedBridge()
+    const callback = vi.fn()
+    const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
+    mocks.invoke
+      .mockResolvedValueOnce({
+        status: 'accepted',
+        download: {
+          downloadId: 'failed-download',
+          filename: 'sample.png',
+          progress: 0.6,
+          status: 'downloading'
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 'accepted',
+        download: {
+          downloadId: 'retry-download',
+          filename: 'sample.png',
+          progress: 0,
+          status: 'pending'
+        }
+      })
+
+    await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
+    const progress = downloadProgressHandler()
+    progress(
+      {},
+      {
+        id: 'failed-download',
+        filename: 'sample.png',
+        progress: 0.6,
+        status: 'error',
+        error: 'network error'
+      }
+    )
+    await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
+    const callsAfterRetry = callback.mock.calls.length
+    progress(
+      {},
+      {
+        id: 'failed-download',
+        filename: 'sample.png',
+        progress: 1,
+        status: 'completed'
+      }
+    )
+    expect(callback).toHaveBeenCalledTimes(callsAfterRetry)
+
+    progress(
+      {},
+      {
+        id: 'retry-download',
+        filename: 'sample.png',
+        progress: 0.25,
+        status: 'downloading'
+      }
+    )
+    expect(callback).toHaveBeenLastCalledWith({
+      downloadId: 'retry-download',
+      filename: 'sample.png',
+      progress: 0.25,
+      status: 'downloading',
+      templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
+    })
+    unsubscribe()
+  })
+
+  it('reconnects progress identity from the active snapshots returned on reopen', async () => {
+    const bridge = hostedBridge()
+    const callback = vi.fn()
+    const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
+    mocks.invoke.mockResolvedValueOnce([
+      {
+        assetId: 'asset-a',
+        filename: 'sample.png',
+        mediaType: 'image',
+        previewUrl: 'https://example.com/sample.png',
+        availability: 'missing',
+        activeDownload: {
+          downloadId: 'active-download',
+          filename: 'sample.png',
+          progress: 0.2,
+          status: 'downloading'
+        }
+      }
+    ])
+
+    await expect(bridge.getTemplateInputAssets('template-a')).resolves.toHaveLength(1)
+    expect(mocks.invoke).toHaveBeenCalledWith('desktop2-get-template-input-assets', {
+      templateId: 'template-a'
+    })
+
+    downloadProgressHandler()(
+      {},
+      {
+        id: 'active-download',
+        filename: 'sample.png',
+        progress: 0.5,
+        status: 'downloading'
+      }
+    )
+    expect(callback).toHaveBeenLastCalledWith({
+      downloadId: 'active-download',
+      filename: 'sample.png',
+      progress: 0.5,
+      status: 'downloading',
+      templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
+    })
+    unsubscribe()
+  })
+
+  it('shares one IPC listener and removes it when the last subscriber leaves', () => {
+    const bridge = hostedBridge()
+    const unsubscribeA = bridge.onTemplateInputDownloadProgress(() => {})
+    const unsubscribeB = bridge.onTemplateInputDownloadProgress(() => {})
+    const registration = mocks.on.mock.calls.find(
+      ([channel]) => channel === 'desktop2-download-progress'
+    )
+
+    expect(registration).toBeDefined()
+    expect(
+      mocks.on.mock.calls.filter(([channel]) => channel === 'desktop2-download-progress')
+    ).toHaveLength(1)
+    unsubscribeA()
+    expect(mocks.removeListener).not.toHaveBeenCalled()
+    unsubscribeB()
+    expect(mocks.removeListener).toHaveBeenCalledWith(
+      'desktop2-download-progress',
+      registration![1]
+    )
   })
 })

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -155,6 +155,30 @@ describe('comfyPreload template input asset bridge', () => {
     unsubscribe()
   })
 
+  it('replays terminal progress that races ahead of the invoke response', async () => {
+    const bridge = hostedBridge()
+    const callback = vi.fn()
+    const unsubscribe = bridge.onTemplateInputDownloadProgress(callback)
+    mocks.invoke.mockImplementationOnce(async () => {
+      downloadProgressHandler()({}, downloadProgress('download-1', 'completed', 1))
+      return {
+        status: 'accepted',
+        download: downloadSnapshot('download-1')
+      }
+    })
+
+    await bridge.downloadTemplateInputAsset('template-a', 'asset-a')
+
+    expect(callback).toHaveBeenCalledExactlyOnceWith({
+      ...downloadSnapshot('download-1', 'completed', 1),
+      templateInputs: [{ templateId: 'template-a', assetId: 'asset-a' }]
+    })
+    const callsAfterCompletion = callback.mock.calls.length
+    downloadProgressHandler()({}, downloadProgress('download-1', 'downloading', 0.5))
+    expect(callback).toHaveBeenCalledTimes(callsAfterCompletion)
+    unsubscribe()
+  })
+
   it('keeps every template consumer on a shared download through completion, then cleans it up', async () => {
     const bridge = hostedBridge()
     const callback = vi.fn()

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ComfyDesktop2BridgeImplementation,
+  ComfyDownloadProgress,
+  TerminalRestore
+} from '../types/comfyDesktopBridge'
 
 const mocks = vi.hoisted(() => ({
   exposeInMainWorld: vi.fn(),
@@ -21,53 +26,21 @@ vi.mock('electron', () => ({
 }))
 
 import './comfyPreload'
-import type { LegacyTerminalBridge } from './comfyPreload'
-import type { ComfyDesktop2BridgeImplementation } from '../types/comfyDesktopBridge'
 
-type TemplateInputRef = { templateId: string; assetId: string }
-type TemplateInputDownload = {
-  downloadId: string
-  filename: string
-  progress: number
-  status: 'pending' | 'downloading' | 'completed' | 'error'
-  error?: string
-}
-type TemplateInputProgress = TemplateInputDownload & {
-  templateInputs: TemplateInputRef[]
-}
-
-type HostedFrontendBridge = ComfyDesktop2BridgeImplementation & {
-  getTemplateInputAssets: (templateId: string) => Promise<
-    | {
-        assetId: string
-        filename: string
-        mediaType: 'image' | 'video' | 'audio'
-        previewUrl: string
-        availability: 'present' | 'missing' | 'unknown'
-        activeDownload?: TemplateInputDownload
-      }[]
-    | null
-  >
-  downloadTemplateInputAsset: (
-    templateId: string,
-    assetId: string
-  ) => Promise<
-    | { status: 'already-present' }
-    | { status: 'accepted' | 'joined'; download: TemplateInputDownload }
-    | { status: 'not-started'; reason: string }
-  >
-  onTemplateInputDownloadProgress: (callback: (data: TemplateInputProgress) => void) => () => void
-  Terminal: LegacyTerminalBridge
+type HostedFrontendBridge = Omit<ComfyDesktop2BridgeImplementation, 'Terminal'> & {
+  Terminal: ComfyDesktop2BridgeImplementation['Terminal'] & {
+    restore: () => Promise<TerminalRestore>
+  }
 }
 
 function hostedBridge(): HostedFrontendBridge {
   return mocks.exposeInMainWorld.mock.calls[0]![1] as HostedFrontendBridge
 }
 
-function downloadProgressHandler(): (event: unknown, progress: Record<string, unknown>) => void {
+function downloadProgressHandler(): (event: unknown, progress: ComfyDownloadProgress) => void {
   const call = mocks.on.mock.calls.find(([channel]) => channel === 'desktop2-download-progress')
   expect(call).toBeDefined()
-  return call![1] as (event: unknown, progress: Record<string, unknown>) => void
+  return call![1] as (event: unknown, progress: ComfyDownloadProgress) => void
 }
 
 describe('comfyPreload model access bridge', () => {
@@ -136,6 +109,7 @@ describe('comfyPreload template input asset bridge', () => {
         {},
         {
           id: 'download-1',
+          url: 'https://example.com/sample.png',
           filename: 'sample.png',
           progress: 0,
           status: 'pending'
@@ -235,6 +209,7 @@ describe('comfyPreload template input asset bridge', () => {
       {},
       {
         id: 'shared-download',
+        url: 'https://example.com/sample.png',
         filename: 'sample.png',
         progress: 0.5,
         status: 'downloading'
@@ -274,6 +249,7 @@ describe('comfyPreload template input asset bridge', () => {
       {},
       {
         id: 'failed-download',
+        url: 'https://example.com/sample.png',
         filename: 'sample.png',
         progress: 0.6,
         status: 'error',
@@ -286,6 +262,7 @@ describe('comfyPreload template input asset bridge', () => {
       {},
       {
         id: 'failed-download',
+        url: 'https://example.com/sample.png',
         filename: 'sample.png',
         progress: 1,
         status: 'completed'
@@ -297,6 +274,7 @@ describe('comfyPreload template input asset bridge', () => {
       {},
       {
         id: 'retry-download',
+        url: 'https://example.com/sample.png',
         filename: 'sample.png',
         progress: 0.25,
         status: 'downloading'
@@ -341,6 +319,7 @@ describe('comfyPreload template input asset bridge', () => {
       {},
       {
         id: 'active-download',
+        url: 'https://example.com/sample.png',
         filename: 'sample.png',
         progress: 0.5,
         status: 'downloading'

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -6,6 +6,10 @@ import type {
   ComfyDesktop2TelemetryBridge,
   ComfyDesktop2TerminalBridge,
   ComfyDownloadProgress,
+  ComfyTemplateInputAssetDownload,
+  ComfyTemplateInputAssetDownloadResult,
+  ComfyTemplateInputDownloadProgress,
+  ComfyTemplateInputReference,
   LogsOutputMsg,
   LogsRestore,
   TerminalRestore
@@ -95,6 +99,126 @@ const Telemetry: ComfyDesktop2TelemetryBridge = {
 
 startLocalFirebaseAuthMonitor(reportFirebaseAuthState)
 
+type TemplateInputProgressCallback = (data: ComfyTemplateInputDownloadProgress) => void
+
+const templateInputsByDownloadId = new Map<string, Map<string, ComfyTemplateInputReference>>()
+const templateInputProgressCallbacks = new Set<TemplateInputProgressCallback>()
+let templateInputProgressHandler:
+  | ((event: IpcRendererEvent, data: ComfyDownloadProgress) => void)
+  | undefined
+
+function templateInputReferenceKey({ templateId, assetId }: ComfyTemplateInputReference): string {
+  return `${templateId}\u0000${assetId}`
+}
+
+function emitTemplateInputProgress(
+  download: ComfyTemplateInputAssetDownload,
+  templateInputs: ComfyTemplateInputReference[]
+): void {
+  const progress = { ...download, templateInputs }
+  for (const callback of templateInputProgressCallbacks) callback(progress)
+}
+
+function removeTemplateInputProgressHandler(): void {
+  if (!templateInputProgressHandler) return
+  ipcRenderer.removeListener('desktop2-download-progress', templateInputProgressHandler)
+  templateInputProgressHandler = undefined
+}
+
+function maybeRemoveTemplateInputProgressHandler(): void {
+  if (templateInputProgressCallbacks.size === 0 && templateInputsByDownloadId.size === 0) {
+    removeTemplateInputProgressHandler()
+  }
+}
+
+function ensureTemplateInputProgressHandler(): void {
+  if (templateInputProgressHandler) return
+  templateInputProgressHandler = (_event, data) => {
+    if (!data.id) return
+    const references = templateInputsByDownloadId.get(data.id)
+    if (!references) return
+    const download: ComfyTemplateInputAssetDownload = {
+      downloadId: data.id,
+      filename: data.filename,
+      progress: data.progress,
+      ...(data.receivedBytes === undefined ? {} : { receivedBytes: data.receivedBytes }),
+      ...(data.totalBytes === undefined ? {} : { totalBytes: data.totalBytes }),
+      status: data.status,
+      ...(data.error === undefined ? {} : { error: data.error })
+    }
+    if (['completed', 'error', 'cancelled'].includes(data.status)) {
+      templateInputsByDownloadId.delete(data.id)
+    }
+    emitTemplateInputProgress(download, [...references.values()])
+    maybeRemoveTemplateInputProgressHandler()
+  }
+  ipcRenderer.on('desktop2-download-progress', templateInputProgressHandler)
+}
+
+function trackTemplateInputDownload(
+  reference: ComfyTemplateInputReference,
+  download: ComfyTemplateInputAssetDownload,
+  emitSnapshot: boolean
+): void {
+  let references = templateInputsByDownloadId.get(download.downloadId)
+  if (!references) {
+    references = new Map()
+    templateInputsByDownloadId.set(download.downloadId, references)
+  }
+  references.set(templateInputReferenceKey(reference), reference)
+  ensureTemplateInputProgressHandler()
+  if (emitSnapshot) emitTemplateInputProgress(download, [...references.values()])
+}
+
+const getTemplateInputAssets: NonNullable<
+  ComfyDesktop2BridgeImplementation['getTemplateInputAssets']
+> = async (templateId) => {
+  const assets = await ipcRenderer.invoke('desktop2-get-template-input-assets', { templateId })
+  if (!assets) return null
+  for (const asset of assets) {
+    if (asset.activeDownload) {
+      trackTemplateInputDownload(
+        { templateId, assetId: asset.assetId },
+        asset.activeDownload,
+        false
+      )
+    }
+  }
+  return assets
+}
+
+const downloadTemplateInputAsset: NonNullable<
+  ComfyDesktop2BridgeImplementation['downloadTemplateInputAsset']
+> = async (templateId, assetId): Promise<ComfyTemplateInputAssetDownloadResult> => {
+  const result = await ipcRenderer.invoke('desktop2-download-template-input-asset', {
+    templateId,
+    assetId
+  })
+  if (result.status === 'accepted' || result.status === 'joined') {
+    trackTemplateInputDownload({ templateId, assetId }, result.download, true)
+  }
+  return result
+}
+
+const onTemplateInputDownloadProgress: NonNullable<
+  ComfyDesktop2BridgeImplementation['onTemplateInputDownloadProgress']
+> = (callback) => {
+  templateInputProgressCallbacks.add(callback)
+  ensureTemplateInputProgressHandler()
+  let subscribed = true
+  return () => {
+    if (!subscribed) return
+    subscribed = false
+    templateInputProgressCallbacks.delete(callback)
+    if (templateInputProgressCallbacks.size === 0) {
+      // A future detail view reconstructs active ownership from its metadata
+      // snapshot. Do not retain identities for a renderer with no consumers.
+      templateInputsByDownloadId.clear()
+    }
+    maybeRemoveTemplateInputProgressHandler()
+  }
+}
+
 const bridge = {
   isRemote: (): boolean => ipcRenderer.sendSync('desktop2-is-remote') as boolean,
   openModelAccessPage: (url: string): Promise<boolean> => {
@@ -110,6 +234,9 @@ const bridge = {
       authToken: authToken || undefined
     })
   },
+  getTemplateInputAssets,
+  downloadTemplateInputAsset,
+  onTemplateInputDownloadProgress,
   pauseDownload: (url: string): Promise<boolean> => {
     return ipcRenderer.invoke('model-download-pause', { url })
   },

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -102,7 +102,9 @@ startLocalFirebaseAuthMonitor(reportFirebaseAuthState)
 type TemplateInputProgressCallback = (data: ComfyTemplateInputDownloadProgress) => void
 
 const templateInputsByDownloadId = new Map<string, Map<string, ComfyTemplateInputReference>>()
+const terminalTemplateInputDownloadsById = new Map<string, ComfyTemplateInputAssetDownload>()
 const templateInputProgressCallbacks = new Set<TemplateInputProgressCallback>()
+const MAX_BUFFERED_TERMINAL_DOWNLOADS = 50
 let templateInputProgressHandler:
   | ((event: IpcRendererEvent, data: ComfyDownloadProgress) => void)
   | undefined
@@ -117,6 +119,33 @@ function emitTemplateInputProgress(
 ): void {
   const progress = { ...download, templateInputs }
   for (const callback of templateInputProgressCallbacks) callback(progress)
+}
+
+function toTemplateInputAssetDownload(
+  data: ComfyDownloadProgress
+): ComfyTemplateInputAssetDownload | undefined {
+  if (!data.id) return undefined
+  return {
+    downloadId: data.id,
+    filename: data.filename,
+    progress: data.progress,
+    ...(data.receivedBytes === undefined ? {} : { receivedBytes: data.receivedBytes }),
+    ...(data.totalBytes === undefined ? {} : { totalBytes: data.totalBytes }),
+    status: data.status,
+    ...(data.error === undefined ? {} : { error: data.error })
+  }
+}
+
+function isTerminalTemplateInputDownload(download: ComfyTemplateInputAssetDownload): boolean {
+  return ['completed', 'error', 'cancelled'].includes(download.status)
+}
+
+function rememberTerminalTemplateInputDownload(download: ComfyTemplateInputAssetDownload): void {
+  terminalTemplateInputDownloadsById.delete(download.downloadId)
+  terminalTemplateInputDownloadsById.set(download.downloadId, download)
+  if (terminalTemplateInputDownloadsById.size <= MAX_BUFFERED_TERMINAL_DOWNLOADS) return
+  const oldestDownloadId = terminalTemplateInputDownloadsById.keys().next().value
+  if (oldestDownloadId) terminalTemplateInputDownloadsById.delete(oldestDownloadId)
 }
 
 function removeTemplateInputProgressHandler(): void {
@@ -134,21 +163,13 @@ function maybeRemoveTemplateInputProgressHandler(): void {
 function ensureTemplateInputProgressHandler(): void {
   if (templateInputProgressHandler) return
   templateInputProgressHandler = (_event, data) => {
-    if (!data.id) return
-    const references = templateInputsByDownloadId.get(data.id)
+    const download = toTemplateInputAssetDownload(data)
+    if (!download) return
+    const isTerminal = isTerminalTemplateInputDownload(download)
+    if (isTerminal) rememberTerminalTemplateInputDownload(download)
+    const references = templateInputsByDownloadId.get(download.downloadId)
     if (!references) return
-    const download: ComfyTemplateInputAssetDownload = {
-      downloadId: data.id,
-      filename: data.filename,
-      progress: data.progress,
-      ...(data.receivedBytes === undefined ? {} : { receivedBytes: data.receivedBytes }),
-      ...(data.totalBytes === undefined ? {} : { totalBytes: data.totalBytes }),
-      status: data.status,
-      ...(data.error === undefined ? {} : { error: data.error })
-    }
-    if (['completed', 'error', 'cancelled'].includes(data.status)) {
-      templateInputsByDownloadId.delete(data.id)
-    }
+    if (isTerminal) templateInputsByDownloadId.delete(download.downloadId)
     emitTemplateInputProgress(download, [...references.values()])
     maybeRemoveTemplateInputProgressHandler()
   }
@@ -167,7 +188,14 @@ function trackTemplateInputDownload(
   }
   references.set(templateInputReferenceKey(reference), reference)
   ensureTemplateInputProgressHandler()
-  if (emitSnapshot) emitTemplateInputProgress(download, [...references.values()])
+  const terminalDownload = terminalTemplateInputDownloadsById.get(download.downloadId)
+  if (terminalDownload) {
+    templateInputsByDownloadId.delete(download.downloadId)
+    emitTemplateInputProgress(terminalDownload, [...references.values()])
+    maybeRemoveTemplateInputProgressHandler()
+  } else if (emitSnapshot) {
+    emitTemplateInputProgress(download, [...references.values()])
+  }
 }
 
 const getTemplateInputAssets: NonNullable<
@@ -190,14 +218,19 @@ const getTemplateInputAssets: NonNullable<
 const downloadTemplateInputAsset: NonNullable<
   ComfyDesktop2BridgeImplementation['downloadTemplateInputAsset']
 > = async (templateId, assetId): Promise<ComfyTemplateInputAssetDownloadResult> => {
-  const result = await ipcRenderer.invoke('desktop2-download-template-input-asset', {
-    templateId,
-    assetId
-  })
-  if (result.status === 'accepted' || result.status === 'joined') {
-    trackTemplateInputDownload({ templateId, assetId }, result.download, true)
+  ensureTemplateInputProgressHandler()
+  try {
+    const result = await ipcRenderer.invoke('desktop2-download-template-input-asset', {
+      templateId,
+      assetId
+    })
+    if (result.status === 'accepted' || result.status === 'joined') {
+      trackTemplateInputDownload({ templateId, assetId }, result.download, true)
+    }
+    return result
+  } finally {
+    maybeRemoveTemplateInputProgressHandler()
   }
-  return result
 }
 
 const onTemplateInputDownloadProgress: NonNullable<
@@ -214,6 +247,7 @@ const onTemplateInputDownloadProgress: NonNullable<
       // A future detail view reconstructs active ownership from its metadata
       // snapshot. Do not retain identities for a renderer with no consumers.
       templateInputsByDownloadId.clear()
+      terminalTemplateInputDownloadsById.clear()
     }
     maybeRemoveTemplateInputProgressHandler()
   }

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -124,7 +124,8 @@ export interface ComfyDesktop2Bridge {
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
   downloadAsset?: (url: string, filename: string, authToken?: string) => Promise<boolean>
   /** Resolve only assets declared by this template. `null` means Desktop cannot
-   *  authorize the current renderer/installation; `[]` means none are declared. */
+   *  authorize the caller or resolve the metadata; `[]` means the resolved
+   *  template declares none. */
   getTemplateInputAssets?: (templateId: string) => Promise<ComfyTemplateInputAsset[] | null>
   /** Start or join the managed download for one declared template asset. */
   downloadTemplateInputAsset?: (

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -16,6 +16,50 @@ export interface ComfyDownloadProgress {
   isImage?: boolean
 }
 
+export interface ComfyTemplateInputReference {
+  templateId: string
+  assetId: string
+}
+
+export interface ComfyTemplateInputAssetDownload {
+  downloadId: string
+  filename: string
+  progress: number
+  receivedBytes?: number
+  totalBytes?: number
+  status: ComfyDownloadProgress['status']
+  error?: string
+}
+
+export interface ComfyTemplateInputDownloadProgress extends ComfyTemplateInputAssetDownload {
+  /** Every template asset currently sharing this managed download job. */
+  templateInputs: ComfyTemplateInputReference[]
+}
+
+export interface ComfyTemplateInputAsset {
+  /** Opaque, template-scoped identifier accepted by `downloadTemplateInputAsset`. */
+  assetId: string
+  filename: string
+  mediaType: 'image' | 'video' | 'audio'
+  /** Desktop-resolved public URL for previewing this declared template asset. */
+  previewUrl: string
+  availability: 'present' | 'missing' | 'unknown'
+  /** Present when this exact asset destination already has a managed job. */
+  activeDownload?: ComfyTemplateInputAssetDownload
+}
+
+export type ComfyTemplateInputAssetDownloadResult =
+  | { status: 'already-present' }
+  | {
+      status: 'accepted' | 'joined'
+      /** Admission snapshot seeds UI state even if the first IPC event raced ahead. */
+      download: ComfyTemplateInputAssetDownload
+    }
+  | {
+      status: 'not-started'
+      reason: 'invalid-request' | 'not-declared' | 'unavailable'
+    }
+
 export interface TerminalRestore {
   buffer: string[]
   size: { cols: number; rows: number }
@@ -79,6 +123,18 @@ export interface ComfyDesktop2Bridge {
   openModelAccessPage?: (url: string) => Promise<boolean>
   downloadModel?: (url: string, filename: string, directory: string) => Promise<boolean>
   downloadAsset?: (url: string, filename: string, authToken?: string) => Promise<boolean>
+  /** Resolve only assets declared by this template. `null` means Desktop cannot
+   *  authorize the current renderer/installation; `[]` means none are declared. */
+  getTemplateInputAssets?: (templateId: string) => Promise<ComfyTemplateInputAsset[] | null>
+  /** Start or join the managed download for one declared template asset. */
+  downloadTemplateInputAsset?: (
+    templateId: string,
+    assetId: string
+  ) => Promise<ComfyTemplateInputAssetDownloadResult>
+  /** Download events decorated with the template asset identities that own the job. */
+  onTemplateInputDownloadProgress?: (
+    callback: (data: ComfyTemplateInputDownloadProgress) => void
+  ) => () => void
   pauseDownload?: (url: string) => Promise<boolean>
   resumeDownload?: (url: string) => Promise<boolean>
   cancelDownload?: (url: string) => Promise<boolean>


### PR DESCRIPTION
## Summary

Adds the trusted Desktop producer for template-declared input assets and exposes stable availability, admission, and progress contracts to the frontend.

## Changes

- **What**: Resolves trusted template input declarations, admits only opaque template/asset IDs, and owns the exact input destination.
- **What**: Extends managed downloads with destination-keyed identity, retry, active snapshots, no-overwrite finalization, and shared-consumer progress correlation.
- **What**: Adds local-installation-only IPC/preload APIs and regenerates the owned bridge contract.
- **Breaking**: None.
- **Dependencies**: Ready for review, but merge/release ordering remains blocked on [#1416](https://github.com/Comfy-Org/Comfy-Desktop/pull/1416). Publish the bridge types before merging the frontend consumer [#15902](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15902).

## Review Focus

- Renderer-controlled URLs and destination paths never cross the IPC boundary.
- Exact-destination identity remains correct across concurrent consumers, retries, and finalization races.
- Progress survives consumer close/reopen and shared-job cases.

## Integration Screenshot

<img width="1295" height="768" alt="Asset-only App after declared inputs resolve" src="https://github.com/user-attachments/assets/6b735e1e-9f79-4406-bab4-93bc25b21947" />

_Frontend #15902 consuming this Desktop producer: declared inputs are downloaded and rebound in App mode, with no stale missing-media error._

## Validation

- Node 25.9.0: 4 focused files / 156 tests.
- Full repository Vitest: 256 files / 4,372 passed / 2 skipped.
- Full typecheck, ESLint, Prettier, and bridge-types generation sync passed.
- End-to-end manual verification with frontend #15902: an asset-only App downloaded and rendered its input with visible progress and no stale missing-media error.

## Local verification

```bash
# Desktop
cd /absolute/path/to/Comfy-Desktop
gh pr checkout 1435
nvm install 25.9.0
nvm use 25.9.0
corepack enable
pnpm install --frozen-lockfile

pnpm exec vitest run \
  src/main/lib/comfyDownloadManager.test.ts \
  src/main/lib/ipc/registerTemplateInputAssetHandlers.test.ts \
  src/main/sources/standalone/templateInputAssets.test.ts \
  src/preload/comfyPreload.test.ts
pnpm run typecheck
pnpm run lint
pnpm run format:check
pnpm run bridge-types:check
pnpm dev
```

For the real integration, build [frontend #15902](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15902) with `DISTRIBUTION=desktop pnpm build`, point the local installation's `--front-end-root` startup argument at that absolute `dist` path, and restart it. Verify asset-only direct-open download/progress/completion, missing-model Starter Pack handoff, already-present input skip, and no activation for remote installations.

Linear: [FE-1491](https://linear.app/comfyorg/issue/FE-1491) · [Review spec](https://app.notion.com/p/3c76d73d365081c9bffde74a29e5b6c4)
