### PR TITLE
fix(mcp): await the flag fetch before the sidebar gate decides

### DIFF
--- a/src/main/host/attach.test.ts
+++ b/src/main/host/attach.test.ts
@@ -24,12 +24,6 @@ describe('shouldInjectMcpSidebar', () => {
       true
     )
   })
-
-  // The finding: `getFlagAsync` can resolve up to ~10s later. If a detach /
-  // hot-swap ran `_installCleanup` in the meantime it clears `attachActive`,
-  // and because detach leaves `comfyContents` alive the destroyed check passes.
-  // Without the attachActive gate this would inject into a detached / re-attached
-  // view.
   it('does not inject when the attach was retired before the flag resolved', () => {
     expect(shouldInjectMcpSidebar({ attachActive: false, enabled: true, destroyed: false })).toBe(
       false

--- a/src/main/host/attach.test.ts
+++ b/src/main/host/attach.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp',
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en',
+    on: () => {}
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: {},
+  WebContentsView: class {},
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeTheme: { on: vi.fn(), shouldUseDarkColors: false }
+}))
+
+import { shouldInjectMcpSidebar } from './attach'
+
+describe('shouldInjectMcpSidebar', () => {
+  it('injects when the attach is live, the flag is enabled, and the view is alive', () => {
+    expect(shouldInjectMcpSidebar({ attachActive: true, enabled: true, destroyed: false })).toBe(
+      true
+    )
+  })
+
+  // The finding: `getFlagAsync` can resolve up to ~10s later. If a detach /
+  // hot-swap ran `_installCleanup` in the meantime it clears `attachActive`,
+  // and because detach leaves `comfyContents` alive the destroyed check passes.
+  // Without the attachActive gate this would inject into a detached / re-attached
+  // view.
+  it('does not inject when the attach was retired before the flag resolved', () => {
+    expect(shouldInjectMcpSidebar({ attachActive: false, enabled: true, destroyed: false })).toBe(
+      false
+    )
+  })
+
+  it('does not inject when the flag resolved disabled', () => {
+    expect(shouldInjectMcpSidebar({ attachActive: true, enabled: false, destroyed: false })).toBe(
+      false
+    )
+  })
+
+  it('does not inject when the view was destroyed', () => {
+    expect(shouldInjectMcpSidebar({ attachActive: true, enabled: true, destroyed: true })).toBe(
+      false
+    )
+  })
+})

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -45,11 +45,7 @@ const TERMINAL_INJECTION_SOURCE_IDS = new Set(['standalone', 'portable', 'git'])
 /** PostHog flag gating the Local MCP sidebar icon. */
 const MCP_SIDEBAR_FLAG = 'mcp_sidebar_enabled'
 
