### PR TITLE
ci(release): comment ToDesktop build link on the release PR

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -431,3 +431,83 @@ jobs:
           fi
 
           echo "Published ${channel_label} release for ${tag}."
+
+  comment-on-release-pr:
+    needs: build
+    # Post the ToDesktop build page + downloads back onto the version-bump PR
+    # that produced this tag. Runs on success or failure (a link to a failed
+    # build is still useful); skipped only when no build id was produced.
+    if: >
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.build.result != 'skipped' &&
+      needs.build.outputs.build_id != ''
+    runs-on: ubuntu-latest
+    name: Comment build link on release PR
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INPUT_PR: ${{ inputs.pr_number }}
+      BUILD_ID: ${{ needs.build.outputs.build_id }}
+      BUILD_STATUS: ${{ needs.build.outputs.build_status }}
+      MAC_URL: ${{ needs.build.outputs.mac_url }}
+      WIN_URL: ${{ needs.build.outputs.windows_url }}
+      LINUX_URL: ${{ needs.build.outputs.linux_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve release PR and upsert build comment
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          app_id="$(jq -r '.id' todesktop.json)"
+          build_url="https://app.todesktop.com/apps/${app_id}/builds/${BUILD_ID}"
+
+          # Which PR produced this tagged commit?
+          pr="${INPUT_PR:-}"
+          if [[ -z "${pr}" ]]; then
+            pr="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].number' 2>/dev/null || true)"
+          fi
+          if [[ -z "${pr}" || "${pr}" == "null" ]]; then
+            subject="$(git log -1 --format=%s "${GITHUB_SHA}")"
+            pr="$(printf '%s' "${subject}" | grep -oE '#[0-9]+' | head -1 | tr -dc '0-9' || true)"
+          fi
+          if [[ -z "${pr}" ]]; then
+            echo "No PR associated with ${GITHUB_SHA}; nothing to comment on."
+            exit 0
+          fi
+
+          if printf '%s' "${BUILD_STATUS}" | grep -qiE '^(succeeded|success|finished|complete|completed)$'; then
+            icon="✅"
+          else
+            icon="⚠️"
+          fi
+
+          marker="<!-- todesktop-build-comment -->"
+          {
+            printf '%s\n' "${marker}"
+            printf '### %s ToDesktop build for `%s`\n\n' "${icon}" "${tag}"
+            printf '**Status:** %s  \n' "${BUILD_STATUS}"
+            printf '**Build page:** %s\n\n' "${build_url}"
+            printf '**Downloads**\n'
+          } > comment.md
+          have_links=0
+          if [[ -n "${MAC_URL}" ]];   then printf -- '- macOS: %s\n'   "${MAC_URL}"   >> comment.md; have_links=1; fi
+          if [[ -n "${WIN_URL}" ]];   then printf -- '- Windows: %s\n' "${WIN_URL}"   >> comment.md; have_links=1; fi
+          if [[ -n "${LINUX_URL}" ]]; then printf -- '- Linux: %s\n'   "${LINUX_URL}" >> comment.md; have_links=1; fi
+          if [[ "${have_links}" -eq 0 ]]; then printf '_No per-platform download links reported._\n' >> comment.md; fi
+
+          # Upsert: update our previous comment (matched by marker) or create a new one.
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" 2>/dev/null | head -1 || true)"
+          if [[ -n "${existing}" && "${existing}" != "null" ]]; then
+            jq -Rs '{body: .}' comment.md | gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" --input - >/dev/null
+            echo "Updated build comment on PR #${pr}."
+          else
+            jq -Rs '{body: .}' comment.md | gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --input - >/dev/null
+            echo "Posted build comment on PR #${pr}."
+          fi


### PR DESCRIPTION
## Summary

After a tag triggers `ToDesktop Build & Release`, auto-post (and keep updated) a comment on the **version-bump PR that produced the tag**, with the ToDesktop build page and per-platform download links.

## What it does

New job `comment-on-release-pr` (`needs: build`):
- **Finds the PR** that produced the tagged commit — `inputs.pr_number` if dispatched with one, else `GET /repos/{repo}/commits/{sha}/pulls`, else a `(#N)` fallback parsed from the merge/squash commit subject.
- **Upserts a comment** (hidden `<!-- todesktop-build-comment -->` marker → updates in place on re-runs instead of stacking duplicates) containing: status, **Build page** `https://app.todesktop.com/apps/<appId>/builds/<buildId>`, and macOS / Windows / Linux download links.
- Reuses the existing `build` job outputs (`build_id`, `mac_url`, `windows_url`, `linux_url`, `build_status`) — no new ToDesktop calls.
- Runs on build **success or failure** (a link to a failed build is still useful); skipped when no `build_id` was produced.
- Scoped `permissions: pull-requests: write` on this job only (workflow-level perms unchanged).

## Notes / follow-up

- The download links come straight from the current build-job outputs; if those are empty (the `extract` step regex-parses the CLI's human-readable text), the comment degrades gracefully to "no per-platform download links reported." Switching that step to `todesktop builds <id> --format json` would populate `.mac/.windows/.linux` properly — separate, optional follow-up to keep this PR single-purpose.
