### PR TITLE
fix(comfybuilder): the client calls the release API

### DIFF
--- a/src/main/comfybuilder/client.test.ts
+++ b/src/main/comfybuilder/client.test.ts
@@ -35,6 +35,26 @@ describe('ComfyBuilderClient', () => {
     expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
   })
 
+  it("lists a build's releases at the right path and reads the releases envelope", async () => {
+    const f = mockFetch(200, { releases: [{ id: 'r1', version: 3, status: 'ready' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('t') })
+    const versions = await client.listVersions('d1')
+    expect(versions).toEqual([{ id: 'r1', version: 3, status: 'ready' }])
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/builds/d1/releases')
+  })
+
+  it('getVersion hits the release detail path', async () => {
+    const f = mockFetch(200, { version: 3, artifacts: [{ id: 'a1' }] })
+    vi.stubGlobal('fetch', f)
+    const client = new ComfyBuilderClient({ baseUrl: 'https://api.test/builder', auth: auth('t') })
+    const detail = await client.getVersion('r1')
+    expect(detail).toEqual({ version: 3, artifacts: [{ id: 'a1' }] })
+    const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('https://api.test/builder/v1/releases/r1')
+  })
+
   it('resolveDownloadUrl returns the presigned url', async () => {
     vi.stubGlobal('fetch', mockFetch(200, { downloadUrl: 'https://gcs/signed', expiresAt: 'x' }))
     const client = new ComfyBuilderClient({ auth: auth('t') })
@@ -65,7 +85,7 @@ describe('ComfyBuilderClient', () => {
     expect(m.modelPolicy).toBeNull()
     expect(m.partnerNodePolicy).toBeNull()
     const call = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!
-    expect(call[0]).toBe('https://api.test/builder/v1/build-versions/ver-9/manifest')
+    expect(call[0]).toBe('https://api.test/builder/v1/releases/ver-9/manifest')
   })
 
   it('rejects a manifest response without an explicit model list', async () => {

--- a/src/main/comfybuilder/client.ts
+++ b/src/main/comfybuilder/client.ts
@@ -1,7 +1,7 @@
 /**
  * ComfyBuilder catalog client - the read side of the functionality library.
  *
- * Lists builds -> versions -> artifacts and resolves an artifact's
+ * Lists builds -> releases -> artifacts and resolves an artifact's
  * presigned download URL, over the deployed builder gateway. Every request
  * carries a bearer token from the injected {@link TokenProvider}; the token
  * never leaves this process and is never returned to callers. Failures surface
@@ -72,7 +72,7 @@ interface DistributionsResponse {
   builds?: Distribution[]
 }
 interface VersionsResponse {
-  versions?: DistributionVersion[]
+  releases?: DistributionVersion[]
 }
 interface VersionDetailResponse {
   version?: number
@@ -103,9 +103,9 @@ export class ComfyBuilderClient {
   /** Versions (build history) of one build. */
   async listVersions(distributionId: string): Promise<DistributionVersion[]> {
     const body = await this.get<VersionsResponse>(
-      `/v1/builds/${encodeURIComponent(distributionId)}/versions`
+      `/v1/builds/${encodeURIComponent(distributionId)}/releases`
     )
-    return body.versions ?? []
+    return body.releases ?? []
   }
 
   /** One version's per-target artifacts (plus its version number). */
@@ -113,7 +113,7 @@ export class ComfyBuilderClient {
     versionId: string
   ): Promise<{ version: number | undefined; artifacts: Artifact[] }> {
     const body = await this.get<VersionDetailResponse>(
-      `/v1/build-versions/${encodeURIComponent(versionId)}`
+      `/v1/releases/${encodeURIComponent(versionId)}`
     )
     return { version: body.version, artifacts: body.artifacts ?? [] }
   }
@@ -126,7 +126,7 @@ export class ComfyBuilderClient {
    */
   async fetchModelManifest(versionId: string): Promise<ModelManifest> {
     const body = await this.get<Partial<ModelManifest>>(
-      `/v1/build-versions/${encodeURIComponent(versionId)}/manifest`
+      `/v1/releases/${encodeURIComponent(versionId)}/manifest`
     )
     if (!Array.isArray(body.models)) {
       throw new ComfyBuilderApiError(


### PR DESCRIPTION
**TL;DR:** Desktop's builder client still called the retired `versions` / `build-versions` spellings, which now 404. Three paths and one envelope field move to `releases`.

Reported by @kosinkadink in [#pillar3-dev-platform](https://comfy-organization.slack.com/archives/C0BD6BR53QX/p1787708417083219): "the names of endpoints (builds vs distributions) is mixed right now."

## Why it was broken

The builder API renamed twice. [#1440](https://github.com/Comfy-Org/Comfy-Desktop/pull/1440) made the first hop on Aug 22 (`distributions` to `builds` / `build-versions`). The server then renamed the sub-resource again to `release`, and in [BE-9421](https://linear.app/comfyorg/issue/BE-9421) ([Comfy-Org/cloud#7419](https://github.com/Comfy-Org/cloud/pull/7419)) deleted its legacy compatibility layer outright. That shipped in comfy-builder `v0.233.8`, which is what prod is pinned to, so every retired spelling 404s in prod and staging today.

Desktop never got the second hop. It listed builds fine and then died at the next call, leaving the entire install chain unreachable.

## What changed

| Method | Was | Now |
|---|---|---|
| `listVersions` | `/v1/builds/{id}/versions` | `/v1/builds/{id}/releases` |
| `getVersion` | `/v1/build-versions/{id}` | `/v1/releases/{id}` |
| `fetchModelManifest` | `/v1/build-versions/{id}/manifest` | `/v1/releases/{id}/manifest` |
| `VersionsResponse` | reads `body.versions` | reads `body.releases` |

`listDistributions` (`/v1/builds`) and `resolveDownloadUrl` (`/v1/build-artifacts/{id}/download`) were already current and are untouched.

No type changes were needed. `DistributionVersion`'s fields (`id`, `version`, `status`, `createdAt`) all exist unchanged on `releases[]` items, and `/v1/releases/{id}` still returns `version` and `artifacts`.

## Validation

**Unit, differential.** `listVersions` and `getVersion` asserted no URL at all, which is precisely how the drift went unnoticed. Both now pin their path. The three changed-path tests fail on the base tree and pass here. Full suite green: 4,532 passed, 2 skipped, plus typecheck, eslint and prettier clean.

**Live, against staging.** Drove the real `ComfyBuilderClient` against `stagingplatformapi.comfy.org/builder` with a Cloud JWT and walked the chain that was previously dead at step two:

```
builds: 7
releases for b7eb1f5b: 1  {"id":"ebb23011-...","status":"complete","version":1,
                           "artifactCounts":{"ready":1,"total":1},"deployable":true}
detail: version 1, artifacts 1
manifest models: 1
download url host: storage.googleapis.com
```

The same walk on the base client returns 404 at `listVersions`.

## Deliberately not in scope

The module's internal vocabulary still says distribution and version, so `listDistributions()` returns `body.builds` and `getVersion(versionId)` calls `/v1/releases/{id}`. That reads contradictorily and is likely half of why this looked mixed in the first place, but renaming `Distribution` and `DistributionVersion` reaches the devplatform callers, the e2e specs and the locale strings, where "distribution" may still be the intended product word. Separate change.

**Not checked:** prod with a prod token. The 404s there are evidenced by the reporter's own probe and by the `v0.233.8` pin.
