### PR TITLE
feat(templates): resolve the picker against the ComfyUI version being installed

### DIFF
--- a/e2e/support/devHooks.ts
+++ b/e2e/support/devHooks.ts
@@ -47,126 +47,166 @@ export interface PopupBoundsResult {
 
 export async function seedDownloads(
   app: ElectronApplication,
-  snapshot: DownloadsTrayStateLike,
+  snapshot: DownloadsTrayStateLike
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, s) => {
-    const helpers = (globalThis as unknown as { __e2e?: { seedDownloads: (s: unknown) => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.seedDownloads(s)
-  }, snapshot))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, s) => {
+      const helpers = (globalThis as unknown as { __e2e?: { seedDownloads: (s: unknown) => void } })
+        .__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.seedDownloads(s)
+    }, snapshot)
+  )
 }
 
 /** Live downloads tray snapshot from main (`active` in-flight + `recent`
  *  terminal entries) - the read counterpart to `seedDownloads`. */
 export async function getLiveDownloadsTrayState(
-  app: ElectronApplication,
+  app: ElectronApplication
 ): Promise<DownloadsTrayStateLike> {
-  return evalWithRetry(() => app.evaluate((_electron) => {
-    const helpers = (globalThis as unknown as { __e2e?: { getDownloadsTrayState: () => unknown } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getDownloadsTrayState() as { active: unknown[]; recent: unknown[] }
-  })) as Promise<DownloadsTrayStateLike>
+  return evalWithRetry(() =>
+    app.evaluate((_electron) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { getDownloadsTrayState: () => unknown } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.getDownloadsTrayState() as { active: unknown[]; recent: unknown[] }
+    })
+  ) as Promise<DownloadsTrayStateLike>
 }
 
 export async function setInstallUpdate(
   app: ElectronApplication,
-  opts: { installationId?: string; available: boolean; version?: string },
+  opts: { installationId?: string; available: boolean; version?: string }
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, o) => {
-    const helpers = (globalThis as unknown as { __e2e?: { setInstallUpdate: (o: unknown) => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.setInstallUpdate(o)
-  }, opts))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, o) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { setInstallUpdate: (o: unknown) => void } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.setInstallUpdate(o)
+    }, opts)
+  )
 }
 
 export async function setAppUpdateState(
   app: ElectronApplication,
-  state: AppUpdateStateLike,
+  state: AppUpdateStateLike
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, s) => {
-    const helpers = (globalThis as unknown as { __e2e?: { setAppUpdateState: (s: unknown) => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.setAppUpdateState(s)
-  }, state))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, s) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { setAppUpdateState: (s: unknown) => void } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.setAppUpdateState(s)
+    }, state)
+  )
 }
 
 export async function getTitlePopupBounds(
-  app: ElectronApplication,
+  app: ElectronApplication
 ): Promise<PopupBoundsResult | null> {
-  return await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as { __e2e?: { getTitlePopupBounds: () => unknown } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getTitlePopupBounds() as PopupBoundsResult | null
-  }))
+  return await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (globalThis as unknown as { __e2e?: { getTitlePopupBounds: () => unknown } })
+        .__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.getTitlePopupBounds() as PopupBoundsResult | null
+    })
+  )
 }
 
 export async function returnFirstInstallHostToDashboard(
-  app: ElectronApplication,
+  app: ElectronApplication
 ): Promise<number | null> {
-  return await evalWithRetry(() => app.evaluate(async () => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { returnFirstInstallHostToDashboard: () => Promise<number | null> }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.returnFirstInstallHostToDashboard()
-  }))
+  return await evalWithRetry(() =>
+    app.evaluate(async () => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { returnFirstInstallHostToDashboard: () => Promise<number | null> }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.returnFirstInstallHostToDashboard()
+    })
+  )
 }
 
 /** Recorded args for an instrumented IPC channel since the last reset. */
 export async function getIpcInvocations(
   app: ElectronApplication,
-  channel: string,
+  channel: string
 ): Promise<unknown[]> {
-  return await evalWithRetry(() => app.evaluate((_electron, c) => {
-    const helpers = (globalThis as unknown as { __e2e?: { getIpcInvocations: (c: string) => unknown[] } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getIpcInvocations(c)
-  }, channel))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, c) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { getIpcInvocations: (c: string) => unknown[] } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.getIpcInvocations(c)
+    }, channel)
+  )
 }
 
 export async function resetIpcInvocations(
   app: ElectronApplication,
-  channel?: string,
+  channel?: string
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, c) => {
-    const helpers = (globalThis as unknown as { __e2e?: { resetIpcInvocations: (c?: string) => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.resetIpcInvocations(c)
-  }, channel))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, c) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { resetIpcInvocations: (c?: string) => void } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.resetIpcInvocations(c)
+    }, channel)
+  )
 }
 
 /** URLs captured by the launcher's `shell.openExternal` wrapper in E2E mode. */
