### PR TITLE
test(templates): pin the starter list inside the mirrorable R2 namespace

### DIFF
--- a/src/main/sources/standalone/remoteStarterTemplates.test.ts
+++ b/src/main/sources/standalone/remoteStarterTemplates.test.ts
@@ -10,6 +10,7 @@ import {
   _resetStarterTemplatesForTest
 } from './remoteStarterTemplates'
 import { CURATED_TEMPLATES, TEMPLATE_MODALITY_ORDER } from './curatedTemplates'
+import { R2_MIRROR_BASE_URL, r2MirrorUrl } from '../../lib/r2Mirror'
 import { fetchJSON } from '../../lib/fetch'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
@@ -439,6 +440,25 @@ describe('G. an oversized or hostile document cannot cost more than it should', 
       parsed?.map((t) => t.id),
       'the sentinel drops while its valid neighbour survives'
     ).toEqual(['ok'])
+  })
+})
+
+describe('H. restricted regions reach the document through the mirror', () => {
+  it('keeps the document inside the mirrorable R2 namespace', () => {
+    expect(
+      r2MirrorUrl(STARTER_TEMPLATES_URL),
+      'a URL outside the R2 prefix gets no mirror, silently cutting off regions where R2 is throttled'
+    ).toBe(`${R2_MIRROR_BASE_URL}/starter-templates.json`)
+  })
+
+  it('degrades to the built-in list when both the primary and the mirror are unreachable', async () => {
+    _resetStarterTemplatesForTest()
+    mockedFetchJSON.mockRejectedValue(new Error('ECONNRESET'))
+    const loaded = await loadStarterTemplates()
+    expect(
+      loaded.map((t) => t.id).sort(),
+      'a blocked region still gets a full picker, never an empty one'
+    ).toEqual([...CURATED_TEMPLATES].map((t) => t.id).sort())
   })
 })
 


### PR DESCRIPTION
**TL;DR:** Tests only. Pins that the starter-templates document stays inside the R2 namespace, which is what lets restricted regions reach it through the GCS mirror.

**Why:** `fetchJSON` already retries the mirror on failure, so the starter list got that behaviour for free when it moved to R2. But it only works while the URL sits under `R2_BASE_URL` — `r2MirrorUrl` returns undefined for anything else. That property lives in a string prefix, so a plausible refactor (own bucket, CDN alias) would cut those regions off with no failing test and no error.

**What changed:** two tests. One asserts the derived mirror URL, one asserts a rejected fetch still yields all sixteen built-in cards. No source file touched.

**Separate ops gap:** the file isn't on the mirror yet.

| File | Primary | Mirror |
|---|---|---|
| `latest.json` | 200 | 200 |
| `torch-index-stacks.json` | 200 | 200 |
| `starter-templates.json` | 200 | **404** |

Nothing is broken — those users fall back to the built-in list. But content changes stay invisible to them until it's synced. Needs `Content-Type: application/json`, or the client won't parse it and falls back the same silent way. Raised with @deepme987 .

**Testing:** mutation-checked — pointing `STARTER_TEMPLATES_URL` at a non-R2 host fails the namespace test, which is the refactor this exists to catch.