-/** Gate for the async, flag-resolved MCP sidebar inject. All three must hold:
- *  the attach is still live (`attachActive` — a detach/hot-swap clears it), the
- *  flag resolved enabled, and the view wasn't destroyed. `attachActive` is the
- *  load-bearing one: detach leaves `comfyContents` alive, so `destroyed` alone
- *  would let a late resolution inject into a detached or re-attached view. */
+/** Allow MCP sidebar inject only if attach is active, flag is enabled, and view is not destroyed. */
 export function shouldInjectMcpSidebar(state: {
   attachActive: boolean
   enabled: boolean
@@ -194,10 +190,8 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   // by `_installCleanup` below.
   let currentInstallName = installation.name
 
-  // Guards async work scheduled from this attach (e.g. the flag-gated MCP
-  // sidebar inject) that can resolve after the view is detached or hot-swapped
-  // — `_installCleanup` clears it, and `isDestroyed()` alone wouldn't, since
-  // detach leaves `comfyContents` alive.
+  // Flags async tasks for this attach; cleared by `_installCleanup`.
+  // `isDestroyed()` isn’t enough—`comfyContents` may outlive detachment.
   let attachActive = true
   let currentPageTitle = ''
   const refreshOsWindowTitle = (): void => {

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -4,7 +4,7 @@ import { attachSessionDownloadHandler } from '../lib/comfyDownloadManager'
 import { getModelDownloadContentScript } from '../lib/comfyContentScript'
 import { getComfyTerminalContentScript } from '../lib/comfyTerminalContentScript'
 import { getMcpSidebarContentScript } from '../lib/mcpSidebarContentScript'
-import { getFlag, recordExposure } from '../lib/experiments'
+import { getFlagAsync, recordExposure } from '../lib/experiments'
 import { closeInstallPopouts } from '../lib/popoutWindows'
 import { _operationAborts, sourceMap } from '../lib/ipc/shared'
 import { readableSymbolColor } from '../lib/theme'
@@ -425,11 +425,16 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
     // `comfyTerminalContentScript.ts` for the dedupe guard.
     if (isLocal && TERMINAL_INJECTION_SOURCE_IDS.has(installation.sourceId)) {
       comfyContents.executeJavaScript(getComfyTerminalContentScript()).catch(() => {})
-      // Local MCP sidebar icon, flag-gated. Same install gate as the terminal.
-      if (getFlag(MCP_SIDEBAR_FLAG) === true) {
+      // Local MCP sidebar icon, flag-gated. `getFlagAsync` awaits the in-flight
+      // boot fetch so a cold start (empty cache) still resolves the flag before
+      // the gate decides; a sync read here would see the not-yet-populated cache
+      // and never inject. Re-check the view is alive after the await.
+      void (async () => {
+        if ((await getFlagAsync(MCP_SIDEBAR_FLAG)) !== true) return
+        if (comfyContents.isDestroyed()) return
         recordExposure(MCP_SIDEBAR_FLAG, 'enabled', 'cache')
         comfyContents.executeJavaScript(getMcpSidebarContentScript()).catch(() => {})
-      }
+      })()
     }
     // Cloud-only patches (popup-blocked toast suppression + post-signin
     // flicker hide). Skipped for local installs — they don't load cloud

--- a/src/main/host/attach.ts
+++ b/src/main/host/attach.ts
@@ -45,6 +45,19 @@ const TERMINAL_INJECTION_SOURCE_IDS = new Set(['standalone', 'portable', 'git'])
 /** PostHog flag gating the Local MCP sidebar icon. */
 const MCP_SIDEBAR_FLAG = 'mcp_sidebar_enabled'
 
+/** Gate for the async, flag-resolved MCP sidebar inject. All three must hold:
+ *  the attach is still live (`attachActive` — a detach/hot-swap clears it), the
+ *  flag resolved enabled, and the view wasn't destroyed. `attachActive` is the
+ *  load-bearing one: detach leaves `comfyContents` alive, so `destroyed` alone
+ *  would let a late resolution inject into a detached or re-attached view. */
+export function shouldInjectMcpSidebar(state: {
+  attachActive: boolean
+  enabled: boolean
+  destroyed: boolean
+}): boolean {
+  return state.attachActive && state.enabled && !state.destroyed
+}
+
 /** Entry point that triggered a zoom reset, tagged as `source` on the
  *  `comfy.desktop.zoom.reset` telemetry event. `titlebar` (the zoom pill)
  *  and `menu` (the title menu's "Reset Zoom") flow through the per-install
@@ -180,6 +193,12 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   // install name changes. Closures over the install lifetime — reset
   // by `_installCleanup` below.
   let currentInstallName = installation.name
+
+  // Guards async work scheduled from this attach (e.g. the flag-gated MCP
+  // sidebar inject) that can resolve after the view is detached or hot-swapped
+  // — `_installCleanup` clears it, and `isDestroyed()` alone wouldn't, since
+  // detach leaves `comfyContents` alive.
+  let attachActive = true
   let currentPageTitle = ''
   const refreshOsWindowTitle = (): void => {
     if (comfyWindow.isDestroyed()) return
@@ -430,8 +449,13 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
       // the gate decides; a sync read here would see the not-yet-populated cache
       // and never inject. Re-check the view is alive after the await.
       void (async () => {
-        if ((await getFlagAsync(MCP_SIDEBAR_FLAG)) !== true) return
-        if (comfyContents.isDestroyed()) return
+        const enabled = (await getFlagAsync(MCP_SIDEBAR_FLAG)) === true
+        // The await can outlive the attach — see `shouldInjectMcpSidebar`.
+        if (
+          !shouldInjectMcpSidebar({ attachActive, enabled, destroyed: comfyContents.isDestroyed() })
+        ) {
+          return
+        }
         recordExposure(MCP_SIDEBAR_FLAG, 'enabled', 'cache')
         comfyContents.executeJavaScript(getMcpSidebarContentScript()).catch(() => {})
       })()
@@ -641,6 +665,9 @@ export function attachInstall(entry: ComfyWindowEntry, opts: AttachInstallOpts):
   entry._installCleanup = (): void => {
     if (entry._installCleanup === null) return
     entry._installCleanup = null
+    // Retire async work still pending from this attach so a late resolution
+    // can't touch a detached or re-attached view.
+    attachActive = false
     deactivateFirebaseAuthReporter(comfyContents)
     installationEvents.off('updated', onInstallationUpdated)
     cancelFailRetry()

--- a/src/main/lib/experiments.ts
+++ b/src/main/lib/experiments.ts
@@ -32,7 +32,13 @@ import { configDir } from './paths'
 import * as mainTelemetry from './telemetry'
 import type { FeatureFlagValue } from './telemetry'
 
-const DEFAULT_TIMEOUT_MS = 1500
+// The boot fetch is fire-and-forget (`void initExperiments`) and its only
+// awaiter is `getFlagAsync`, which wants the real value. A short timeout here
+// doesn't protect boot — it just discards a slow-but-successful fetch, leaving
+// the cache unseeded and every `getFlagAsync` reader stuck on `undefined`. So
+// the cap is a hang-guard, not a UI budget: long enough that a slow network
+// still resolves and seeds the cache.
+const DEFAULT_TIMEOUT_MS = 10_000
 
 export type ExperimentExposureSource = 'cache' | 'remote' | 'fallback'
 


### PR DESCRIPTION
## Summary

The Local MCP sidebar icon never appears in packaged/ToDesktop builds, even though the `mcp_sidebar_enabled` flag is on in PostHog. It works in `pnpm dev` but not for real users. This makes the whole feature invisible in production.

## Root cause

The injection gate read the flag synchronously (`getFlag`) at `dom-ready`, before the async PostHog fetch had populated the cache. On a cold start (fresh or wiped install, i.e. every real first launch) `getFlag` returns `undefined`, so the icon is never injected.

Worse, the boot fetch is capped at a 1500ms timeout, and on timeout it returns `{}` — which skips `writeCache`, so the flag is never seeded on disk either. That means it fails on every subsequent launch too, not just the first. Dev only worked because the fetch happened to win the race on a warm machine.

## Changes

- `attach.ts`: the gate now `await`s `getFlagAsync` (the accessor every other flag consumer already uses) so injection waits for the fetch to resolve instead of reading an empty cache. Guards `comfyContents.isDestroyed()` since we now await across a tick.
- `experiments.ts`: `initExperiments` is fire-and-forget and its only awaiter is `getFlagAsync`, so the 1500ms cap wasn't protecting boot — it just discarded slow-but-successful fetches and left the cache unseeded. Raised to a 10s hang-guard so a slow network still resolves and seeds the cache.

## Review focus

- `experiments.ts` `DEFAULT_TIMEOUT_MS`: `loadFeatureFlagsImmediate` has exactly one caller (`initExperiments`), which is `void`-called at boot, so widening this timeout doesn't block startup. Worth a sanity check that no other path depends on the 1500ms bound.

## Testing

- Reproduced the failure locally by forcing the timeout to 1ms and clearing the flag cache: the icon disappeared, and logs confirmed the chain (empty cache -> fetch returns {} -> getFlag undefined -> willInject=false).
- With the fix, verified the icon appears on a cold-boot **packaged** build (empty cache) built via `electron-builder --dir` — the same packaging path as the failing ToDesktop build.
- Also built and smoke-tested an integration build (this fix merged with upstream/main) to confirm no regression in other features.