-export async function getShellOpenExternalCalls(
-  app: ElectronApplication,
-): Promise<string[]> {
-  return await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as { __e2e?: { getShellOpenExternalCalls: () => string[] } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getShellOpenExternalCalls()
-  }))
+export async function getShellOpenExternalCalls(app: ElectronApplication): Promise<string[]> {
+  return await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { getShellOpenExternalCalls: () => string[] } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.getShellOpenExternalCalls()
+    })
+  )
 }
 
 export async function resetShellOpenExternalCalls(app: ElectronApplication): Promise<void> {
-  await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as { __e2e?: { resetShellOpenExternalCalls: () => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.resetShellOpenExternalCalls()
-  }))
+  await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { resetShellOpenExternalCalls: () => void } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.resetShellOpenExternalCalls()
+    })
+  )
 }
 
 /** Register a synthetic running session so the REQUIRES_STOPPED guard and
  *  `sessionStore.isRunning` fire without spawning a real ComfyUI process. */
 export async function seedRunningSession(
   app: ElectronApplication,
-  opts: { installationId: string; installationName: string },
+  opts: { installationId: string; installationName: string }
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, o) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { seedRunningSession: (o: unknown) => void }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.seedRunningSession(o)
-  }, opts))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, o) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { seedRunningSession: (o: unknown) => void }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.seedRunningSession(o)
+    }, opts)
+  )
 }
 
 /** Mount the install-backed panelView eagerly. Production lazily mounts it
@@ -174,37 +214,48 @@ export async function seedRunningSession(
  *  reachable right after launch call this to skip the lazy step. */
 export async function ensureInstallPanelView(
   app: ElectronApplication,
-  installationId: string,
+  installationId: string
 ): Promise<boolean> {
-  return await evalWithRetry(() => app.evaluate((_electron, id) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { ensureInstallPanelView: (id: string) => boolean }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.ensureInstallPanelView(id)
-  }, installationId))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, id) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { ensureInstallPanelView: (id: string) => boolean }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.ensureInstallPanelView(id)
+    }, installationId)
+  )
 }
 
 /** Force every release-cache entry's `checkedAt` to `maxCheckedAt` (ms) to
  *  drive the stale-data auto-refresh watcher without waiting wall-clock. */
 export async function ageReleaseCache(
   app: ElectronApplication,
-  maxCheckedAt: number,
+  maxCheckedAt: number
 ): Promise<void> {
-  await evalWithRetry(() => app.evaluate((_electron, ts) => {
-    const helpers = (globalThis as unknown as { __e2e?: { ageReleaseCache: (ts: number) => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.ageReleaseCache(ts)
-  }, maxCheckedAt))
+  await evalWithRetry(() =>
+    app.evaluate((_electron, ts) => {
+      const helpers = (
+        globalThis as unknown as { __e2e?: { ageReleaseCache: (ts: number) => void } }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.ageReleaseCache(ts)
+    }, maxCheckedAt)
+  )
 }
 
 /** Drop every synthetic session seeded via `seedRunningSession`. */
 export async function clearRunningSessions(app: ElectronApplication): Promise<void> {
-  await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as { __e2e?: { clearRunningSessions: () => void } }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.clearRunningSessions()
-  }))
+  await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (globalThis as unknown as { __e2e?: { clearRunningSessions: () => void } })
+        .__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.clearRunningSessions()
+    })
+  )
 }
 
 export interface RunningSessionSnapshotLike {
@@ -218,15 +269,19 @@ export interface RunningSessionSnapshotLike {
  *  or synthetic). Returns `null` when no session is registered. */
 export async function getRunningSessionSnapshot(
   app: ElectronApplication,
-  installationId: string,
+  installationId: string
 ): Promise<RunningSessionSnapshotLike | null> {
-  return await evalWithRetry(() => app.evaluate((_electron, id) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { getRunningSessionSnapshot: (id: string) => unknown }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getRunningSessionSnapshot(id) as RunningSessionSnapshotLike | null
-  }, installationId))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, id) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { getRunningSessionSnapshot: (id: string) => unknown }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.getRunningSessionSnapshot(id) as RunningSessionSnapshotLike | null
+    }, installationId)
+  )
 }
 
 /** Whether main still holds the per-install background-operation slot
@@ -234,30 +289,38 @@ export async function getRunningSessionSnapshot(
  *  triggering a new picker op, since main rejects overlapping ops. */
 export async function hasActiveOperation(
   app: ElectronApplication,
-  installationId: string,
+  installationId: string
 ): Promise<boolean> {
-  return await evalWithRetry(() => app.evaluate((_electron, id) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { hasActiveOperation: (id: string) => boolean }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.hasActiveOperation(id)
-  }, installationId))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, id) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { hasActiveOperation: (id: string) => boolean }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.hasActiveOperation(id)
+    }, installationId)
+  )
 }
 
 /** Whether main currently holds the launching marker for `installationId`,
  *  i.e. the install is inside the boot window (spawned, not yet port-ready). */
 export async function isInstallLaunching(
   app: ElectronApplication,
-  installationId: string,
+  installationId: string
 ): Promise<boolean> {
-  return await evalWithRetry(() => app.evaluate((_electron, id) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { isLaunching: (id: string) => boolean }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.isLaunching(id)
-  }, installationId))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, id) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { isLaunching: (id: string) => boolean }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.isLaunching(id)
+    }, installationId)
+  )
 }
 
 /** Whether main has a launch handler in flight for `installationId` -
@@ -265,15 +328,19 @@ export async function isInstallLaunching(
  *  `isInstallLaunching` (spawn -> port-ready) cannot see. */
 export async function hasActiveLaunch(
   app: ElectronApplication,
-  installationId: string,
+  installationId: string
 ): Promise<boolean> {
-  return await evalWithRetry(() => app.evaluate((_electron, id) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { hasActiveLaunch: (id: string) => boolean }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.hasActiveLaunch(id)
-  }, installationId))
+  return await evalWithRetry(() =>
+    app.evaluate((_electron, id) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { hasActiveLaunch: (id: string) => boolean }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.hasActiveLaunch(id)
+    }, installationId)
+  )
 }
 
 /** Arm the one-shot launch-spawn hold: the NEXT launch parks right before
@@ -281,35 +348,47 @@ export async function hasActiveLaunch(
  *  until released or aborted. Pair with `releaseLaunchSpawnHold` in a
  *  finally so a failed test can't leave a launch parked forever. */
 export async function armLaunchSpawnHold(app: ElectronApplication): Promise<void> {
-  await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { armLaunchSpawnHold: () => void }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.armLaunchSpawnHold()
-  }))
+  await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { armLaunchSpawnHold: () => void }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.armLaunchSpawnHold()
+    })
+  )
 }
 
 /** Release a held launch (and disarm a not-yet-consumed hold). Idempotent. */
 export async function releaseLaunchSpawnHold(app: ElectronApplication): Promise<void> {
-  await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { releaseLaunchSpawnHold: () => void }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    helpers.releaseLaunchSpawnHold()
-  }))
+  await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { releaseLaunchSpawnHold: () => void }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      helpers.releaseLaunchSpawnHold()
+    })
+  )
 }
 
 /** Whether a launch is currently parked at the spawn hold. */
 export async function isLaunchSpawnHeld(app: ElectronApplication): Promise<boolean> {
-  return await evalWithRetry(() => app.evaluate(() => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { isLaunchSpawnHeld: () => boolean }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.isLaunchSpawnHeld()
-  }))
+  return await evalWithRetry(() =>
+    app.evaluate(() => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: { isLaunchSpawnHeld: () => boolean }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return helpers.isLaunchSpawnHeld()
+    })
+  )
 }
 
 /** Read the `checkedAt` ms timestamp of the shared release-cache entry
@@ -317,13 +396,52 @@ export async function isLaunchSpawnHeld(app: ElectronApplication): Promise<boole
 export async function getReleaseCacheCheckedAt(
   app: ElectronApplication,
   repo: string,
-  channel: string,
+  channel: string
 ): Promise<number | null> {
-  return await evalWithRetry(() => app.evaluate((_electron, args) => {
-    const helpers = (globalThis as unknown as {
-      __e2e?: { getReleaseCacheCheckedAt: (r: string, c: string) => number | null }
-    }).__e2e
-    if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
-    return helpers.getReleaseCacheCheckedAt(args.repo, args.channel)
-  }, { repo, channel }))
+  return await evalWithRetry(() =>
+    app.evaluate(
+      (_electron, args) => {
+        const helpers = (
+          globalThis as unknown as {
+            __e2e?: { getReleaseCacheCheckedAt: (r: string, c: string) => number | null }
+          }
+        ).__e2e
+        if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+        return helpers.getReleaseCacheCheckedAt(args.repo, args.channel)
+      },
+      { repo, channel }
+    )
+  )
+}
+
+export interface StarterTemplateCardLike {
+  id: string
+  modality: string
+  recommended: boolean
+  apiNode: boolean
+  thumbnailUrl: string | null
+}
+
+/**
+ * Starter-template cards the picker would render for `comfyVersion`, resolved
+ * through the real network path in the main process. Pass `null` for the
+ * 'latest' channel.
+ */
+export async function resolveStarterTemplateCards(
+  app: ElectronApplication,
+  comfyVersion: string | null
+): Promise<StarterTemplateCardLike[]> {
+  return (await evalWithRetry(() =>
+    app.evaluate(async (_electron, version) => {
+      const helpers = (
+        globalThis as unknown as {
+          __e2e?: {
+            resolveStarterTemplateCards: (v: string | null) => Promise<StarterTemplateCardLike[]>
+          }
+        }
+      ).__e2e
+      if (!helpers) throw new Error('E2E helpers not registered (process.env.E2E !== "1"?)')
+      return await helpers.resolveStarterTemplateCards(version)
+    }, comfyVersion)
+  )) as StarterTemplateCardLike[]
 }

