### PR TITLE
feat(announcement): add commercial-license bullet to the MiniMax H3 modal

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -698,9 +698,9 @@
       "lead": "MiniMax's latest open source, SOTA video model, available now",
       "highlights": [
         "Run for free on Comfy Cloud or Comfy Desktop",
-        "Works with your existing ComfyUI workflows"
+        "Works with your existing ComfyUI workflows",
+        "Want to use it commercially? Reach out to get a license"
       ],
-      "personalFree": "Free for personal use",
       "requestLicenseCta": "Request License",
       "learnMoreCta": "Learn More",
       "imageAlt": "MiniMax H3 announcement",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -698,9 +698,9 @@
       "lead": "MiniMax \u6700\u65b0\u7684\u5f00\u6e90 SOTA \u89c6\u9891\u6a21\u578b\uff0c\u73b0\u5df2\u4e0a\u7ebf",
       "highlights": [
         "\u5728 Comfy Cloud \u6216 Comfy Desktop \u4e0a\u514d\u8d39\u8fd0\u884c",
-        "\u517c\u5bb9\u4f60\u73b0\u6709\u7684 ComfyUI \u5de5\u4f5c\u6d41"
+        "\u517c\u5bb9\u4f60\u73b0\u6709\u7684 ComfyUI \u5de5\u4f5c\u6d41",
+        "\u60f3\u7528\u4e8e\u5546\u4e1a\u7528\u9014\uff1f\u8054\u7cfb\u6211\u4eec\u83b7\u53d6\u6388\u6743"
       ],
-      "personalFree": "\u4e2a\u4eba\u4f7f\u7528\u514d\u8d39",
       "requestLicenseCta": "\u7533\u8bf7\u6388\u6743",
       "learnMoreCta": "\u4e86\u89e3\u66f4\u591a",
       "imageAlt": "MiniMax H3 \u516c\u544a",

--- a/src/renderer/src/components/AnnouncementModal.vue
+++ b/src/renderer/src/components/AnnouncementModal.vue
@@ -152,25 +152,22 @@ onUnmounted(() => {
                 </ul>
               </div>
               <footer class="announce-footer">
-                <p class="announce-note">{{ $t('announcement.minimax.personalFree') }}</p>
-                <div class="announce-actions">
-                  <button
-                    class="brand-ghost"
-                    type="button"
-                    data-testid="announcement-learn-more"
-                    @click="openCta('learn_more', LEARN_MORE_URL)"
-                  >
-                    {{ $t('announcement.minimax.learnMoreCta') }}
-                  </button>
-                  <button
-                    class="brand-primary"
-                    type="button"
-                    data-testid="announcement-request-license"
-                    @click="openCta('request_license', REQUEST_LICENSE_URL)"
-                  >
-                    {{ $t('announcement.minimax.requestLicenseCta') }}
-                  </button>
-                </div>
+                <button
+                  class="brand-ghost"
+                  type="button"
+                  data-testid="announcement-learn-more"
+                  @click="openCta('learn_more', LEARN_MORE_URL)"
+                >
+                  {{ $t('announcement.minimax.learnMoreCta') }}
+                </button>
+                <button
+                  class="brand-primary"
+                  type="button"
+                  data-testid="announcement-request-license"
+                  @click="openCta('request_license', REQUEST_LICENSE_URL)"
+                >
+                  {{ $t('announcement.minimax.requestLicenseCta') }}
+                </button>
               </footer>
             </div>
           </div>
@@ -362,24 +359,10 @@ onUnmounted(() => {
 
 .announce-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-  flex-wrap: wrap;
   gap: 16px;
   padding-top: clamp(1rem, 1.5vw, 1.5rem);
   border-top: 1px solid color-mix(in oklab, var(--neutral-100) 8%, transparent);
-}
-.announce-note {
-  margin: 0;
-  font-size: var(--takeover-fs-caption);
-  color: var(--neutral-300);
-  font-family: var(--font-sans);
-  line-height: 1.4;
-}
-.announce-actions {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-left: auto;
 }
 </style>


### PR DESCRIPTION
Follow-up to #1467 (merged). Adds a third highlight to the MiniMax H3 announcement modal — "Want to use it commercially? Reach out to get a license" — and removes the separate personal-use footer note, keeping the Learn More + Request License CTAs (both carry the Desktop-origin UTM).