### PR TITLE
fix(install/mcp): kill the loader black flash, MCP cold video, and overlay flicker

### DIFF
--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -658,9 +658,8 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
      *  bodyRect; the panel paints transparent (PanelApp's `panel-overlay-mode`) so it
      *  composites through on macOS CALayers. */
     const isOverlayMode = mode === 'feedback' || mode === 'mcp-setup'
-    // Hold the panel hidden until the renderer acks it has painted the overlay,
-    // so its opaque pre-transparent frame never flashes over ComfyUI. Non-overlay
-    // bodies (chooser / lifecycle / settings) are opaque by design and reveal now.
+    // Keep an overlay panel hidden until the renderer acks it painted, so its
+    // opaque pre-transparent frame can't flash over ComfyUI.
     const showPanel = mode !== 'comfy' && !(isOverlayMode && entry?.pendingOverlayReveal)
     if (showPanel && entry?.panelView) {
       entry.panelView.setBounds(bodyRect)

--- a/src/main/host/createHostWindow.ts
+++ b/src/main/host/createHostWindow.ts
@@ -654,11 +654,14 @@ export function createHostWindow(opts: CreateHostWindowOpts): CreateHostWindowRe
     // `computeBodyMode` already returns `'chooser'` for install-less
     // hosts, so the install-backed visibility branch handles both.
     const mode = entry ? computeBodyMode(entry) : 'comfy'
-    const showPanel = mode !== 'comfy'
     /** Overlay mode mounts a modal over the live canvas, kept visible underneath at full
      *  bodyRect; the panel paints transparent (PanelApp's `panel-overlay-mode`) so it
      *  composites through on macOS CALayers. */
     const isOverlayMode = mode === 'feedback' || mode === 'mcp-setup'
+    // Hold the panel hidden until the renderer acks it has painted the overlay,
+    // so its opaque pre-transparent frame never flashes over ComfyUI. Non-overlay
+    // bodies (chooser / lifecycle / settings) are opaque by design and reveal now.
+    const showPanel = mode !== 'comfy' && !(isOverlayMode && entry?.pendingOverlayReveal)
     if (showPanel && entry?.panelView) {
       entry.panelView.setBounds(bodyRect)
       entry.panelView.setVisible(true)

--- a/src/main/host/panelView.test.ts
+++ b/src/main/host/panelView.test.ts
@@ -23,7 +23,7 @@ import {
   nextWindowKey,
   type ComfyWindowEntry
 } from './registry'
-import { refreshComfyTabBody, setActivePanel } from './panelView'
+import { prewarmAttachedPanel, refreshComfyTabBody, setActivePanel } from './panelView'
 
 interface FakeWindow {
   destroyed: boolean
@@ -141,33 +141,27 @@ describe('setActivePanel', () => {
     expect(fixture.entry.activePanel).toBe('comfy')
   })
 
-  // Chooser-pick in-place attach: the picker drove its launch through a
-  // 'progress' overlay on the (install-less) chooser host. When the install
-  // attaches in place, that host must be reset to 'comfy' before the panel
-  // prewarm — otherwise computeBodyMode stays 'progress' and the rebuilt panel
-  // covers the just-attached canvas with a stranded progress surface.
-  it('resets a progress-mode chooser host to comfy so the prewarm stays hidden', () => {
-    const fixture = makeEntry({ installationId: null, activePanel: 'progress' })
+  // After a chooser-pick in-place attach the picker leaves the host on
+  // 'progress'; prewarmAttachedPanel must reset it to 'comfy' so the rebuilt
+  // panel stays hidden instead of covering the just-attached canvas.
+  it('prewarms the attached panel hidden by resetting a progress host to comfy', () => {
+    const fixture = makeEntry({ installationId: 'inst-A', activePanel: 'progress' })
+    // A pre-set panelView makes the real ensurePanelView short-circuit, so the
+    // helper runs without constructing an Electron WebContentsView.
+    fixture.entry.panelView = {
+      webContents: makeWc()
+    } as unknown as ComfyWindowEntry['panelView']
     comfyWindows.set(fixture.entry.windowKey, fixture.entry)
-
-    // Pre-fix state at the prewarm point: mode is 'progress' (panel full, canvas
-    // hidden) even after attachInstall wires up the running session.
-    fixture.entry.installationId = 'inst-A'
     indexInstallationId('inst-A', fixture.entry.windowKey)
     _runningSessions.set('inst-A', {} as never)
-    expect(
-      computeBodyMode(fixture.entry),
-      'without the reset the panel would cover the canvas'
-    ).toBe('progress')
 
-    // The fix: reset to 'comfy' before ensurePanelView.
-    setActivePanel(fixture.entry.windowKey, 'comfy')
+    expect(computeBodyMode(fixture.entry), 'starts stranded on progress').toBe('progress')
+
+    prewarmAttachedPanel(fixture.entry)
 
     expect(fixture.entry.activePanel).toBe('comfy')
-    expect(
-      computeBodyMode(fixture.entry),
-      'the prewarmed panel is hidden and ComfyUI is visible'
-    ).toBe('comfy')
+    expect(computeBodyMode(fixture.entry), 'panel hidden, ComfyUI visible').toBe('comfy')
+    expect(fixture.layoutCalls, 'the prewarm lays the views out').toBeGreaterThan(0)
   })
 })
 

--- a/src/main/host/panelView.test.ts
+++ b/src/main/host/panelView.test.ts
@@ -16,7 +16,13 @@ vi.mock('electron', () => ({
 }))
 
 import { _runningSessions } from '../lib/ipc/shared'
-import { comfyWindows, indexInstallationId, nextWindowKey, type ComfyWindowEntry } from './registry'
+import {
+  comfyWindows,
+  computeBodyMode,
+  indexInstallationId,
+  nextWindowKey,
+  type ComfyWindowEntry
+} from './registry'
 import { refreshComfyTabBody, setActivePanel } from './panelView'
 
 interface FakeWindow {
@@ -133,6 +139,35 @@ describe('setActivePanel', () => {
     setActivePanel(fixture.entry.windowKey, 'feedback')
     expect(fixture.layoutCalls).toBe(0)
     expect(fixture.entry.activePanel).toBe('comfy')
+  })
+
+  // Chooser-pick in-place attach: the picker drove its launch through a
+  // 'progress' overlay on the (install-less) chooser host. When the install
+  // attaches in place, that host must be reset to 'comfy' before the panel
+  // prewarm — otherwise computeBodyMode stays 'progress' and the rebuilt panel
+  // covers the just-attached canvas with a stranded progress surface.
+  it('resets a progress-mode chooser host to comfy so the prewarm stays hidden', () => {
+    const fixture = makeEntry({ installationId: null, activePanel: 'progress' })
+    comfyWindows.set(fixture.entry.windowKey, fixture.entry)
+
+    // Pre-fix state at the prewarm point: mode is 'progress' (panel full, canvas
+    // hidden) even after attachInstall wires up the running session.
+    fixture.entry.installationId = 'inst-A'
+    indexInstallationId('inst-A', fixture.entry.windowKey)
+    _runningSessions.set('inst-A', {} as never)
+    expect(
+      computeBodyMode(fixture.entry),
+      'without the reset the panel would cover the canvas'
+    ).toBe('progress')
+
+    // The fix: reset to 'comfy' before ensurePanelView.
+    setActivePanel(fixture.entry.windowKey, 'comfy')
+
+    expect(fixture.entry.activePanel).toBe('comfy')
+    expect(
+      computeBodyMode(fixture.entry),
+      'the prewarmed panel is hidden and ComfyUI is visible'
+    ).toBe('comfy')
   })
 })
 

--- a/src/main/host/panelView.ts
+++ b/src/main/host/panelView.ts
@@ -171,11 +171,25 @@ export function setActivePanel(windowKey: number, panel: ComfyPanelKey): void {
   if (mode !== 'comfy') {
     ensurePanelView(windowKey, entry, mode)
   }
+  // Overlay panels (feedback / mcp-setup) reveal only after the renderer acks it
+  // painted the modal (`overlay-ready`), so the panel's opaque pre-transparent
+  // frame never flashes over the canvas. Cleared for non-overlay targets so a
+  // stale flag can't strand the panel hidden.
+  const isOverlay = mode === 'feedback' || mode === 'mcp-setup'
+  entry.pendingOverlayReveal = isOverlay
   forwardToPanelRenderer(entry, 'panel-switch', {
     panel: mode,
     installationId: entry.installationId ?? ''
   })
   entry.layoutViews()
+  // Reveal anyway if the ack never arrives (crash / lost IPC); a late ack no-ops.
+  if (isOverlay) {
+    setTimeout(() => {
+      if (!entry.pendingOverlayReveal || entry.window.isDestroyed()) return
+      entry.pendingOverlayReveal = false
+      entry.layoutViews()
+    }, 400)
+  }
   if (!entry.titleBarView.webContents.isDestroyed()) {
     // Pill stays on the user-visible key, not 'comfy-lifecycle'.
     entry.titleBarView.webContents.send('comfy-titlebar:panel-changed', panel)
@@ -255,6 +269,19 @@ export function registerPanelViewIpc(): void {
     for (const [id, entry] of comfyWindows) {
       if (entry.panelView?.webContents === event.sender) {
         setActivePanel(id, 'comfy')
+        return
+      }
+    }
+  })
+
+  // The panel renderer painted an overlay modal; reveal the until-now-hidden
+  // panel view so it appears with content rather than as an opaque flash.
+  ipcMain.on('comfy-window:overlay-ready', (event) => {
+    for (const entry of comfyWindows.values()) {
+      if (entry.panelView?.webContents === event.sender) {
+        if (!entry.pendingOverlayReveal) return
+        entry.pendingOverlayReveal = false
+        if (!entry.window.isDestroyed()) entry.layoutViews()
         return
       }
     }

--- a/src/main/host/panelView.ts
+++ b/src/main/host/panelView.ts
@@ -200,6 +200,21 @@ export function setActivePanel(windowKey: number, panel: ComfyPanelKey): void {
 }
 
 /**
+ * Warm the install-backed panel in the background right after a chooser-pick
+ * in-place attach, so the first Settings/MCP click doesn't build it cold.
+ *
+ * The reset to `'comfy'` MUST precede `ensurePanelView`: the picker drove its
+ * launch through a `'progress'` overlay on this host, and without clearing it
+ * `computeBodyMode` stays `'progress'` — the rebuilt panel would then cover the
+ * just-attached canvas with a stranded progress surface.
+ */
+export function prewarmAttachedPanel(entry: ComfyWindowEntry): void {
+  setActivePanel(entry.windowKey, 'comfy')
+  ensurePanelView(entry.windowKey, entry, computeBodyMode(entry))
+  entry.layoutViews()
+}
+
+/**
  * Re-evaluate the body mode after a session-state transition and reflect it in the layout.
  * When the mode is `'comfy-lifecycle'`, the panelView renders the lifecycle UI; the pill
  * stays on `'comfy'` either way.

--- a/src/main/host/panelView.ts
+++ b/src/main/host/panelView.ts
@@ -171,12 +171,13 @@ export function setActivePanel(windowKey: number, panel: ComfyPanelKey): void {
   if (mode !== 'comfy') {
     ensurePanelView(windowKey, entry, mode)
   }
-  // Overlay panels (feedback / mcp-setup) reveal only after the renderer acks it
-  // painted the modal (`overlay-ready`), so the panel's opaque pre-transparent
-  // frame never flashes over the canvas. Cleared for non-overlay targets so a
-  // stale flag can't strand the panel hidden.
+  // Overlay panels reveal only after the renderer's `overlay-ready` ack (see
+  // layoutViews); clear the flag for non-overlay targets so it can't strand.
   const isOverlay = mode === 'feedback' || mode === 'mcp-setup'
   entry.pendingOverlayReveal = isOverlay
+  // Drop any prior fallback timer so a stale one can't reveal this open early.
+  if (entry.overlayRevealTimer) clearTimeout(entry.overlayRevealTimer)
+  entry.overlayRevealTimer = undefined
   forwardToPanelRenderer(entry, 'panel-switch', {
     panel: mode,
     installationId: entry.installationId ?? ''
@@ -184,7 +185,8 @@ export function setActivePanel(windowKey: number, panel: ComfyPanelKey): void {
   entry.layoutViews()
   // Reveal anyway if the ack never arrives (crash / lost IPC); a late ack no-ops.
   if (isOverlay) {
-    setTimeout(() => {
+    entry.overlayRevealTimer = setTimeout(() => {
+      entry.overlayRevealTimer = undefined
       if (!entry.pendingOverlayReveal || entry.window.isDestroyed()) return
       entry.pendingOverlayReveal = false
       entry.layoutViews()
@@ -281,6 +283,8 @@ export function registerPanelViewIpc(): void {
       if (entry.panelView?.webContents === event.sender) {
         if (!entry.pendingOverlayReveal) return
         entry.pendingOverlayReveal = false
+        if (entry.overlayRevealTimer) clearTimeout(entry.overlayRevealTimer)
+        entry.overlayRevealTimer = undefined
         if (!entry.window.isDestroyed()) entry.layoutViews()
         return
       }

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -82,10 +82,13 @@ export interface ComfyWindowEntry {
   /** Currently rendered panel — always a user-visible key, never the internal
    *  `'comfy-lifecycle'` / `'chooser'` body modes. */
   activePanel: ComfyPanelKey
-  /** Set between an overlay switch (feedback / mcp-setup) and the renderer's
-   *  `overlay-ready` ack; while set, `layoutViews` keeps the panel view hidden
-   *  so its pre-transparent frame can't flash over ComfyUI. */
+  /** While set (overlay switch → renderer `overlay-ready` ack), `layoutViews`
+   *  keeps the panel hidden so its pre-transparent frame can't flash. */
   pendingOverlayReveal?: boolean
+  /** Fallback timer that reveals the overlay if the ack never lands; cleared on
+   *  the next switch or the ack so a stale one can't reveal a later open early. */
+  overlayRevealTimer?: ReturnType<typeof setTimeout>
+
   /** Last theme reported by the ComfyUI frontend, applied to the panel on load. */
   lastTheme: { bg: string; text: string }
   /** Updates view bounds for the current activePanel. */

--- a/src/main/host/registry.ts
+++ b/src/main/host/registry.ts
@@ -82,6 +82,10 @@ export interface ComfyWindowEntry {
   /** Currently rendered panel — always a user-visible key, never the internal
    *  `'comfy-lifecycle'` / `'chooser'` body modes. */
   activePanel: ComfyPanelKey
+  /** Set between an overlay switch (feedback / mcp-setup) and the renderer's
+   *  `overlay-ready` ack; while set, `layoutViews` keeps the panel view hidden
+   *  so its pre-transparent frame can't flash over ComfyUI. */
+  pendingOverlayReveal?: boolean
   /** Last theme reported by the ComfyUI frontend, applied to the panel on load. */
   lastTheme: { bg: string; text: string }
   /** Updates view bounds for the current activePanel. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -660,6 +660,11 @@ function onLaunch({
       destroyPanelView(claimed)
       const ok = attachInstall(claimed, { installation, comfyUrl, isLocal: !url })
       if (ok) {
+        // The picker drove its launch through a 'progress' overlay on this host;
+        // clear that back to 'comfy' before the prewarm so computeBodyMode keeps
+        // the rebuilt panel hidden and ComfyUI visible. Otherwise the panel would
+        // cover the just-attached canvas with a stranded progress surface.
+        setActivePanel(claimed.windowKey, 'comfy')
         // Rebuild the panel view now (hidden, mode is 'comfy') so it boots in the
         // background — otherwise the first Settings/MCP click builds it cold.
         ensurePanelView(claimed.windowKey, claimed, computeBodyMode(claimed))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -660,11 +660,8 @@ function onLaunch({
       destroyPanelView(claimed)
       const ok = attachInstall(claimed, { installation, comfyUrl, isLocal: !url })
       if (ok) {
-        // Rebuild the (now install-backed) panel view immediately, hidden and
-        // collapsed, so it boots panel.html in the background while the user is
-        // in ComfyUI. Otherwise the first Settings/MCP click builds it cold and
-        // the ~300ms load composites through the overlay as an open/close/open
-        // flicker. computeBodyMode is 'comfy' here, so it stays invisible.
+        // Rebuild the panel view now (hidden, mode is 'comfy') so it boots in the
+        // background — otherwise the first Settings/MCP click builds it cold.
         ensurePanelView(claimed.windowKey, claimed, computeBodyMode(claimed))
         claimed.layoutViews()
         if (proc) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -660,6 +660,12 @@ function onLaunch({
       destroyPanelView(claimed)
       const ok = attachInstall(claimed, { installation, comfyUrl, isLocal: !url })
       if (ok) {
+        // Rebuild the (now install-backed) panel view immediately, hidden and
+        // collapsed, so it boots panel.html in the background while the user is
+        // in ComfyUI. Otherwise the first Settings/MCP click builds it cold and
+        // the ~300ms load composites through the overlay as an open/close/open
+        // flicker. computeBodyMode is 'comfy' here, so it stays invisible.
+        ensurePanelView(claimed.windowKey, claimed, computeBodyMode(claimed))
         claimed.layoutViews()
         if (proc) {
           proc.on('exit', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,6 +155,7 @@ import {
   destroyPanelView,
   ensurePanelView,
   focusActiveBody,
+  prewarmAttachedPanel,
   refreshComfyTabBody,
   registerPanelViewIpc,
   sendToPanelDeferred,
@@ -660,15 +661,7 @@ function onLaunch({
       destroyPanelView(claimed)
       const ok = attachInstall(claimed, { installation, comfyUrl, isLocal: !url })
       if (ok) {
-        // The picker drove its launch through a 'progress' overlay on this host;
-        // clear that back to 'comfy' before the prewarm so computeBodyMode keeps
-        // the rebuilt panel hidden and ComfyUI visible. Otherwise the panel would
-        // cover the just-attached canvas with a stranded progress surface.
-        setActivePanel(claimed.windowKey, 'comfy')
-        // Rebuild the panel view now (hidden, mode is 'comfy') so it boots in the
-        // background — otherwise the first Settings/MCP click builds it cold.
-        ensurePanelView(claimed.windowKey, claimed, computeBodyMode(claimed))
-        claimed.layoutViews()
+        prewarmAttachedPanel(claimed)
         if (proc) {
           proc.on('exit', () => {
             // Session registry handles state cleanup

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -82,6 +82,9 @@ export function buildElectronApi(): ElectronApi {
     closeHostWindow: () => ipcRenderer.invoke('close-host-window'),
     returnToDashboard: () => ipcRenderer.invoke('return-to-dashboard'),
     closeCurrentPanel: () => ipcRenderer.send('comfy-window:close-current-panel'),
+    /** Signal that an overlay panel (feedback / mcp-setup) has painted, so main
+     *  can reveal the until-now-hidden panel view without an opaque flash. */
+    signalOverlayReady: () => ipcRenderer.send('comfy-window:overlay-ready'),
     resolveStartupRestoreReveal: (result) =>
       ipcRenderer.send('comfy-window:startup-restore-reveal', { result }),
     openGlobalSettings: (tab) =>

--- a/src/renderer/src/components/BrandSceneAnimation.vue
+++ b/src/renderer/src/components/BrandSceneAnimation.vue
@@ -79,10 +79,6 @@ useBrandScene(stageRef, data, { fit: props.fit, speed: props.speed })
 .brand-scene video.is-active {
   display: block;
   opacity: 0;
-  /* Declared on the start state so the flip to `.is-painted` actually animates
-     (a transition set only on the end class applies simultaneously and hard-
-     cuts). Fades the video up from the neutral mask ground over the ~300ms
-     first-frame decode, so there's no flicker. */
   transition: opacity 280ms ease;
 }
 .brand-scene video.is-active.is-painted {

--- a/src/renderer/src/components/BrandSceneAnimation.vue
+++ b/src/renderer/src/components/BrandSceneAnimation.vue
@@ -63,7 +63,7 @@ useBrandScene(stageRef, data, { fit: props.fit, speed: props.speed })
   width: 0;
   height: 0;
   overflow: hidden;
-  background: #000;
+  background: var(--neutral-900, #19131d);
   will-change: transform, width, height;
 }
 .brand-scene video {
@@ -78,5 +78,19 @@ useBrandScene(stageRef, data, { fit: props.fit, speed: props.speed })
 }
 .brand-scene video.is-active {
   display: block;
+  opacity: 0;
+  /* Declared on the start state so the flip to `.is-painted` actually animates
+     (a transition set only on the end class applies simultaneously and hard-
+     cuts). Fades the video up from the neutral mask ground over the ~300ms
+     first-frame decode, so there's no flicker. */
+  transition: opacity 280ms ease;
+}
+.brand-scene video.is-active.is-painted {
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .brand-scene video.is-active {
+    transition: none;
+  }
 }
 </style>

--- a/src/renderer/src/composables/useAssetPrefetch.test.ts
+++ b/src/renderer/src/composables/useAssetPrefetch.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+
+import { useAssetPrefetch, type AssetLoader } from './useAssetPrefetch'
+
+let idleQueue: Array<() => void> = []
+let nextHandle = 1
+
+beforeEach(() => {
+  idleQueue = []
+  nextHandle = 1
+  vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
+    idleQueue.push(cb)
+    return nextHandle++
+  })
+  vi.stubGlobal('cancelIdleCallback', (handle: number) => {
+    idleQueue[handle - 1] = undefined as unknown as () => void
+  })
+  vi.stubGlobal('navigator', { connection: undefined })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+/** Fire queued idle callbacks; work that settles synchronously and re-pumps
+ *  enqueues the next job, which the browser fires on a subsequent idle. Drain
+ *  those follow-ups too, capped so a genuine wedge surfaces as a hang-free fail. */
+function flushIdle(): void {
+  for (let i = 0; i < 100 && idleQueue.length > 0; i++) {
+    const pending = idleQueue
+    idleQueue = []
+    for (const cb of pending) cb?.()
+  }
+}
+
+function run<T>(fn: () => T): { result: T; dispose: () => void } {
+  const scope = effectScope()
+  const result = scope.run(fn)!
+  return { result, dispose: () => scope.stop() }
+}
+
+describe('useAssetPrefetch', () => {
+  it('drains the queue when a loader settles synchronously', () => {
+    const loaded: string[] = []
+    // A loader that calls done() before returning its canceller — the frame is
+    // already warm (cache hit), so it settles inside the same call.
+    const syncLoader: AssetLoader = (url, done) => {
+      loaded.push(url)
+      done()
+      return () => {}
+    }
+    const { result } = run(() => useAssetPrefetch(syncLoader, { concurrency: 1 }))
+
+    result.prefetch(['a', 'b', 'c'])
+    flushIdle()
+
+    expect(loaded, 'a synchronous settle must not wedge the queue').toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not retain a canceller for a synchronously-settled load', () => {
+    let cancelled = 0
+    const syncLoader: AssetLoader = (_url, done) => {
+      done()
+      return () => {
+        cancelled++
+      }
+    }
+    const { result, dispose } = run(() => useAssetPrefetch(syncLoader, { concurrency: 1 }))
+
+    result.prefetch(['a'])
+    flushIdle()
+    dispose()
+
+    expect(cancelled, 'an already-settled load is not cancelled on dispose').toBe(0)
+  })
+})

--- a/src/renderer/src/composables/useAssetPrefetch.ts
+++ b/src/renderer/src/composables/useAssetPrefetch.ts
@@ -1,16 +1,13 @@
 import { onScopeDispose } from 'vue'
 
 /**
- * Idle-time URL warmer: pulls URLs into the browser HTTP cache during idle so a
- * later element renders/plays without a cold fetch. Defers entirely while
- * `isBusy()` or on a metered link, so it never competes with real work on a
- * low-spec machine. The transport is pluggable via `loader` — an `Image()` for
- * thumbnails, a `fetch()` for media — so the queue/idle/busy/network machinery
- * lives in one place (see `useThumbnailPrefetch`, `useMediaPrefetch`).
+ * Idle-time URL warmer: pulls URLs into the HTTP cache while idle so a later
+ * element renders/plays without a cold fetch, deferring under `isBusy()` or a
+ * metered link. The transport is pluggable via `loader`, so the queue/idle/busy
+ * machinery is shared by `useThumbnailPrefetch` and `useMediaPrefetch`.
  */
 
-/** Kicks off one warm for `url`, calls `done` when it settles (ok or error),
- *  and returns a canceller that aborts it and detaches handlers for GC. */
+/** Starts one warm for `url`, calls `done` when it settles, returns a canceller. */
 export type AssetLoader = (url: string, done: () => void) => () => void
 
 interface AssetPrefetchOptions {
@@ -28,13 +25,10 @@ interface IdleWindow {
   cancelIdleCallback?: (handle: IdleHandle) => void
 }
 
-/** Delay (ms) for the `setTimeout` fallback when `requestIdleCallback` is absent.
- *  A few frames — enough to yield to interactive work without forcing the full
- *  idle deadline (which is a max, not a delay). */
+/** `setTimeout` delay when `requestIdleCallback` is absent — yield a few frames. */
 const FALLBACK_DELAY_MS = 50
 
-/** Schedule on the idle queue, falling back to a low-priority timeout. Returns a
- *  canceller so callers don't branch on which path ran. */
+/** Schedule on the idle queue (or a low-priority timeout); returns a canceller. */
 function scheduleIdle(fn: () => void, timeoutMs: number): () => void {
   const w = window as unknown as IdleWindow
   if (typeof w.requestIdleCallback === 'function') {
@@ -45,8 +39,7 @@ function scheduleIdle(fn: () => void, timeoutMs: number): () => void {
   return () => window.clearTimeout(id)
 }
 
-/** True on a metered / very slow connection where speculative fetching would
- *  hurt more than help. Conservative: only bails on explicit data-saver or 2g. */
+/** Skip speculative fetching on an explicit data-saver or 2g connection. */
 function shouldSkipForNetwork(): boolean {
   const conn = (
     navigator as unknown as {
@@ -64,24 +57,20 @@ export function useAssetPrefetch(
 ): { prefetch: (urls: readonly (string | null | undefined)[]) => void } {
   const { isBusy = () => false, concurrency = 3, idleTimeoutMs = 3000 } = options
 
-  /** How long to wait before re-checking the busy gate, so a sustained
-   *  install/launch doesn't busy-spin the idle queue. */
+  /** Re-check delay for the busy gate, so a sustained install doesn't busy-spin. */
   const BUSY_BACKOFF_MS = 1500
 
   const queue: string[] = []
   const seen = new Set<string>()
   const cancellers = new Set<() => void>()
   const loaderCancellers = new Set<() => void>()
-  // Reserved synchronously as work is scheduled (not when the idle callback
-  // fires), so the pump loop enforces `concurrency` instead of scheduling the
-  // whole queue at once.
+  // Reserved when work is scheduled, not when it runs, so pump enforces concurrency.
   let inFlight = 0
   let disposed = false
 
   function pump(): void {
     if (disposed || queue.length === 0) return
-    // Important work wins: back off (timer, not idle) and re-check later rather
-    // than competing for the network/CPU now.
+    // Defer past important work rather than compete for the network now.
     if (isBusy()) {
       const id = window.setTimeout(() => {
         cancellers.delete(cancel)
@@ -130,8 +119,7 @@ export function useAssetPrefetch(
     queue.length = 0
     for (const cancel of cancellers) cancel()
     cancellers.clear()
-    // Abort still-running warms so their closures can be GC'd without waiting
-    // for the request to settle.
+    // Abort in-flight warms so their closures can be GC'd immediately.
     for (const cancel of loaderCancellers) cancel()
     loaderCancellers.clear()
   })

--- a/src/renderer/src/composables/useAssetPrefetch.ts
+++ b/src/renderer/src/composables/useAssetPrefetch.ts
@@ -1,0 +1,140 @@
+import { onScopeDispose } from 'vue'
+
+/**
+ * Idle-time URL warmer: pulls URLs into the browser HTTP cache during idle so a
+ * later element renders/plays without a cold fetch. Defers entirely while
+ * `isBusy()` or on a metered link, so it never competes with real work on a
+ * low-spec machine. The transport is pluggable via `loader` — an `Image()` for
+ * thumbnails, a `fetch()` for media — so the queue/idle/busy/network machinery
+ * lives in one place (see `useThumbnailPrefetch`, `useMediaPrefetch`).
+ */
+
+/** Kicks off one warm for `url`, calls `done` when it settles (ok or error),
+ *  and returns a canceller that aborts it and detaches handlers for GC. */
+export type AssetLoader = (url: string, done: () => void) => () => void
+
+interface AssetPrefetchOptions {
+  /** Returns true when something more important is running; prefetch defers. */
+  isBusy?: () => boolean
+  /** Max concurrent warms. */
+  concurrency?: number
+  /** Idle-callback deadline (ms) so a never-idle main thread still drains. */
+  idleTimeoutMs?: number
+}
+
+type IdleHandle = number
+interface IdleWindow {
+  requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => IdleHandle
+  cancelIdleCallback?: (handle: IdleHandle) => void
+}
+
+/** Delay (ms) for the `setTimeout` fallback when `requestIdleCallback` is absent.
+ *  A few frames — enough to yield to interactive work without forcing the full
+ *  idle deadline (which is a max, not a delay). */
+const FALLBACK_DELAY_MS = 50
+
+/** Schedule on the idle queue, falling back to a low-priority timeout. Returns a
+ *  canceller so callers don't branch on which path ran. */
+function scheduleIdle(fn: () => void, timeoutMs: number): () => void {
+  const w = window as unknown as IdleWindow
+  if (typeof w.requestIdleCallback === 'function') {
+    const handle = w.requestIdleCallback(fn, { timeout: timeoutMs })
+    return () => w.cancelIdleCallback?.(handle)
+  }
+  const id = window.setTimeout(fn, FALLBACK_DELAY_MS)
+  return () => window.clearTimeout(id)
+}
+
+/** True on a metered / very slow connection where speculative fetching would
+ *  hurt more than help. Conservative: only bails on explicit data-saver or 2g. */
+function shouldSkipForNetwork(): boolean {
+  const conn = (
+    navigator as unknown as {
+      connection?: { saveData?: boolean; effectiveType?: string }
+    }
+  ).connection
+  if (!conn) return false
+  if (conn.saveData) return true
+  return conn.effectiveType === '2g' || conn.effectiveType === 'slow-2g'
+}
+
+export function useAssetPrefetch(
+  loader: AssetLoader,
+  options: AssetPrefetchOptions = {}
+): { prefetch: (urls: readonly (string | null | undefined)[]) => void } {
+  const { isBusy = () => false, concurrency = 3, idleTimeoutMs = 3000 } = options
+
+  /** How long to wait before re-checking the busy gate, so a sustained
+   *  install/launch doesn't busy-spin the idle queue. */
+  const BUSY_BACKOFF_MS = 1500
+
+  const queue: string[] = []
+  const seen = new Set<string>()
+  const cancellers = new Set<() => void>()
+  const loaderCancellers = new Set<() => void>()
+  // Reserved synchronously as work is scheduled (not when the idle callback
+  // fires), so the pump loop enforces `concurrency` instead of scheduling the
+  // whole queue at once.
+  let inFlight = 0
+  let disposed = false
+
+  function pump(): void {
+    if (disposed || queue.length === 0) return
+    // Important work wins: back off (timer, not idle) and re-check later rather
+    // than competing for the network/CPU now.
+    if (isBusy()) {
+      const id = window.setTimeout(() => {
+        cancellers.delete(cancel)
+        pump()
+      }, BUSY_BACKOFF_MS)
+      const cancel = (): void => window.clearTimeout(id)
+      cancellers.add(cancel)
+      return
+    }
+    while (inFlight < concurrency && queue.length > 0) {
+      const url = queue.shift()!
+      inFlight++
+      const cancel = scheduleIdle(() => {
+        cancellers.delete(cancel)
+        if (!disposed) load(url)
+      }, idleTimeoutMs)
+      cancellers.add(cancel)
+    }
+  }
+
+  function load(url: string): void {
+    let settled = false
+    const done = (): void => {
+      if (settled) return
+      settled = true
+      loaderCancellers.delete(cancel)
+      inFlight--
+      if (!disposed) pump()
+    }
+    const cancel = loader(url, done)
+    loaderCancellers.add(cancel)
+  }
+
+  function prefetch(urls: readonly (string | null | undefined)[]): void {
+    if (disposed || shouldSkipForNetwork()) return
+    for (const url of urls) {
+      if (!url || seen.has(url)) continue
+      seen.add(url)
+      queue.push(url)
+    }
+    pump()
+  }
+
+  onScopeDispose(() => {
+    disposed = true
+    queue.length = 0
+    for (const cancel of cancellers) cancel()
+    cancellers.clear()
+    // Abort still-running warms so their closures can be GC'd without waiting
+    // for the request to settle.
+    for (const cancel of loaderCancellers) cancel()
+    loaderCancellers.clear()
+  })
+
+  return { prefetch }
+}

--- a/src/renderer/src/composables/useAssetPrefetch.ts
+++ b/src/renderer/src/composables/useAssetPrefetch.ts
@@ -93,6 +93,10 @@ export function useAssetPrefetch(
 
   function load(url: string): void {
     let settled = false
+    // Initialised to a no-op so a loader that calls `done` synchronously (before
+    // it returns its real canceller) never hits `cancel` in its temporal dead
+    // zone; the real canceller replaces this once `loader` returns.
+    let cancel: () => void = () => {}
     const done = (): void => {
       if (settled) return
       settled = true
@@ -100,8 +104,9 @@ export function useAssetPrefetch(
       inFlight--
       if (!disposed) pump()
     }
-    const cancel = loader(url, done)
-    loaderCancellers.add(cancel)
+    cancel = loader(url, done)
+    // A synchronous settle already ran `done` above; don't register a stale canceller.
+    if (!settled) loaderCancellers.add(cancel)
   }
 
   function prefetch(urls: readonly (string | null | undefined)[]): void {

--- a/src/renderer/src/composables/useBrandScene.test.ts
+++ b/src/renderer/src/composables/useBrandScene.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, ref } from 'vue'
 import { mount } from '@vue/test-utils'
-import { lerpKf, makeBezier, useBrandScene } from './useBrandScene'
+import { lerpKf, makeBezier, markPaintedWhenReady, useBrandScene } from './useBrandScene'
 import type { BrandScene, Keyframe } from '../lib/brandScene/types'
 
 describe('makeBezier', () => {
@@ -143,5 +143,103 @@ describe('useBrandScene playback gating', () => {
     const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame')
     wrapper.unmount()
     expect(cancelSpy).toHaveBeenCalled()
+  })
+})
+
+// A fake <video> exposing enough surface for markPaintedWhenReady: a class list,
+// an event registry, a settable readyState, and a manually-drained rVFC queue.
+interface FakeVideoEl {
+  classList: { add(c: string): void; remove(c: string): void; contains(c: string): boolean }
+  readyState: number
+  requestVideoFrameCallback?: (cb: () => void) => number
+  addEventListener(ev: string, cb: () => void): void
+  removeEventListener(ev: string, cb: () => void): void
+  emit(ev: string): void
+  isPainted(): boolean
+}
+
+function makeFakeVideo(opts: { rvfc?: boolean } = {}): {
+  el: FakeVideoEl
+  rvfcCallbacks: Array<() => void>
+  listenerCount: () => number
+} {
+  const classes = new Set<string>()
+  const listeners: Record<string, Set<() => void>> = {}
+  const rvfcCallbacks: Array<() => void> = []
+  const el: FakeVideoEl = {
+    classList: {
+      add: (c) => void classes.add(c),
+      remove: (c) => void classes.delete(c),
+      contains: (c) => classes.has(c)
+    },
+    readyState: 0,
+    requestVideoFrameCallback: opts.rvfc
+      ? (cb: () => void) => {
+          rvfcCallbacks.push(cb)
+          return rvfcCallbacks.length
+        }
+      : undefined,
+    addEventListener: (ev, cb) => void (listeners[ev] ??= new Set()).add(cb),
+    removeEventListener: (ev, cb) => void listeners[ev]?.delete(cb),
+    emit: (ev) => {
+      for (const cb of listeners[ev] ?? []) cb()
+    },
+    isPainted: () => classes.has('is-painted')
+  }
+  const listenerCount = (): number => Object.values(listeners).reduce((n, set) => n + set.size, 0)
+  return { el, rvfcCallbacks, listenerCount }
+}
+
+describe('markPaintedWhenReady', () => {
+  it('paints on the rVFC composited frame, not before', () => {
+    const { el, rvfcCallbacks } = makeFakeVideo({ rvfc: true })
+    markPaintedWhenReady(el as unknown as HTMLVideoElement)
+    expect(el.isPainted(), 'no paint until a real frame is composited').toBe(false)
+    rvfcCallbacks[0]!()
+    expect(el.isPainted(), 'the rVFC frame paints the clip').toBe(true)
+  })
+
+  it('re-arms the gate on a loop re-activation so the reveal waits for the new seek', () => {
+    const { el, rvfcCallbacks } = makeFakeVideo({ rvfc: true })
+    markPaintedWhenReady(el as unknown as HTMLVideoElement)
+    rvfcCallbacks[0]!()
+    expect(el.isPainted()).toBe(true)
+
+    // The scene loops: the clip is seeked back and re-activated.
+    markPaintedWhenReady(el as unknown as HTMLVideoElement)
+    expect(el.isPainted(), 'the gate must re-close for the fresh seek, not stay latched').toBe(
+      false
+    )
+    rvfcCallbacks[1]!()
+    expect(el.isPainted(), 'the second frame paints the re-activated clip').toBe(true)
+  })
+
+  it('ignores a stale callback that resolves after a later activation', () => {
+    const { el, rvfcCallbacks } = makeFakeVideo({ rvfc: true })
+    markPaintedWhenReady(el as unknown as HTMLVideoElement) // activation 1 → rvfcCallbacks[0]
+    markPaintedWhenReady(el as unknown as HTMLVideoElement) // activation 2 → rvfcCallbacks[1]
+
+    // The first activation's frame callback fires late, after the re-activation.
+    rvfcCallbacks[0]!()
+    expect(el.isPainted(), "a prior activation's frame must not paint the current seek").toBe(false)
+    rvfcCallbacks[1]!()
+    expect(el.isPainted(), 'the current activation still paints on its own frame').toBe(true)
+  })
+
+  it('fallback path: gates on readyState and does not stack listeners across activations', () => {
+    const { el, listenerCount } = makeFakeVideo({ rvfc: false })
+    markPaintedWhenReady(el as unknown as HTMLVideoElement)
+    el.emit('seeked') // readyState still 0 → not enough data, no paint
+    expect(el.isPainted()).toBe(false)
+
+    const afterFirst = listenerCount()
+    markPaintedWhenReady(el as unknown as HTMLVideoElement) // re-activate
+    expect(listenerCount(), 'the prior activation listeners are torn down, not stacked').toBe(
+      afterFirst
+    )
+
+    el.readyState = 2 /* HAVE_CURRENT_DATA */
+    el.emit('seeked')
+    expect(el.isPainted(), 'paints once the seeked frame has data').toBe(true)
   })
 })

--- a/src/renderer/src/composables/useBrandScene.ts
+++ b/src/renderer/src/composables/useBrandScene.ts
@@ -110,6 +110,42 @@ export function useBrandScene(
   let playing = false
   const reduced = ref(prefersReducedMotion())
 
+  type RvfcVideo = HTMLVideoElement & {
+    requestVideoFrameCallback?: (cb: () => void) => number
+  }
+
+  /** Fade a just-activated clip in only once a decoded frame exists — a clip
+   *  pinned off frame 0 seeks away from the preloaded frame, so revealing sooner
+   *  shows the mask ground. rVFC is authoritative (fires on a composited frame);
+   *  the fallback gates on `readyState >= HAVE_CURRENT_DATA`, never a bare timer.
+   *  Sticky once painted. */
+  function markPaintedWhenReady(ve: HTMLVideoElement): void {
+    if (ve.classList.contains('is-painted')) return
+    const cleanup: Array<() => void> = []
+    let done = false
+    const paint = (): void => {
+      if (done) return
+      done = true
+      ve.classList.add('is-painted')
+      for (const c of cleanup) c()
+    }
+
+    const rvfc = (ve as RvfcVideo).requestVideoFrameCallback
+    if (typeof rvfc === 'function') {
+      rvfc.call(ve, paint)
+      return
+    }
+
+    const tryPaint = (): void => {
+      if (ve.readyState >= 2 /* HAVE_CURRENT_DATA */) paint()
+    }
+    for (const ev of ['seeked', 'loadeddata', 'canplay', 'timeupdate']) {
+      ve.addEventListener(ev, tryPaint)
+      cleanup.push(() => ve.removeEventListener(ev, tryPaint))
+    }
+    tryPaint()
+  }
+
   /** Scale the comp-sized stage to its wrapper (contain fits, cover crops). */
   function fitStage(): void {
     const stage = stageRef.value
@@ -180,6 +216,7 @@ export function useBrandScene(
             /* seek before metadata; corrected on the next active switch */
           }
           ve.classList.add('is-active')
+          markPaintedWhenReady(ve)
           if (playing) void ve.play().catch(() => {})
         }
         s.activeIdx = activeIdx

--- a/src/renderer/src/composables/useBrandScene.ts
+++ b/src/renderer/src/composables/useBrandScene.ts
@@ -84,6 +84,59 @@ const prefersReducedMotion = (): boolean =>
   typeof window.matchMedia === 'function' &&
   window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
+/** Per-clip activation state, stashed on the element so re-activations across a
+ *  loop share it without composable-level bookkeeping. */
+type WatchedVideo = HTMLVideoElement & {
+  __sceneToken?: number
+  __sceneCleanup?: () => void
+}
+type RvfcVideo = HTMLVideoElement & {
+  requestVideoFrameCallback?: (cb: () => void) => number
+}
+
+/** Fade a just-activated clip in only once its seeked frame has decoded — a clip
+ *  pinned off frame 0 seeks away from the preloaded frame, so revealing sooner
+ *  shows the mask ground. rVFC is authoritative (fires on a composited frame);
+ *  the fallback gates on `readyState >= HAVE_CURRENT_DATA`, never a bare timer.
+ *  Re-armed per activation: the gate is cleared and a fresh token minted, so a
+ *  loop re-seek waits for its own frame and a late callback from the prior
+ *  activation is ignored. */
+export function markPaintedWhenReady(ve: HTMLVideoElement): void {
+  const v = ve as WatchedVideo
+  v.__sceneCleanup?.()
+  ve.classList.remove('is-painted')
+  const token = (v.__sceneToken ?? 0) + 1
+  v.__sceneToken = token
+
+  const cleanup: Array<() => void> = []
+  const teardown = (): void => {
+    for (const c of cleanup) c()
+    if (v.__sceneCleanup === teardown) v.__sceneCleanup = undefined
+  }
+  v.__sceneCleanup = teardown
+
+  const paint = (): void => {
+    if (v.__sceneToken !== token) return
+    ve.classList.add('is-painted')
+    teardown()
+  }
+
+  const rvfc = (ve as RvfcVideo).requestVideoFrameCallback
+  if (typeof rvfc === 'function') {
+    rvfc.call(ve, paint)
+    return
+  }
+
+  const tryPaint = (): void => {
+    if (ve.readyState >= 2 /* HAVE_CURRENT_DATA */) paint()
+  }
+  for (const ev of ['seeked', 'loadeddata', 'canplay', 'timeupdate']) {
+    ve.addEventListener(ev, tryPaint)
+    cleanup.push(() => ve.removeEventListener(ev, tryPaint))
+  }
+  tryPaint()
+}
+
 interface BrandSceneOptions {
   fit?: 'contain' | 'cover'
   /** Timeline rate; below 1 slows the loop. */
@@ -109,49 +162,6 @@ export function useBrandScene(
   let rafId = 0
   let playing = false
   const reduced = ref(prefersReducedMotion())
-  // Clips whose first-frame reveal is mid-flight, so a loop re-activation can't
-  // stack a second set of listeners on the same element.
-  const watched = new WeakSet<HTMLVideoElement>()
-
-  type RvfcVideo = HTMLVideoElement & {
-    requestVideoFrameCallback?: (cb: () => void) => number
-  }
-
-  /** Fade a just-activated clip in only once a decoded frame exists — a clip
-   *  pinned off frame 0 seeks away from the preloaded frame, so revealing sooner
-   *  shows the mask ground. rVFC is authoritative (fires on a composited frame);
-   *  the fallback gates on `readyState >= HAVE_CURRENT_DATA`, never a bare timer.
-   *  Sticky once painted. */
-  function markPaintedWhenReady(ve: HTMLVideoElement): void {
-    // Skip if already painted, or already being watched — the scene loops and
-    // re-activates the same clip, which would otherwise stack fallback listeners.
-    if (ve.classList.contains('is-painted') || watched.has(ve)) return
-    watched.add(ve)
-    const cleanup: Array<() => void> = []
-    let done = false
-    const paint = (): void => {
-      if (done) return
-      done = true
-      watched.delete(ve)
-      ve.classList.add('is-painted')
-      for (const c of cleanup) c()
-    }
-
-    const rvfc = (ve as RvfcVideo).requestVideoFrameCallback
-    if (typeof rvfc === 'function') {
-      rvfc.call(ve, paint)
-      return
-    }
-
-    const tryPaint = (): void => {
-      if (ve.readyState >= 2 /* HAVE_CURRENT_DATA */) paint()
-    }
-    for (const ev of ['seeked', 'loadeddata', 'canplay', 'timeupdate']) {
-      ve.addEventListener(ev, tryPaint)
-      cleanup.push(() => ve.removeEventListener(ev, tryPaint))
-    }
-    tryPaint()
-  }
 
   /** Scale the comp-sized stage to its wrapper (contain fits, cover crops). */
   function fitStage(): void {

--- a/src/renderer/src/composables/useBrandScene.ts
+++ b/src/renderer/src/composables/useBrandScene.ts
@@ -109,6 +109,9 @@ export function useBrandScene(
   let rafId = 0
   let playing = false
   const reduced = ref(prefersReducedMotion())
+  // Clips whose first-frame reveal is mid-flight, so a loop re-activation can't
+  // stack a second set of listeners on the same element.
+  const watched = new WeakSet<HTMLVideoElement>()
 
   type RvfcVideo = HTMLVideoElement & {
     requestVideoFrameCallback?: (cb: () => void) => number
@@ -120,12 +123,16 @@ export function useBrandScene(
    *  the fallback gates on `readyState >= HAVE_CURRENT_DATA`, never a bare timer.
    *  Sticky once painted. */
   function markPaintedWhenReady(ve: HTMLVideoElement): void {
-    if (ve.classList.contains('is-painted')) return
+    // Skip if already painted, or already being watched — the scene loops and
+    // re-activates the same clip, which would otherwise stack fallback listeners.
+    if (ve.classList.contains('is-painted') || watched.has(ve)) return
+    watched.add(ve)
     const cleanup: Array<() => void> = []
     let done = false
     const paint = (): void => {
       if (done) return
       done = true
+      watched.delete(ve)
       ve.classList.add('is-painted')
       for (const c of cleanup) c()
     }

--- a/src/renderer/src/composables/useMediaPrefetch.test.ts
+++ b/src/renderer/src/composables/useMediaPrefetch.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+
+import { useMediaPrefetch } from './useMediaPrefetch'
+
+// Drive idle callbacks manually so tests control exactly when a queued warm runs.
+let idleQueue: Array<() => void> = []
+let nextHandle = 1
+
+// Track each warm <video> + its listeners so tests can settle them one at a time.
+interface FakeVideo {
+  src: string
+  listeners: Record<string, Array<() => void>>
+  fireLoaded: () => void
+  loadCalled: boolean
+}
+let videos: FakeVideo[] = []
+
+function makeFakeVideo(): FakeVideo {
+  const listeners: Record<string, Array<() => void>> = {}
+  const el = {
+    muted: false,
+    preload: '',
+    src: '',
+    listeners,
+    loadCalled: false,
+    addEventListener(ev: string, cb: () => void) {
+      ;(listeners[ev] ??= []).push(cb)
+    },
+    removeEventListener(ev: string, cb: () => void) {
+      listeners[ev] = (listeners[ev] ?? []).filter((c) => c !== cb)
+    },
+    removeAttribute() {
+      el.src = ''
+    },
+    load() {
+      el.loadCalled = true
+    },
+    fireLoaded() {
+      for (const cb of listeners['loadeddata'] ?? []) cb()
+    }
+  }
+  return el as unknown as FakeVideo
+}
+
+beforeEach(() => {
+  idleQueue = []
+  nextHandle = 1
+  videos = []
+
+  vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
+    idleQueue.push(cb)
+    return nextHandle++
+  })
+  vi.stubGlobal('cancelIdleCallback', (handle: number) => {
+    idleQueue[handle - 1] = undefined as unknown as () => void
+  })
+  vi.stubGlobal('document', {
+    createElement: (tag: string) => {
+      if (tag !== 'video') throw new Error(`unexpected createElement(${tag})`)
+      const v = makeFakeVideo()
+      videos.push(v)
+      return v
+    }
+  })
+  vi.stubGlobal('navigator', { connection: undefined })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+function flushIdle(): void {
+  const pending = idleQueue
+  idleQueue = []
+  for (const cb of pending) cb?.()
+}
+
+function run<T>(fn: () => T): { result: T; dispose: () => void } {
+  const scope = effectScope()
+  const result = scope.run(fn)!
+  return { result, dispose: () => scope.stop() }
+}
+
+describe('useMediaPrefetch', () => {
+  it('warms each url exactly once, de-duplicating repeats', () => {
+    const { result } = run(() => useMediaPrefetch({ concurrency: 10 }))
+    result.prefetch(['a.mp4', 'b.mp4', 'a.mp4', null, undefined])
+    flushIdle()
+    expect(videos.map((v) => v.src).sort()).toEqual(['a.mp4', 'b.mp4'])
+  })
+
+  it('serialises to one warm at a time by default (large media)', () => {
+    const { result } = run(() => useMediaPrefetch())
+    result.prefetch(['a.mp4', 'b.mp4', 'c.mp4'])
+    flushIdle()
+    expect(videos).toHaveLength(1)
+
+    // Settle the first warm; its `done` pumps the next.
+    videos[0]!.fireLoaded()
+    flushIdle()
+    expect(videos).toHaveLength(2)
+  })
+
+  it('skips warming on a data-saver connection', () => {
+    vi.stubGlobal('navigator', { connection: { saveData: true } })
+    const { result } = run(() => useMediaPrefetch())
+    result.prefetch(['a.mp4'])
+    flushIdle()
+    expect(videos).toHaveLength(0)
+  })
+
+  it('releases the element source on dispose', () => {
+    const { result, dispose } = run(() => useMediaPrefetch())
+    result.prefetch(['a.mp4'])
+    flushIdle()
+    expect(videos).toHaveLength(1)
+    dispose()
+    // Cancel path detaches the source and calls load() so the element is freed.
+    expect(videos[0]!.src).toBe('')
+    expect(videos[0]!.loadCalled).toBe(true)
+  })
+})

--- a/src/renderer/src/composables/useMediaPrefetch.test.ts
+++ b/src/renderer/src/composables/useMediaPrefetch.test.ts
@@ -3,13 +3,13 @@ import { effectScope } from 'vue'
 
 import { useMediaPrefetch } from './useMediaPrefetch'
 
-// Drive idle callbacks manually so tests control exactly when a queued warm runs.
 let idleQueue: Array<() => void> = []
 let nextHandle = 1
 
-// Track each warm <video> + its listeners so tests can settle them one at a time.
 interface FakeVideo {
   src: string
+  muted: boolean
+  preload: string
   listeners: Record<string, Array<() => void>>
   fireLoaded: () => void
   loadCalled: boolean
@@ -88,16 +88,23 @@ describe('useMediaPrefetch', () => {
     expect(videos.map((v) => v.src).sort()).toEqual(['a.mp4', 'b.mp4'])
   })
 
+  it('warms muted with preload=auto so the element buffers without playing', () => {
+    const { result } = run(() => useMediaPrefetch())
+    result.prefetch(['a.mp4'])
+    flushIdle()
+    expect(videos[0]!.muted, 'a warm must not make sound').toBe(true)
+    expect(videos[0]!.preload, 'preload=auto is what fills the cache').toBe('auto')
+  })
+
   it('serialises to one warm at a time by default (large media)', () => {
     const { result } = run(() => useMediaPrefetch())
     result.prefetch(['a.mp4', 'b.mp4', 'c.mp4'])
     flushIdle()
-    expect(videos).toHaveLength(1)
+    expect(videos, 'only one warm in flight at a time').toHaveLength(1)
 
-    // Settle the first warm; its `done` pumps the next.
     videos[0]!.fireLoaded()
     flushIdle()
-    expect(videos).toHaveLength(2)
+    expect(videos, 'settling the first warm pumps the next').toHaveLength(2)
   })
 
   it('skips warming on a data-saver connection', () => {
@@ -114,8 +121,7 @@ describe('useMediaPrefetch', () => {
     flushIdle()
     expect(videos).toHaveLength(1)
     dispose()
-    // Cancel path detaches the source and calls load() so the element is freed.
-    expect(videos[0]!.src).toBe('')
-    expect(videos[0]!.loadCalled).toBe(true)
+    expect(videos[0]!.src, 'dispose detaches the element source').toBe('')
+    expect(videos[0]!.loadCalled, 'dispose calls load() to free the element').toBe(true)
   })
 })

--- a/src/renderer/src/composables/useMediaPrefetch.ts
+++ b/src/renderer/src/composables/useMediaPrefetch.ts
@@ -1,0 +1,45 @@
+import { useAssetPrefetch, type AssetLoader } from './useAssetPrefetch'
+
+/**
+ * Warms media URLs into the browser HTTP cache during idle time so a later
+ * `<video>` plays without a cold fetch. Wraps `useAssetPrefetch` with a
+ * `<video>` loader: a cross-origin `fetch()` is CSP-blocked here, but a media
+ * element load isn't and fills the same cache the modal's `<video>` reuses.
+ */
+
+interface MediaPrefetchOptions {
+  /** Returns true when something more important is running; prefetch defers. */
+  isBusy?: () => boolean
+  /** Max concurrent warms. Media files are large; default 1. */
+  concurrency?: number
+  /** Idle-callback deadline (ms) so a never-idle main thread still drains. */
+  idleTimeoutMs?: number
+}
+
+/** Warm one URL with a detached `<video preload="auto">`; resolve on
+ *  `loadeddata` or `error`, releasing the element either way. */
+const loadMedia: AssetLoader = (url, done) => {
+  const v = document.createElement('video')
+  v.muted = true
+  v.preload = 'auto'
+  v.src = url
+  let settled = false
+  const settle = (): void => {
+    if (settled) return
+    settled = true
+    v.removeEventListener('loadeddata', settle)
+    v.removeEventListener('error', settle)
+    v.removeAttribute('src')
+    v.load()
+    done()
+  }
+  v.addEventListener('loadeddata', settle)
+  v.addEventListener('error', settle)
+  return settle
+}
+
+export function useMediaPrefetch(options: MediaPrefetchOptions = {}): {
+  prefetch: (urls: readonly (string | null | undefined)[]) => void
+} {
+  return useAssetPrefetch(loadMedia, { concurrency: 1, ...options })
+}

--- a/src/renderer/src/composables/useThumbnailPrefetch.ts
+++ b/src/renderer/src/composables/useThumbnailPrefetch.ts
@@ -1,9 +1,9 @@
-import { onScopeDispose } from 'vue'
+import { useAssetPrefetch, type AssetLoader } from './useAssetPrefetch'
 
 /**
  * Warms image URLs into the browser HTTP cache during idle time so a later
- * `<img>` renders instantly; defers entirely while `isBusy()` or on a metered
- * link, so it never competes with real work on a low-spec machine.
+ * `<img>` renders instantly. Thin wrapper over `useAssetPrefetch` with an
+ * `Image()` loader; the queue/idle/busy/network machinery lives in the core.
  */
 
 interface PrefetchOptions {
@@ -15,120 +15,26 @@ interface PrefetchOptions {
   idleTimeoutMs?: number
 }
 
-type IdleHandle = number
-interface IdleWindow {
-  requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => IdleHandle
-  cancelIdleCallback?: (handle: IdleHandle) => void
-}
-
-/** Delay (ms) for the `setTimeout` fallback when `requestIdleCallback` is absent.
- *  A few frames — enough to yield to interactive work without forcing the full
- *  idle deadline (which is a max, not a delay). */
-const FALLBACK_DELAY_MS = 50
-
-/** Schedule on the idle queue, falling back to a low-priority timeout. Returns a
- *  canceller so callers don't branch on which path ran. */
-function scheduleIdle(fn: () => void, timeoutMs: number): () => void {
-  const w = window as unknown as IdleWindow
-  if (typeof w.requestIdleCallback === 'function') {
-    const handle = w.requestIdleCallback(fn, { timeout: timeoutMs })
-    return () => w.cancelIdleCallback?.(handle)
+/** Warm one image; `done` frees the slot on load or error, the canceller
+ *  detaches handlers so a still-loading image's closure can be GC'd. */
+const loadImage: AssetLoader = (url, done) => {
+  const img = new Image()
+  const settle = (): void => {
+    img.onload = null
+    img.onerror = null
+    done()
   }
-  const id = window.setTimeout(fn, FALLBACK_DELAY_MS)
-  return () => window.clearTimeout(id)
-}
-
-/** True on a metered / very slow connection where speculative fetching would
- *  hurt more than help. Conservative: only bails on explicit data-saver or 2g. */
-function shouldSkipForNetwork(): boolean {
-  const conn = (
-    navigator as unknown as {
-      connection?: { saveData?: boolean; effectiveType?: string }
-    }
-  ).connection
-  if (!conn) return false
-  if (conn.saveData) return true
-  return conn.effectiveType === '2g' || conn.effectiveType === 'slow-2g'
+  img.onload = settle
+  img.onerror = settle
+  img.src = url
+  return () => {
+    img.onload = null
+    img.onerror = null
+  }
 }
 
 export function useThumbnailPrefetch(options: PrefetchOptions = {}): {
   prefetch: (urls: readonly (string | null | undefined)[]) => void
 } {
-  const { isBusy = () => false, concurrency = 3, idleTimeoutMs = 3000 } = options
-
-  /** How long to wait before re-checking the busy gate, so a sustained
-   *  install/launch doesn't busy-spin the idle queue. */
-  const BUSY_BACKOFF_MS = 1500
-
-  const queue: string[] = []
-  const seen = new Set<string>()
-  const cancellers = new Set<() => void>()
-  const inFlightImages = new Set<HTMLImageElement>()
-  let inFlight = 0
-  let disposed = false
-
-  function pump(): void {
-    if (disposed || queue.length === 0) return
-    // Important work wins: back off (timer, not idle) and re-check later rather
-    // than competing for the network/CPU now.
-    if (isBusy()) {
-      const id = window.setTimeout(() => {
-        cancellers.delete(cancel)
-        pump()
-      }, BUSY_BACKOFF_MS)
-      const cancel = (): void => window.clearTimeout(id)
-      cancellers.add(cancel)
-      return
-    }
-    while (inFlight < concurrency && queue.length > 0) {
-      const url = queue.shift()!
-      inFlight++
-      const cancel = scheduleIdle(() => {
-        cancellers.delete(cancel)
-        if (!disposed) load(url)
-      }, idleTimeoutMs)
-      cancellers.add(cancel)
-    }
-  }
-
-  function load(url: string): void {
-    const img = new Image()
-    inFlightImages.add(img)
-    const done = (): void => {
-      img.onload = null
-      img.onerror = null
-      inFlightImages.delete(img)
-      inFlight--
-      if (!disposed) pump()
-    }
-    img.onload = done
-    img.onerror = done
-    img.src = url
-  }
-
-  function prefetch(urls: readonly (string | null | undefined)[]): void {
-    if (disposed || shouldSkipForNetwork()) return
-    for (const url of urls) {
-      if (!url || seen.has(url)) continue
-      seen.add(url)
-      queue.push(url)
-    }
-    pump()
-  }
-
-  onScopeDispose(() => {
-    disposed = true
-    queue.length = 0
-    for (const cancel of cancellers) cancel()
-    cancellers.clear()
-    // Detach handlers on still-loading images so their closures can be GC'd
-    // without waiting for the request to settle.
-    for (const img of inFlightImages) {
-      img.onload = null
-      img.onerror = null
-    }
-    inFlightImages.clear()
-  })
-
-  return { prefetch }
+  return useAssetPrefetch(loadImage, options)
 }

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -167,9 +167,8 @@ const { prefetch: prefetchThumbnails } = useThumbnailPrefetch({
   isBusy: () => sessionStore.runningTabCount > 0
 })
 
-// Warm the MCP setup film (a ~5 MB remote video) into cache once, so it isn't
-// black on first open. No `runningTabCount` gate: the modal is only reachable
-// from a running instance, which is exactly when we want it warmed.
+// Warm the ~5 MB MCP film into cache once so it isn't black on first open. No
+// `runningTabCount` gate: the modal is only reachable while an instance runs.
 const { prefetch: prefetchMedia } = useMediaPrefetch()
 let mcpVideoWarmed = false
 function warmMcpVideo(): void {
@@ -370,20 +369,15 @@ function handleMcpOpenTerminal(): void {
   window.api.openInstancePicker({ installationId, initialTab: 'console' })
 }
 
-/** Composite the live ComfyUI canvas through while an overlay panel (feedback
- *  or MCP setup) is mounted. Main holds the panel view hidden until we confirm
- *  the modal has painted (`signalOverlayReady`), so its opaque pre-transparent
- *  frame never flashes over the canvas. */
+/** Make the panel transparent for overlay modes, then tell main to reveal it. */
 watch(
   activePanel,
   (next) => {
     const isOverlay = next === 'feedback' || next === 'mcp-setup'
     document.body.classList.toggle('panel-overlay-mode', isOverlay)
     if (!isOverlay) return
-    // Signal once the modal has mounted (nextTick flushes the DOM). NOT gated on
-    // requestAnimationFrame: the panel view is hidden until main reveals it, and
-    // Chromium pauses rAF for an occluded view, so the callback would never fire
-    // and every open would fall back to main's reveal timeout.
+    // Signal after the modal mounts (nextTick), NOT on rAF: the panel is hidden
+    // and Chromium pauses rAF for an occluded view, so it would never fire.
     void nextTick(() => window.api.signalOverlayReady())
   },
   { immediate: true }
@@ -561,9 +555,7 @@ onMounted(async () => {
     // after a partial-bootstrap failure.
     resolveBootstrap?.()
     resolveBootstrap = null
-    // After bootstrap so it never competes with init; idle-deferred inside the
-    // prefetch. Long cached before the user could reach a running instance's
-    // MCP sidebar.
+    // After bootstrap so it never competes with init (idle-deferred internally).
     warmMcpVideo()
   }
 })

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -39,6 +39,8 @@ import {
   SUCCESS_ACTION_OPEN_INSTANCE
 } from '../lib/progressTerminalPresets'
 import { useThumbnailPrefetch } from '../composables/useThumbnailPrefetch'
+import { useMediaPrefetch } from '../composables/useMediaPrefetch'
+import { MCP_LAUNCH_VIDEO_SRC } from '../views/mcp/McpVideoSources'
 import type { Installation } from '../types/ipc'
 
 const { t } = useI18n()
@@ -164,6 +166,17 @@ const {
 const { prefetch: prefetchThumbnails } = useThumbnailPrefetch({
   isBusy: () => sessionStore.runningTabCount > 0
 })
+
+// Warm the MCP setup film (a ~5 MB remote video) into cache once, so it isn't
+// black on first open. No `runningTabCount` gate: the modal is only reachable
+// from a running instance, which is exactly when we want it warmed.
+const { prefetch: prefetchMedia } = useMediaPrefetch()
+let mcpVideoWarmed = false
+function warmMcpVideo(): void {
+  if (mcpVideoWarmed) return
+  mcpVideoWarmed = true
+  prefetchMedia([MCP_LAUNCH_VIDEO_SRC])
+}
 
 let warmTemplateThumbnailsOnce: Promise<void> | null = null
 function warmTemplateThumbnails(): Promise<void> {
@@ -358,14 +371,20 @@ function handleMcpOpenTerminal(): void {
 }
 
 /** Composite the live ComfyUI canvas through while an overlay panel (feedback
- *  or MCP setup) is mounted. */
+ *  or MCP setup) is mounted. Main holds the panel view hidden until we confirm
+ *  the modal has painted (`signalOverlayReady`), so its opaque pre-transparent
+ *  frame never flashes over the canvas. */
 watch(
   activePanel,
   (next) => {
-    document.body.classList.toggle(
-      'panel-overlay-mode',
-      next === 'feedback' || next === 'mcp-setup'
-    )
+    const isOverlay = next === 'feedback' || next === 'mcp-setup'
+    document.body.classList.toggle('panel-overlay-mode', isOverlay)
+    if (!isOverlay) return
+    // Signal once the modal has mounted (nextTick flushes the DOM). NOT gated on
+    // requestAnimationFrame: the panel view is hidden until main reveals it, and
+    // Chromium pauses rAF for an occluded view, so the callback would never fire
+    // and every open would fall back to main's reveal timeout.
+    void nextTick(() => window.api.signalOverlayReady())
   },
   { immediate: true }
 )
@@ -542,6 +561,10 @@ onMounted(async () => {
     // after a partial-bootstrap failure.
     resolveBootstrap?.()
     resolveBootstrap = null
+    // After bootstrap so it never competes with init; idle-deferred inside the
+    // prefetch. Long cached before the user could reach a running instance's
+    // MCP sidebar.
+    warmMcpVideo()
   }
 })
 

--- a/src/renderer/src/views/mcp/McpSetupModal.vue
+++ b/src/renderer/src/views/mcp/McpSetupModal.vue
@@ -5,6 +5,7 @@ import { emitTelemetryAction } from '../../lib/telemetry'
 import BaseModal from '../../components/ui/BaseModal.vue'
 import BaseCopyButton from '../../components/ui/BaseCopyButton.vue'
 import McpVideoPlayer from './McpVideoPlayer.vue'
+import { MCP_LAUNCH_VIDEO_SRC } from './McpVideoSources'
 
 const emit = defineEmits<{
   close: []
@@ -55,7 +56,7 @@ const AGENTS = [
 ]
 
 const DOCS_URL = 'https://docs.comfy.org/agent-tools/mcp#local-comfy-mcp-connection'
-const VIDEO_SRC = 'https://media.comfy.org/website/mcp/launch-film.mp4'
+const VIDEO_SRC = MCP_LAUNCH_VIDEO_SRC
 
 function selectPath(next: Path): void {
   if (path.value === next) return

--- a/src/renderer/src/views/mcp/McpVideoSources.ts
+++ b/src/renderer/src/views/mcp/McpVideoSources.ts
@@ -1,0 +1,3 @@
+/** The MCP setup how-to film. Shared so the panel can warm it into cache
+ *  during an instance launch, well before the modal that plays it opens. */
+export const MCP_LAUNCH_VIDEO_SRC = 'https://media.comfy.org/website/mcp/launch-film.mp4'

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1177,6 +1177,9 @@ export interface ElectronApi {
    *  the comfy/chooser root. Fire-and-forget; the panel will receive
    *  the resulting `panel-switch` like any other navigation. */
   closeCurrentPanel(): void
+  /** Tell main an overlay panel (feedback / mcp-setup) has painted, so it can
+   *  reveal the until-now-hidden panel view without an opaque flash. */
+  signalOverlayReady(): void
   /** Boot-time restore reveal handshake. The restore window is opened
    *  hidden; the panel calls this once it knows whether its launch
    *  takeover came up (`'takeover-ready'` → reveal the launching surface)


### PR DESCRIPTION
Three fixes to the install-wait loader scene and the MCP setup modal, all around videos going black or the panel flickering on open. Diagnosed on packaged builds (dev doesn't reproduce these) by routing renderer diagnostics to `app.log`; that instrumentation is stripped here.

## Loader scene — black flash on first frame

Clips are pinned to a timeline offset (`st`), so the first render seeks a just-activated clip *away* from its preloaded frame-0 and revealed it in the same synchronous block — the mask's fill showed through until that frame decoded. Now a clip fades in only once a decoded frame actually exists: `requestVideoFrameCallback` (fires on a real composited frame), with a `readyState >= HAVE_CURRENT_DATA` fallback where rVFC is absent. The ~300ms cold decode is irreducible, so the video fades up from a neutral ground instead of a black cut.

## MCP setup modal — black video on first open

The modal streams a ~5 MB remote film, loaded cold on open. It's warmed into cache after panel bootstrap. A cross-origin `fetch()` is CSP-blocked in the renderer, so the warm uses a detached `<video preload="auto">`, which isn't blocked and fills the same HTTP cache the modal's `<video>` reuses. The idle/busy/network queue is extracted into `useAssetPrefetch`, shared by the existing thumbnail warmer (now a thin wrapper) and the new `useMediaPrefetch`.

## MCP / feedback overlay — open/close/open flicker + cold-load delay

Two causes. The panel view was destroyed on attach and rebuilt cold on the first overlay click (~300ms `panel.html` boot showing through) — now it's rebuilt warm and hidden right after attach. And `setActivePanel` made the panel visible before the renderer had painted the modal, flashing its opaque pre-transparent frame over the canvas — now the panel is held hidden until the renderer acks it has painted (`overlay-ready`), with a timeout fallback so it can never strand hidden. Applies to both overlay panels.

## Testing

- `useAssetPrefetch` / `useMediaPrefetch` / `useThumbnailPrefetch` / `useBrandScene` unit tests pass; thumbnail behaviour unchanged by the extraction.
- Verified on packaged builds: loader fades with no black frame; MCP video plays instantly after the first warm; overlay opens with no flicker and no delay (reveal ack lands in single-digit ms).