--- a/e2e/template-version-pin.test.ts
+++ b/e2e/template-version-pin.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Proves the starter-template picker resolves against the ComfyUI version the
+ * install will actually run, using the real network path.
+ *
+ * The unit tests mock `fetchJSON`, so they can only assert which URL we ask
+ * for. This runs inside Electron, where `net.request` works, and hits the real
+ * `requirements.txt` and template indexes. That makes it the only place the
+ * whole chain is exercised: read the pin a ComfyUI release ships, fetch that
+ * revision's index, and drop or substitute a card that release cannot open.
+ *
+ * Anchored on `video_minimax_h3_t2v`, which is present in the index v0.30.2
+ * pins and absent from the one v0.28.2 pins. That is the shipping bug: on an
+ * older install the card renders and then cannot be opened.
+ *
+ * Network-dependent by design. Skipped when offline rather than failed, since
+ * a red CI run here would say nothing about the code.
+ */
+
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './launchApp'
+import { resolveStarterTemplateCards, type StarterTemplateCardLike } from './support/devHooks'
+
+/** In the index v0.30.2 pins, absent from the one v0.28.2 pins. */
+const NEWER_ONLY_TEMPLATE = 'video_minimax_h3_t2v'
+const OLDER_COMFY = 'v0.28.2'
+const NEWER_COMFY = 'v0.30.2'
+
+let ctx: AppContext
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  ctx = await launchApp({ settings: { firstUseCompleted: true, telemetryEnabled: false } })
+})
+
+test.afterAll(async () => {
+  await ctx.cleanup()
+})
+
+const video = (cards: StarterTemplateCardLike[]): StarterTemplateCardLike[] =>
+  cards.filter((c) => c.modality === 'video')
+
+test('the picker offers only templates the target ComfyUI can open @windows @macos @linux', async () => {
+  const older = await resolveStarterTemplateCards(ctx.app, OLDER_COMFY)
+  const newer = await resolveStarterTemplateCards(ctx.app, NEWER_COMFY)
+
+  // Offline, both resolutions fall back to the built-in list and the
+  // comparison below proves nothing. Skip rather than report a false failure.
+  test.skip(
+    older.length === 0 || newer.length === 0,
+    'needs network access to raw.githubusercontent.com'
+  )
+  const reachedPinnedIndex = newer.some((c) => c.id === NEWER_ONLY_TEMPLATE)
+  test.skip(!reachedPinnedIndex, 'template index unreachable, nothing to compare')
+
+  expect(
+    video(older).map((c) => c.id),
+    `${OLDER_COMFY} does not ship this template, so offering it renders a card that cannot open`
+  ).not.toContain(NEWER_ONLY_TEMPLATE)
+
+  expect(
+    video(newer).map((c) => c.id),
+    `${NEWER_COMFY} does ship it, so the pin must not over-filter`
+  ).toContain(NEWER_ONLY_TEMPLATE)
+})
+
+test('every tab stays full on an older ComfyUI @windows @macos @linux', async () => {
+  const cards = await resolveStarterTemplateCards(ctx.app, OLDER_COMFY)
+  test.skip(cards.length === 0, 'needs network access')
+
+  for (const modality of ['video', 'image', '3d', 'audio']) {
+    const tab = cards.filter((c) => c.modality === modality)
+    expect(tab, `${modality} tab`).toHaveLength(4)
+    expect(
+      tab.filter((c) => c.recommended),
+      `${modality} auto-pick`
+    ).toHaveLength(1)
+    expect(
+      tab.find((c) => c.recommended)?.apiNode,
+      `${modality} auto-pick must not spend credits`
+    ).toBe(false)
+  }
+  expect(new Set(cards.map((c) => c.id)).size, 'ids are the picker option key').toBe(cards.length)
+})
+
+test('previews come from the pinned revision, not main @windows @macos @linux', async () => {
+  const cards = await resolveStarterTemplateCards(ctx.app, OLDER_COMFY)
+  const withThumb = cards.find((c) => c.thumbnailUrl)
+  test.skip(!withThumb, 'needs network access')
+
+  // v0.28.2 pins comfyui-workflow-templates==0.11.12.
+  expect(
+    withThumb!.thumbnailUrl,
+    'a main-revision preview beside a pinned card is two revisions in one card'
+  ).toContain('/v0.11.12/')
+})
+
+test('the latest channel resolves against main @windows @macos @linux', async () => {
+  const cards = await resolveStarterTemplateCards(ctx.app, null)
+  const withThumb = cards.find((c) => c.thumbnailUrl)
+  test.skip(!withThumb, 'needs network access')
+
+  // Latest fast-forwards past the newest stable tag, so pinning it to that tag
+  // would hide templates the install does support.
+  expect(withThumb!.thumbnailUrl, 'latest must not wear an older tag').toContain('/main/')
+})

--- a/e2e/template-version-pin.test.ts
+++ b/e2e/template-version-pin.test.ts
@@ -20,6 +20,14 @@ import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import { resolveStarterTemplateCards, type StarterTemplateCardLike } from './support/devHooks'
 
+/** The picker option shape, as it crosses `window.api.getFieldOptions`. */
+interface PickerOption {
+  value: string
+  label: string
+  recommended?: boolean
+  data?: { apiNode?: boolean }
+}
+
 /** In the index v0.30.2 pins, absent from the one v0.28.2 pins. */
 const NEWER_ONLY_TEMPLATE = 'video_minimax_h3_t2v'
 const OLDER_COMFY = 'v0.28.2'
@@ -103,4 +111,55 @@ test('the latest channel resolves against main @windows @macos @linux', async ()
   // Latest fast-forwards past the newest stable tag, so pinning it to that tag
   // would hide templates the install does support.
   expect(withThumb!.thumbnailUrl, 'latest must not wear an older tag').toContain('/main/')
+})
+
+/**
+ * The tests above call the resolver directly. These go through the renderer's
+ * own IPC instead, the same call the install wizard makes, so the wiring
+ * between a picked release/version and the cards the picker renders is covered
+ * rather than assumed.
+ */
+async function pickerOptions(release: string, comfyVersion?: string): Promise<PickerOption[]> {
+  const selections: Record<string, unknown> = {
+    release: { value: release, label: release, data: { latestStableTag: NEWER_COMFY } }
+  }
+  if (comfyVersion) selections.comfyVersion = { value: comfyVersion, label: comfyVersion }
+  return await ctx.panel.evaluate<PickerOption[]>(
+    `window.api.getFieldOptions('standalone', 'bundledTemplate', ${JSON.stringify(selections)})`
+  )
+}
+
+test('the wizard renders version-correct cards through its own IPC @windows @macos @linux', async () => {
+  const older = await pickerOptions('stable', OLDER_COMFY)
+  const newer = await pickerOptions('stable', NEWER_COMFY)
+  test.skip(older.length === 0 || newer.length === 0, 'needs network access')
+
+  const ids = (options: PickerOption[]): string[] => options.map((o) => o.value)
+  test.skip(!ids(newer).includes(NEWER_ONLY_TEMPLATE), 'template index unreachable')
+
+  expect(
+    ids(older),
+    `picking ${OLDER_COMFY} must not surface a card that release cannot open`
+  ).not.toContain(NEWER_ONLY_TEMPLATE)
+  expect(ids(newer), `${NEWER_COMFY} ships it, so it must still be offered`).toContain(
+    NEWER_ONLY_TEMPLATE
+  )
+})
+
+test('the wizard always offers a skip plus four cards per tab @windows @macos @linux', async () => {
+  const options = await pickerOptions('stable', OLDER_COMFY)
+  test.skip(options.length === 0, 'needs network access')
+
+  // "None" leads the list, then four cards in each of four modalities.
+  expect(options[0]!.value, 'the skip option must come first').toBe('none')
+  expect(options.length, 'skip + 4 cards x 4 tabs').toBe(17)
+
+  const recommended = options.filter((o) => o.recommended)
+  expect(recommended, 'one auto-pick per tab').toHaveLength(4)
+  for (const option of recommended) {
+    expect(
+      option.data?.apiNode,
+      `${option.value} is auto-selected, so it must not spend credits`
+    ).toBeFalsy()
+  }
 })

--- a/src/main/lib/e2eHooks.ts
+++ b/src/main/lib/e2eHooks.ts
@@ -19,6 +19,10 @@ import { _test_getOpenTitlePopupBounds } from '../popups/titlePopup'
 import { stageModels, resolveModelManifest, installModelsRoot } from '../comfybuilder'
 import { getBuilderClient } from '../devplatform/session'
 import { returnToDashboard } from '../host/detach'
+import {
+  loadTemplateCatalog,
+  resetTemplateCatalogCache
+} from '../sources/standalone/templateCatalog'
 import { comfyWindows, getEntryByInstallationId, isInstallHost } from '../host/registry'
 import { ensurePanelView } from '../host/panelView'
 import {
@@ -58,6 +62,14 @@ interface SetInstallUpdateOpts {
   version?: string
 }
 
+export interface StarterTemplateCard {
+  id: string
+  modality: string
+  recommended: boolean
+  apiNode: boolean
+  thumbnailUrl: string | null
+}
+
 export interface E2EHelpers {
   /** Replace the downloads tray with a snapshot and broadcast `tray-state-changed`. */
   seedDownloads(snapshot: DownloadsTrayState): void
@@ -70,6 +82,10 @@ export interface E2EHelpers {
   /** "Return to Dashboard" on the first install-backed host window. Resolves to the
    *  BrowserWindow id flipped, or null if none exists. */
   returnFirstInstallHostToDashboard(): Promise<number | null>
+  /** Starter-template cards the picker would render for `comfyVersion`, resolved
+   *  through the real network path. `null` means the 'latest' channel, which
+   *  follows master HEAD and so resolves against the live index. */
+  resolveStarterTemplateCards(comfyVersion: string | null): Promise<StarterTemplateCard[]>
   /** Recorded invocations for an instrumented IPC channel; each entry is the handler's first arg. */
   getIpcInvocations(channel: string): unknown[]
   /** Clear recorded invocations for one channel, or all when called with no argument. */
@@ -136,6 +152,18 @@ export function registerE2EHooks(): void {
         return id
       }
       return null
+    },
+    async resolveStarterTemplateCards(comfyVersion) {
+      // Uncached, so consecutive versions in one test each resolve for real.
+      resetTemplateCatalogCache()
+      const cards = await loadTemplateCatalog({ comfyVersion })
+      return cards.map((c) => ({
+        id: c.id,
+        modality: c.modality,
+        recommended: c.recommended,
+        apiNode: c.apiNode,
+        thumbnailUrl: c.thumbnailUrl
+      }))
     },
     getIpcInvocations,
     resetIpcInvocations,

--- a/src/main/lib/fetch.ts
+++ b/src/main/lib/fetch.ts
@@ -75,13 +75,47 @@ function _headerString(value: string | string[] | undefined): string | undefined
 // entirely. Splitting these lets the mirror-retry below run WITHOUT leaking the
 // primary's ETag to the mirror (cached: undefined) and WITHOUT poisoning the
 // primary's persisted cache entry with mirror-tagged data (cacheKey: undefined).
+function parseJson(body: string, url: string): unknown {
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new Error(`Invalid JSON response from ${url}`)
+  }
+}
+
 function fetchJSONOnce(
   url: string,
   cached: CacheEntry | undefined,
-  cacheKey: string | undefined
+  cacheKey: string | undefined,
+  parse: (body: string, url: string) => unknown = parseJson,
+  timeoutMs?: number
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const request = net.request({ url, cache: 'no-cache' })
+    // `net.request` has no timeout of its own, so a stalled connection would
+    // hang every caller awaiting it. `settled` keeps a late timer from
+    // rejecting a request that already finished.
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const finish =
+      <T>(fn: (v: T) => void) =>
+      (value: T) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        fn(value)
+      }
+    const done = finish(resolve)
+    const fail = finish(reject)
+    if (timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        try {
+          request.abort()
+        } catch {}
+        fail(new Error(`Timed out after ${timeoutMs}ms fetching ${url}`))
+      }, timeoutMs)
+      timer.unref?.()
+    }
     request.setHeader('User-Agent', 'ComfyUI-Desktop-2')
 
     const ghToken = process.env.GITHUB_TOKEN
@@ -104,7 +138,7 @@ function fetchJSONOnce(
       response.on('data', (chunk) => (data += chunk.toString()))
       response.on('end', () => {
         if (response.statusCode === 304 && cached) {
-          resolve(structuredClone(cached.data))
+          done(structuredClone(cached.data))
           return
         }
         if (response.statusCode !== 200) {
@@ -125,14 +159,14 @@ function fetchJSONOnce(
               msg += ' (rate limited)'
             }
           }
-          reject(new Error(msg))
+          fail(new Error(msg))
           return
         }
         let parsed: unknown
         try {
-          parsed = JSON.parse(data)
-        } catch {
-          reject(new Error(`Invalid JSON response from ${url}`))
+          parsed = parse(data, url)
+        } catch (err) {
+          fail(err instanceof Error ? err : new Error(String(err)))
           return
         }
         if (cacheKey) {
@@ -141,10 +175,10 @@ function fetchJSONOnce(
             _cacheSet(cacheKey, { etag, data: parsed })
           }
         }
-        resolve(parsed)
+        done(parsed)
       })
     })
-    request.on('error', (err) => reject(err))
+    request.on('error', (err) => fail(err))
     request.end()
   })
 }
@@ -155,14 +189,39 @@ export function _resetCacheForTest(): void {
   _loaded = false
 }
 
-export async function fetchJSON(url: string, opts?: { refresh?: boolean }): Promise<unknown> {
+/**
+ * Plain-text sibling of `fetchJSON`, sharing its `net.request` stack, ETag
+ * cache, and R2-mirror retry. Used for manifests that are not JSON, such as
+ * ComfyUI's `requirements.txt`.
+ */
+export async function fetchText(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<string> {
+  const body = await fetchOne(url, opts, (text) => text)
+  if (typeof body !== 'string') throw new Error(`Expected a text body from ${url}`)
+  return body
+}
+
+export async function fetchJSON(
+  url: string,
+  opts?: { refresh?: boolean; timeoutMs?: number }
+): Promise<unknown> {
+  return fetchOne(url, opts, parseJson)
+}
+
+async function fetchOne(
+  url: string,
+  opts: { refresh?: boolean; timeoutMs?: number } | undefined,
+  parse: (body: string, url: string) => unknown
+): Promise<unknown> {
   _ensureLoaded()
   // `refresh` ignores the persisted ETag so the response is never served from cache. Used
   // for R2 manifests where a stale value would strand users on an old release.
   const cached = opts?.refresh ? undefined : _cache.get(url)
 
   try {
-    return await fetchJSONOnce(url, cached, url)
+    return await fetchJSONOnce(url, cached, url, parse, opts?.timeoutMs)
   } catch (primaryErr) {
     // If this is an R2 URL with a configured mirror, retry once against it
     // before falling back to the persisted cache. The retry deliberately
@@ -172,7 +231,7 @@ export async function fetchJSON(url: string, opts?: { refresh?: boolean }): Prom
     const mirror = r2MirrorUrl(url)
     if (mirror && mirror !== url) {
       try {
-        return await fetchJSONOnce(mirror, undefined, undefined)
+        return await fetchJSONOnce(mirror, undefined, undefined, parse, opts?.timeoutMs)
       } catch {
         // fall through to cache / primary error
       }

--- a/src/main/sources/standalone/curatedTemplates.ts
+++ b/src/main/sources/standalone/curatedTemplates.ts
@@ -65,10 +65,14 @@ const IMAGE_SUBTYPES = new Set(['webp', 'png', 'jpg', 'jpeg', 'gif', 'avif'])
  * subtype isn't an image (e.g. `mp3`), so the caller falls back to the glyph
  * without a doomed network request. Pure + exported for reuse and tests.
  */
-export function thumbnailUrlFor(id: string, mediaSubtype: string): string | null {
+export function thumbnailUrlFor(
+  id: string,
+  mediaSubtype: string,
+  assetBase: string = RAW_TEMPLATES_BASE
+): string | null {
   const ext = (mediaSubtype || 'webp').toLowerCase()
   if (!IMAGE_SUBTYPES.has(ext)) return null
-  return `${RAW_TEMPLATES_BASE}/${id}-1.${ext}`
+  return `${assetBase}/${id}-1.${ext}`
 }
 
 /**

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
 
 vi.mock('electron', () => ({
   app: { getPath: () => '' },
@@ -14,6 +15,15 @@ vi.mock('../../lib/fetch', () => ({
 vi.mock('../../lib/comfyui-releases', () => ({
   getLatestStableTag: vi.fn()
 }))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
 
 import { standalone, buildPinnedVariant } from './index'
 import { resetTemplateCatalogCache } from './templateCatalog'
@@ -236,7 +246,50 @@ describe('standalone.buildInstallation', () => {
 describe('standalone.getFieldOptions bundledTemplate', () => {
   beforeEach(() => {
     mockedFetchJSON.mockReset()
+    resolveTemplatePackageVersion.mockReset()
+    resolveTemplatePackageVersion.mockResolvedValue(null)
     resetTemplateCatalogCache()
+  })
+
+  const channel = (value: string, latestStableTag: string | null = 'v0.30.2'): FieldOption => ({
+    value,
+    label: value,
+    data: { latestStableTag } as unknown as Record<string, unknown>
+  })
+
+  it('pins the stable channel to the tag the install lands on', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!('bundledTemplate', { release: channel('stable') }, {})
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.30.2')
+  })
+
+  it('honours a specific stable tag pick over the channel head', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      { release: channel('stable'), comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' } },
+      {}
+    )
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+  })
+
+  it('leaves the latest channel on main, since it installs past the newest tag', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!('bundledTemplate', { release: channel('latest') }, {})
+    expect(
+      resolveTemplatePackageVersion,
+      'pinning master HEAD to a stable tag would hide templates it supports'
+    ).toHaveBeenCalledWith(null)
+  })
+
+  it('ignores a comfyVersion left over from a switch to latest', async () => {
+    mockedFetchJSON.mockResolvedValue([])
+    await standalone.getFieldOptions!(
+      'bundledTemplate',
+      { release: channel('latest'), comfyVersion: { value: 'v0.28.2', label: 'v0.28.2' } },
+      {}
+    )
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith(null)
   })
 
   it('leads with the skip sentinel, then one option per curated template', async () => {

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -555,7 +555,23 @@ export const standalone: SourcePlugin = {
       // "None" comes first as the skip option; the per-modality recommended
       // picks carry `recommended` on their own option so the wizard auto-selects
       // a real template (the lightest "wow"), not the skip.
-      const catalog = await loadTemplateCatalog()
+      // Resolve the picker against the ComfyUI the install will actually run,
+      // so a template that version cannot open is never offered. Only honour a
+      // comfyVersion pick on the stable channel: `getFieldOptions` returns []
+      // for 'latest', so a value left over from a channel toggle is stale.
+      const releaseData = selections.release?.data as
+        | { latestStableTag?: string | null }
+        | undefined
+      const isStableChannel = selections.release?.value === 'stable'
+      const pickedTag =
+        isStableChannel &&
+        typeof selections.comfyVersion?.value === 'string' &&
+        /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
+          ? selections.comfyVersion.value
+          : null
+      const targetComfyVersion =
+        pickedTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
+      const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null
       const installation = installId ? await installations.get(installId) : null

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -556,21 +556,26 @@ export const standalone: SourcePlugin = {
       // picks carry `recommended` on their own option so the wizard auto-selects
       // a real template (the lightest "wow"), not the skip.
       // Resolve the picker against the ComfyUI the install will actually run,
-      // so a template that version cannot open is never offered. Only honour a
-      // comfyVersion pick on the stable channel: `getFieldOptions` returns []
-      // for 'latest', so a value left over from a channel toggle is stale.
+      // so a template that version cannot open is never offered.
+      //
+      // Stable lands on a known tag, so pin to it. Latest fast-forwards to
+      // master HEAD, which is AHEAD of the newest stable tag: pinning it there
+      // would hide templates the install does support, so it resolves against
+      // `main` (comfyVersion null) instead.
       const releaseData = selections.release?.data as
         | { latestStableTag?: string | null }
         | undefined
       const isStableChannel = selections.release?.value === 'stable'
+      // `getFieldOptions` returns [] for 'latest', so a comfyVersion left over
+      // from a channel toggle is stale. Mirrors the guard in `buildInstallation`.
       const pickedTag =
-        isStableChannel &&
         typeof selections.comfyVersion?.value === 'string' &&
         /^v\d+\.\d+\.\d+$/.test(selections.comfyVersion.value)
           ? selections.comfyVersion.value
           : null
-      const targetComfyVersion =
-        pickedTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag())
+      const targetComfyVersion = isStableChannel
+        ? (pickedTag ?? releaseData?.latestStableTag ?? (await getLatestStableTag()))
+        : null
       const catalog = await loadTemplateCatalog({ comfyVersion: targetComfyVersion })
 
       const installId = typeof context.installationId === 'string' ? context.installationId : null

--- a/src/main/sources/standalone/templateCatalog.ts
+++ b/src/main/sources/standalone/templateCatalog.ts
@@ -13,7 +13,11 @@
 import { fetchJSON } from '../../lib/fetch'
 import { loadStarterTemplates, _resetStarterTemplatesForTest } from './remoteStarterTemplates'
 import {
-  INDEX_URL,
+  resolveTemplatePackageVersion,
+  templateAssetBaseFor,
+  templateIndexUrlFor
+} from './templatePin'
+import {
   TEMPLATE_MODALITY_ORDER,
   thumbnailUrlFor,
   type TemplateModality,
@@ -148,8 +152,9 @@ function hydrateOne(card: {
   apiNode: boolean
   location: IndexLocation | undefined
   snapshot?: TemplateSnapshot
+  assetBase: string
 }): HydratedTemplate {
-  const { id, modality, recommended, apiNode, location, snapshot } = card
+  const { id, modality, recommended, apiNode, location, snapshot, assetBase } = card
   const entry = location?.entry
 
   const title = typeof entry?.title === 'string' ? entry.title : (snapshot?.title ?? id)
@@ -174,7 +179,7 @@ function hydrateOne(card: {
     description,
     sizeBytes,
     apiNode,
-    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype),
+    thumbnailUrl: thumbnailUrlFor(id, mediaSubtype, assetBase),
     category: location?.category ?? ''
   }
 }
@@ -199,41 +204,58 @@ function byModalityOrder(a: HydratedTemplate, b: HydratedTemplate): number {
 /** Coalesces the wizard's field-options read and the thumbnail warm-up — which
  *  fire together at picker open — into one index fetch; a later open refetches. */
 const CATALOG_TTL_MS = 60_000
-let catalogInFlight: Promise<HydratedTemplate[]> | null = null
-let catalogCache: { at: number; value: HydratedTemplate[] } | null = null
+/** Keyed by target version, so toggling the release channel mid-wizard
+ *  re-resolves against that version's index instead of serving the last one. */
+const catalogInFlight = new Map<string, Promise<HydratedTemplate[]>>()
+const catalogCache = new Map<string, { at: number; value: HydratedTemplate[] }>()
 
-export function loadTemplateCatalog(): Promise<HydratedTemplate[]> {
-  if (catalogCache && Date.now() - catalogCache.at < CATALOG_TTL_MS) {
-    return Promise.resolve(catalogCache.value)
-  }
-  if (catalogInFlight) return catalogInFlight
-  catalogInFlight = loadTemplateCatalogUncached()
+export function loadTemplateCatalog(opts?: {
+  comfyVersion?: string | null
+}): Promise<HydratedTemplate[]> {
+  const key = opts?.comfyVersion ?? ''
+  const cached = catalogCache.get(key)
+  if (cached && Date.now() - cached.at < CATALOG_TTL_MS) return Promise.resolve(cached.value)
+
+  const existing = catalogInFlight.get(key)
+  if (existing) return existing
+
+  const promise = loadTemplateCatalogUncached(opts?.comfyVersion ?? null)
     .then((value) => {
-      catalogCache = { at: Date.now(), value }
+      catalogCache.set(key, { at: Date.now(), value })
       return value
     })
     .finally(() => {
-      catalogInFlight = null
+      catalogInFlight.delete(key)
     })
-  return catalogInFlight
+  catalogInFlight.set(key, promise)
+  return promise
 }
 
 /** Drops the memoized catalog so the next read refetches. Test-only. */
 export function resetTemplateCatalogCache(): void {
-  catalogInFlight = null
-  catalogCache = null
+  catalogInFlight.clear()
+  catalogCache.clear()
   // The starter list is memoized for the process, so leaving it would make a
   // reset only half-work and any fetch-count assertion order-dependent.
   _resetStarterTemplatesForTest()
 }
 
-async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
+async function loadTemplateCatalogUncached(
+  comfyVersion: string | null
+): Promise<HydratedTemplate[]> {
+  // Hydrate against the index the TARGET ComfyUI ships, not `main`: a template
+  // added after that release is absent there, so it is dropped or substituted
+  // rather than offered as a card the install cannot open.
+  const pin = await resolveTemplatePackageVersion(comfyVersion).catch(() => null)
+  // Previews must come from the same revision as the cards, not `main`.
+  const assetBase = templateAssetBaseFor(pin)
+
   // The card list comes from R2 so content can change it without a release;
   // `loadStarterTemplates` falls back to `CURATED_TEMPLATES` on any failure and
   // never rejects, so this stays a straight read.
   const [starterTemplates, index] = await Promise.all([
     loadStarterTemplates(),
-    fetchJSON(INDEX_URL).catch(() => null)
+    fetchJSON(templateIndexUrlFor(pin)).catch(() => null)
   ])
 
   const byId = index ? indexById(index) : new Map<string, IndexLocation>()
@@ -254,7 +276,15 @@ async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
     if (location || !online) {
       used.add(curated.id)
       catalog.push(
-        hydrateOne({ id: curated.id, modality, recommended, apiNode, location, snapshot })
+        hydrateOne({
+          id: curated.id,
+          modality,
+          recommended,
+          apiNode,
+          location,
+          snapshot,
+          assetBase
+        })
       )
       continue
     }
@@ -268,7 +298,14 @@ async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
     if (sub) {
       used.add(sub.entry.name)
       catalog.push(
-        hydrateOne({ id: sub.entry.name, modality, recommended, apiNode: false, location: sub })
+        hydrateOne({
+          id: sub.entry.name,
+          modality,
+          recommended,
+          apiNode: false,
+          location: sub,
+          assetBase
+        })
       )
     } else {
       used.add(curated.id)
@@ -279,7 +316,8 @@ async function loadTemplateCatalogUncached(): Promise<HydratedTemplate[]> {
           recommended,
           apiNode,
           location: undefined,
-          snapshot
+          snapshot,
+          assetBase
         })
       )
     }

--- a/src/main/sources/standalone/templatePin.test.ts
+++ b/src/main/sources/standalone/templatePin.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchText = vi.fn()
+vi.mock('../../lib/fetch', () => ({ fetchText: (...a: unknown[]) => fetchText(...a) }))
+
+import {
+  resolveTemplatePackageVersion,
+  templateIndexUrlFor,
+  parseTemplatePin,
+  _resetForTest
+} from './templatePin'
+import { INDEX_URL } from './curatedTemplates'
+
+function requirements(pin: string | null): string {
+  return [
+    'comfyui-frontend-package==1.47.12',
+    ...(pin ? [pin] : []),
+    'comfyui-embedded-docs==0.5.9',
+    'torch',
+    'numpy>=1.25.0'
+  ].join('\n')
+}
+
+beforeEach(() => {
+  _resetForTest()
+  fetchText.mockReset()
+})
+
+describe('parseTemplatePin', () => {
+  it('reads the hyphenated package name ComfyUI actually pins', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui-workflow-templates==0.11.31')),
+      'the pin uses the hyphenated package name'
+    ).toBe('0.11.31')
+  })
+
+  it('does not match the underscored form', () => {
+    expect(
+      parseTemplatePin(requirements('comfyui_workflow_templates==0.11.31')),
+      'the underscored form is the Python import path, never the pin'
+    ).toBeNull()
+  })
+
+  it('tolerates surrounding whitespace and comments', () => {
+    expect(parseTemplatePin('  comfyui-workflow-templates==0.11.31  # pinned\n')).toBe('0.11.31')
+  })
+
+  it.each([
+    ['absent', requirements(null)],
+    ['no version', requirements('comfyui-workflow-templates==')],
+    ['range not pin', requirements('comfyui-workflow-templates>=0.11.0')],
+    ['empty file', ''],
+    ['garbage', 'this is not a requirements file'],
+    ['non-numeric', requirements('comfyui-workflow-templates==abc')]
+  ])('%s yields null', (_label, contents) => {
+    expect(parseTemplatePin(contents)).toBeNull()
+  })
+})
+
+describe('resolveTemplatePackageVersion', () => {
+  it('resolves a tag through requirements.txt to the pinned version', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+    expect(fetchText).toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it('treats a bare version and a v-prefixed tag identically', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const prefixed = await resolveTemplatePackageVersion('v0.30.2')
+    _resetForTest()
+    fetchText.mockClear()
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    const bare = await resolveTemplatePackageVersion('0.30.2')
+    expect(bare).toBe(prefixed)
+    expect(fetchText, 'the bare tag is the one normalized to v0.30.2').toHaveBeenCalledWith(
+      expect.stringContaining('v0.30.2/requirements.txt'),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+  })
+
+  it.each([[null], [undefined], ['']])('returns null for an unresolvable tag: %s', async (tag) => {
+    expect(await resolveTemplatePackageVersion(tag as string | null)).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('rejects a tag that is not version-shaped without fetching', async () => {
+    expect(await resolveTemplatePackageVersion('../../etc/passwd')).toBeNull()
+    expect(await resolveTemplatePackageVersion('master')).toBeNull()
+    expect(fetchText).not.toHaveBeenCalled()
+  })
+
+  it('returns null when requirements.txt 404s', async () => {
+    fetchText.mockRejectedValue(new Error('HTTP 404'))
+    expect(await resolveTemplatePackageVersion('v9.99.99')).toBeNull()
+  })
+
+  it('returns null when the fetch rejects, without throwing', async () => {
+    fetchText.mockRejectedValue(new Error('offline'))
+    await expect(resolveTemplatePackageVersion('v0.30.2')).resolves.toBeNull()
+  })
+
+  it('caches a resolved tag — one network hit for repeat lookups', async () => {
+    fetchText.mockResolvedValue(requirements('comfyui-workflow-templates==0.11.31'))
+    await resolveTemplatePackageVersion('v0.30.2')
+    await resolveTemplatePackageVersion('v0.30.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a failure too, so a 404 is not refetched every picker open', async () => {
+    fetchText.mockRejectedValue(new Error('404'))
+    await resolveTemplatePackageVersion('v0.28.2')
+    await resolveTemplatePackageVersion('v0.28.2')
+    expect(fetchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps separate tags separate', async () => {
+    fetchText.mockImplementation((url: string) =>
+      Promise.resolve(
+        requirements(
+          url.includes('v0.28.2')
+            ? 'comfyui-workflow-templates==0.11.12'
+            : 'comfyui-workflow-templates==0.11.31'
+        )
+      )
+    )
+    expect(await resolveTemplatePackageVersion('v0.28.2')).toBe('0.11.12')
+    expect(await resolveTemplatePackageVersion('v0.30.2')).toBe('0.11.31')
+  })
+})
+
+describe('templateIndexUrlFor', () => {
+  it('builds the versioned index URL for a resolved pin', () => {
+    expect(templateIndexUrlFor('0.11.31')).toBe(
+      'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/v0.11.31/templates/index.json'
+    )
+  })
+
+  it('falls back to the live main index when the pin is unknown', () => {
+    expect(templateIndexUrlFor(null), 'fails open to today’s behaviour').toBe(INDEX_URL)
+  })
+
+  it('refuses a pin that is not version-shaped', () => {
+    expect(templateIndexUrlFor('../../evil')).toBe(INDEX_URL)
+    expect(templateIndexUrlFor('main')).toBe(INDEX_URL)
+  })
+})

--- a/src/main/sources/standalone/templatePin.ts
+++ b/src/main/sources/standalone/templatePin.ts
@@ -1,0 +1,86 @@
+/**
+ * Maps a ComfyUI version to the template index it ships. ComfyUI pins
+ * `comfyui-workflow-templates` in its `requirements.txt`, and that pin is the
+ * only compatibility map that exists — the index carries no version field.
+ *
+ * Every failure returns `null`, which falls back to the live `main` index.
+ */
+import { fetchText } from '../../lib/fetch'
+import { INDEX_URL, RAW_TEMPLATES_BASE } from './curatedTemplates'
+
+const MAX_PIN_CACHE_SIZE = 100
+const PIN_TIMEOUT_MS = 5000
+
+const VERSION_TAG_PATTERN = /^v?\d+(?:\.\d+)*$/
+/** Hyphenated; the underscored form is the Python import path, not the pin. */
+const PIN_PATTERN = /^\s*comfyui-workflow-templates\s*==\s*(\d+(?:\.\d+)*)\s*(?:#.*)?$/m
+
+const TEMPLATES_REPO = 'https://raw.githubusercontent.com/Comfy-Org/workflow_templates'
+const COMFYUI_REPO = 'https://raw.githubusercontent.com/comfyanonymous/ComfyUI'
+
+/** Failures cache as `null`, so a 404 isn't refetched on every picker open. */
+const pinCache = new Map<string, string | null>()
+const inflight = new Map<string, Promise<string | null>>()
+
+export function parseTemplatePin(contents: string): string | null {
+  return PIN_PATTERN.exec(contents)?.[1] ?? null
+}
+
+/** Both forms are persisted; see `version.ts:tagsEqual` for the strip-side. */
+function normalizeTag(tag: string): string {
+  return tag.startsWith('v') ? tag : `v${tag}`
+}
+
+/** `null` when the pin can't be determined. Never throws. */
+export async function resolveTemplatePackageVersion(
+  comfyTag: string | null | undefined
+): Promise<string | null> {
+  if (!comfyTag || !VERSION_TAG_PATTERN.test(comfyTag)) return null
+
+  const ref = normalizeTag(comfyTag)
+  const cached = pinCache.get(ref)
+  if (cached !== undefined) return cached
+  const existing = inflight.get(ref)
+  if (existing) return existing
+
+  const promise = (async () => {
+    const resolved = await fetchText(`${COMFYUI_REPO}/${ref}/requirements.txt`, {
+      timeoutMs: PIN_TIMEOUT_MS
+    })
+      .then(parseTemplatePin)
+      .catch(() => null)
+    remember(ref, resolved)
+    inflight.delete(ref)
+    return resolved
+  })()
+
+  inflight.set(ref, promise)
+  return promise
+}
+
+/** `VERSION_TAG_PATTERN` admits unbounded dot-groups, so cap the key space. */
+function remember(ref: string, resolved: string | null): void {
+  if (pinCache.size >= MAX_PIN_CACHE_SIZE) {
+    const oldest = pinCache.keys().next().value
+    if (oldest !== undefined) pinCache.delete(oldest)
+  }
+  pinCache.set(ref, resolved)
+}
+
+/** Falls back to `main` when the pin is unknown or malformed. */
+export function templateIndexUrlFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return INDEX_URL
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates/index.json`
+}
+
+/** Thumbnail base, so previews match the index they came from. */
+export function templateAssetBaseFor(packageVersion: string | null): string {
+  if (!packageVersion || !VERSION_TAG_PATTERN.test(packageVersion)) return RAW_TEMPLATES_BASE
+  return `${TEMPLATES_REPO}/${normalizeTag(packageVersion)}/templates`
+}
+
+/** @internal — exposed for tests. */
+export function _resetForTest(): void {
+  pinCache.clear()
+  inflight.clear()
+}

--- a/src/main/sources/standalone/templateVersionPin.test.ts
+++ b/src/main/sources/standalone/templateVersionPin.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as TemplatePinModule from './templatePin'
+
+vi.mock('../../lib/fetch', () => ({ fetchJSON: vi.fn(), fetchText: vi.fn() }))
+
+const resolveTemplatePackageVersion = vi.fn()
+vi.mock('./templatePin', async (importOriginal) => {
+  const actual = await importOriginal<typeof TemplatePinModule>()
+  return {
+    ...actual,
+    resolveTemplatePackageVersion: (...a: unknown[]) => resolveTemplatePackageVersion(...a)
+  }
+})
+
+import { loadTemplateCatalog, resetTemplateCatalogCache } from './templateCatalog'
+import { CURATED_TEMPLATES, INDEX_URL, TEMPLATE_MODALITY_ORDER } from './curatedTemplates'
+import { fetchJSON } from '../../lib/fetch'
+
+const mockedFetchJSON = vi.mocked(fetchJSON)
+
+/** A live index carrying every curated id, minus `omit`, plus `extra` spares. */
+function indexWithout(omit: string[], extra: string[] = []): unknown {
+  const byModality: Record<string, { name: string }[]> = {}
+  for (const t of CURATED_TEMPLATES) {
+    if (omit.includes(t.id)) continue
+    byModality[t.modality] ??= []
+    byModality[t.modality]!.push({ name: t.id })
+  }
+  for (const name of extra) {
+    byModality.image ??= []
+    byModality.image.push({ name })
+  }
+  return Object.entries(byModality).map(([type, templates]) => ({
+    type,
+    title: type,
+    templates: templates.map((t) => ({ ...t, size: 1000, mediaSubtype: 'webp' }))
+  }))
+}
+
+beforeEach(() => {
+  mockedFetchJSON.mockReset()
+  resolveTemplatePackageVersion.mockReset()
+  resolveTemplatePackageVersion.mockResolvedValue(null)
+  resetTemplateCatalogCache()
+})
+
+describe('the picker resolves against the version the install will run', () => {
+  it('fetches the index the pinned package ships, not main', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledWith('v0.28.2')
+    expect(
+      mockedFetchJSON.mock.calls.some(([url]) => String(url).includes('v0.11.12')),
+      'hydrating against main would offer templates the install cannot open'
+    ).toBe(true)
+  })
+
+  it('falls back to the main index when the pin cannot be resolved', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue(null)
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    await loadTemplateCatalog({ comfyVersion: null })
+    expect(mockedFetchJSON).toHaveBeenCalledWith(INDEX_URL)
+  })
+
+  it('survives a pin lookup that throws', async () => {
+    resolveTemplatePackageVersion.mockRejectedValue(new Error('offline'))
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(catalog.length).toBe(CURATED_TEMPLATES.length)
+  })
+
+  it('replaces a template the pinned index does not carry', async () => {
+    const image = CURATED_TEMPLATES.filter((t) => t.modality === 'image' && !t.apiNode)
+    const missing = image[0]!
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    // Every other image id is gone too, so the spare is the only candidate left.
+    mockedFetchJSON.mockResolvedValue(
+      indexWithout(
+        image.map((t) => t.id),
+        ['image_substitute']
+      )
+    )
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(
+      catalog.find((c) => c.id === missing.id),
+      'a card absent from the pinned index cannot be opened'
+    ).toBeUndefined()
+    expect(
+      catalog.find((c) => c.id === 'image_substitute'),
+      'the slot takes a template this version actually ships'
+    ).toBeDefined()
+  })
+
+  it('still fills every tab when the pinned index omits a whole modality', async () => {
+    const video = CURATED_TEMPLATES.filter((t) => t.modality === 'video').map((t) => t.id)
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithout(video))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    for (const modality of TEMPLATE_MODALITY_ORDER) {
+      expect(catalog.filter((c) => c.modality === modality).length, modality).toBeGreaterThan(0)
+    }
+  })
+
+  it('points thumbnails at the pinned revision, so previews match the cards', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    const catalog = await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    const withThumb = catalog.find((c) => c.thumbnailUrl)!
+    expect(
+      withThumb.thumbnailUrl,
+      'a main-revision preview beside a pinned card is two revisions in one'
+    ).toContain('v0.11.12')
+  })
+
+  it('re-resolves when the target version changes mid-wizard', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadTemplateCatalog({ comfyVersion: 'v0.30.2' })
+    expect(
+      resolveTemplatePackageVersion.mock.calls.map(([v]) => v),
+      'a version-keyed cache must not serve the previous channel'
+    ).toEqual(['v0.28.2', 'v0.30.2'])
+  })
+
+  it('serves the cached catalog for a repeated version', async () => {
+    resolveTemplatePackageVersion.mockResolvedValue('0.11.12')
+    mockedFetchJSON.mockResolvedValue(indexWithout([]))
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    await loadTemplateCatalog({ comfyVersion: 'v0.28.2' })
+    expect(resolveTemplatePackageVersion).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
**TL;DR:** The starter-template picker now resolves against the ComfyUI version the install will actually run, so it stops offering templates that version cannot open.

**Why:** The picker hydrates from the templates repo's `main`, but the install may be an older ComfyUI. Anything added upstream after that release shows up as a card the user clicks and nothing happens. `video_minimax_h3_t2v` does this today for anyone installing v0.28.2.

ComfyUI pins `comfyui-workflow-templates==X` in its own `requirements.txt`, and that pin is the only compatibility map that exists — the index carries no version field.

**What changed:**
- `templatePin.ts` reads that pin for the target tag; the catalog hydrates against that revision's index instead of `main`.
- Thumbnails use the same revision, so a card and its preview can't come from two different ones.
- The catalog cache is keyed by target version, so toggling the release channel mid-wizard re-resolves.
- Stable pins to its tag. Latest fast-forwards past the newest stable tag, so it stays on `main` — pinning it would hide templates it does support.
- `fetch.ts` gains `fetchText` (same request stack, ETag cache, mirror retry) and an optional `timeoutMs`. `net.request` has no timeout, and this sits on the picker's critical path.

**Failure behaviour:** unresolvable pin, thrown lookup, or unreachable index all fall back to the `main` index and the built-in snapshots — i.e. exactly what ships today.

**Testing:** 24 unit tests plus 6 e2e. The unit tests mock `fetchJSON` so they only prove which URL we ask for; the e2e run in the real app against live indexes, four via the resolver and two through `window.api.getFieldOptions` (the wizard's own IPC). Mutation-checked: reverting to `main`, reverting the thumbnail base, or un-keying the cache each fail tests. Full suite 4565 passing.

Not covered: nobody clicks a card. These drive the data path, not the rendered UI, which this PR doesn't change.
