### PR TITLE
feat(updater): correlate update telemetry across launches

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2242,7 +2242,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         app.removeListener('before-quit', onUpdateInstallQuit)
         clearQuitReason()
         if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
-        mainTelemetry.emit('comfy.desktop.app_update.startup_install_backstop_recovered', {})
+        updater.recordStartupInstallBackstopRecovered()
         void openStartupSurface()
         hostReentryGate.open()
       }, STARTUP_INSTALL_QUIT_BACKSTOP_MS)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2360,6 +2360,7 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         tray = null
       }
     }
+    updater.recordProcessExit()
     if (_stopPeriodicReleaseChecks) {
       _stopPeriodicReleaseChecks()
       _stopPeriodicReleaseChecks = null

--- a/src/main/lib/startup-attempt-marker.test.ts
+++ b/src/main/lib/startup-attempt-marker.test.ts
@@ -5,7 +5,8 @@ import path from 'path'
 import {
   clearStartupAttemptMarker,
   readStartupAttemptMarker,
-  recordStartupAttempt
+  recordStartupAttempt,
+  recordStartupAttemptOutcome
 } from './startup-attempt-marker'
 
 /**
@@ -42,9 +43,12 @@ describe('startup attempt marker', () => {
   })
 
   it('records, reads back, and clears a marker', () => {
-    expect(recordStartupAttempt('1.0.35')).toBe(true)
+    expect(recordStartupAttempt('1.0.35', 'attempt-35')).toBe(true)
     const read = readStartupAttemptMarker()
-    expect(read).toMatchObject({ state: 'present', marker: { version: '1.0.35' } })
+    expect(read).toMatchObject({
+      state: 'present',
+      marker: { version: '1.0.35', attemptId: 'attempt-35' }
+    })
     expect(read.state === 'present' && read.marker.attemptedAt).toBeTruthy()
 
     clearStartupAttemptMarker()
@@ -53,10 +57,31 @@ describe('startup attempt marker', () => {
   })
 
   it('overwrites a previous marker with the new version', () => {
-    expect(recordStartupAttempt('1.0.34')).toBe(true)
-    expect(recordStartupAttempt('1.0.35')).toBe(true)
+    expect(recordStartupAttempt('1.0.34', 'attempt-34')).toBe(true)
+    expect(recordStartupAttempt('1.0.35', 'attempt-35')).toBe(true)
     const read = readStartupAttemptMarker()
-    expect(read).toMatchObject({ state: 'present', marker: { version: '1.0.35' } })
+    expect(read).toMatchObject({
+      state: 'present',
+      marker: { version: '1.0.35', attemptId: 'attempt-35' }
+    })
+  })
+
+  it('records an emitted outcome without removing the loop-breaker', () => {
+    expect(recordStartupAttempt('1.0.35', 'attempt-35')).toBe(true)
+    const read = readStartupAttemptMarker()
+    expect(read.state).toBe('present')
+    if (read.state !== 'present') return
+
+    recordStartupAttemptOutcome(read.marker, 'still_pending')
+
+    expect(readStartupAttemptMarker()).toMatchObject({
+      state: 'present',
+      marker: {
+        version: '1.0.35',
+        attemptId: 'attempt-35',
+        reportedOutcome: 'still_pending'
+      }
+    })
   })
 
   it('treats a corrupt marker file as absent instead of throwing', () => {
@@ -96,7 +121,7 @@ describe('startup attempt marker', () => {
     // not enough); the caller must treat this as "do not install".
     mockConfigDir = path.join(dir, 'blocker')
     fs.writeFileSync(mockConfigDir, 'not a directory')
-    expect(recordStartupAttempt('1.0.35')).toBe(false)
+    expect(recordStartupAttempt('1.0.35', 'attempt-35')).toBe(false)
   })
 
   it('returns false when the marker writes but cannot be read back (fail closed)', () => {
@@ -116,7 +141,7 @@ describe('startup attempt marker', () => {
       return realRead(p, opts as BufferEncoding)
     }) as typeof fs.readFileSync)
 
-    expect(recordStartupAttempt('1.0.35')).toBe(false)
+    expect(recordStartupAttempt('1.0.35', 'attempt-35')).toBe(false)
     vi.restoreAllMocks()
     // The write itself landed; only the read-back verification failed.
     expect(fs.existsSync(markerFile())).toBe(true)

--- a/src/main/lib/startup-attempt-marker.ts
+++ b/src/main/lib/startup-attempt-marker.ts
@@ -23,6 +23,8 @@ import { readFileWithRetrySync, writeFileSafe } from './safe-file'
 export interface StartupAttemptMarker {
   version: string
   attemptedAt: string
+  attemptId?: string
+  reportedOutcome?: string
 }
 
 export type StartupAttemptMarkerRead =
@@ -50,7 +52,13 @@ export function readStartupAttemptMarker(): StartupAttemptMarkerRead {
         state: 'present',
         marker: {
           version: marker.version,
-          attemptedAt: typeof marker.attemptedAt === 'string' ? marker.attemptedAt : ''
+          attemptedAt: typeof marker.attemptedAt === 'string' ? marker.attemptedAt : '',
+          ...(typeof marker.attemptId === 'string' && marker.attemptId
+            ? { attemptId: marker.attemptId }
+            : {}),
+          ...(typeof marker.reportedOutcome === 'string' && marker.reportedOutcome
+            ? { reportedOutcome: marker.reportedOutcome }
+            : {})
         }
       }
     }
@@ -62,22 +70,40 @@ export function readStartupAttemptMarker(): StartupAttemptMarkerRead {
 
 /**
  * Record that a startup install of `version` is about to run, and verify the
- * marker actually landed on disk. The write is durable (fsynced before the
- * rename publishes it) so the machine rebooting into the installer - or losing
- * power mid-update - cannot roll it back out of the OS write cache. Returns
- * false when it could not be persisted or the read-back does not match - the
- * caller must then NOT install, because a marker that only lives in memory
- * cannot break the reinstall loop.
+ * marker actually landed on disk. `attemptId` keeps telemetry correlated when
+ * settings.json is unavailable or restored from backup. The write is durable
+ * (fsynced before the rename publishes it) so the machine rebooting into the
+ * installer - or losing power mid-update - cannot roll it back out of the OS
+ * write cache. Returns false when it could not be persisted or the read-back
+ * does not match - the caller must then NOT install, because a marker that only
+ * lives in memory cannot break the reinstall loop.
  */
-export function recordStartupAttempt(version: string): boolean {
-  const marker: StartupAttemptMarker = { version, attemptedAt: new Date().toISOString() }
+export function recordStartupAttempt(version: string, attemptId: string): boolean {
+  const marker: StartupAttemptMarker = {
+    version,
+    attemptedAt: new Date().toISOString(),
+    attemptId
+  }
   try {
     writeFileSafe(markerPath(), JSON.stringify(marker, null, 2), { durable: true })
   } catch {
     return false
   }
   const readBack = readStartupAttemptMarker()
-  return readBack.state === 'present' && readBack.marker.version === version
+  return (
+    readBack.state === 'present' &&
+    readBack.marker.version === version &&
+    readBack.marker.attemptId === attemptId
+  )
+}
+
+/** Persist the latest emitted status without removing the loop-breaker. */
+export function recordStartupAttemptOutcome(marker: StartupAttemptMarker, outcome: string): void {
+  try {
+    writeFileSafe(markerPath(), JSON.stringify({ ...marker, reportedOutcome: outcome }, null, 2), {
+      durable: true
+    })
+  } catch {}
 }
 
 export function clearStartupAttemptMarker(): void {

--- a/src/main/lib/telemetry.ts
+++ b/src/main/lib/telemetry.ts
@@ -292,7 +292,7 @@ export function asDeployment(value: unknown): Deployment | null {
  * `unknown` rather than silently being misclassified). Mirrors the
  * renderer's `deriveAppChannel` so both surfaces agree.
  */
-function deriveAppChannel(appVersion: string): string {
+export function deriveAppChannel(appVersion: string): string {
   if (!appVersion) return 'unknown'
   const v = appVersion.toLowerCase()
   if (v.includes('-beta')) return 'beta'

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -17,7 +17,8 @@ vi.mock('electron', () => ({
       return ''
     },
     getVersion: () => mockAppVersion,
-    releaseSingleInstanceLock: vi.fn()
+    releaseSingleInstanceLock: vi.fn(),
+    once: vi.fn()
   },
   ipcMain: {
     handle: vi.fn()
@@ -375,6 +376,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     vi.doMock('./quit-state', () => ({
       clearQuitReason: vi.fn(),
       setQuitReason: vi.fn(),
+      getQuitReason: vi.fn(() => 'none'),
       isSessionEnding: vi.fn(() => sessionEnding)
     }))
     vi.doMock('../settings', () => ({
@@ -684,6 +686,83 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(installs[0]?.[1]).toMatchObject({
       version: '1.0.1',
       bakFallbacks: expect.any(Number)
+    })
+  })
+
+  it('correlates updater transitions with one privacy-safe attempt id and release context', async () => {
+    await bootUpdater()
+    for (const cb of listeners['update-available'] || []) cb({ version: '1.0.1' })
+    for (const cb of listeners['update-downloaded'] || []) cb({ version: '1.0.1' })
+
+    const available = findEmitCalls('comfy.desktop.app_update.available')[0]?.[1] as Record<
+      string,
+      unknown
+    >
+    const complete = findEmitCalls('comfy.desktop.app_update.download_complete')[0]?.[1]
+    expect(available).toMatchObject({
+      running_version: '1.0.0',
+      target_version: '1.0.1',
+      app_channel: 'stable',
+      platform: 'win32',
+      updater_provider: 'todesktop',
+      updater_mode: 'packaged',
+      update_attempt_id: expect.any(String)
+    })
+    expect(complete).toMatchObject({ update_attempt_id: available.update_attempt_id })
+  })
+
+  it('emits the staged-update startup decision with marker and updater state', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = null
+    const updater = await bootUpdater()
+    vi.useFakeTimers()
+    try {
+      const pending = updater.applyPendingUpdateOnStartup()
+      await vi.advanceTimersByTimeAsync(5100)
+      await pending
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(findEmitCalls('comfy.desktop.app_update.startup_decision')[0]?.[1]).toMatchObject({
+      decision: 'install',
+      reason: 'ready_check',
+      pending_version: '1.0.1',
+      updater_state: 'unknown',
+      marker_state: 'absent',
+      update_attempt_id: expect.any(String)
+    })
+  })
+
+  it('reports a previous startup attempt terminal outcome once on the next launch', async () => {
+    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
+    settingsStore['lastStartupUpdateAttemptId'] = 'attempt-1'
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    const updater = await bootUpdater()
+
+    await updater.applyPendingUpdateOnStartup()
+    await updater.applyPendingUpdateOnStartup()
+
+    const outcomes = findEmitCalls('comfy.desktop.app_update.previous_attempt_outcome')
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]?.[1]).toMatchObject({
+      update_attempt_id: 'attempt-1',
+      target_version: '1.0.1',
+      outcome: 'still_pending'
+    })
+  })
+
+  it('classifies an old-version relaunch with no staged target as rolled back', async () => {
+    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
+    settingsStore['lastStartupUpdateAttemptId'] = 'attempt-rollback'
+    const updater = await bootUpdater()
+
+    await updater.applyPendingUpdateOnStartup()
+
+    expect(
+      findEmitCalls('comfy.desktop.app_update.previous_attempt_outcome')[0]?.[1]
+    ).toMatchObject({
+      update_attempt_id: 'attempt-rollback',
+      outcome: 'rolled_back'
     })
   })
 

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -789,7 +789,8 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       pending_version: '1.0.1',
       updater_state: 'unknown',
       marker_state: 'absent',
-      update_attempt_id: expect.any(String)
+      update_attempt_id: expect.any(String),
+      bakFallbacks: expect.any(Number)
     })
   })
 
@@ -810,7 +811,8 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(outcomes[0]?.[1]).toMatchObject({
       update_attempt_id: 'attempt-1',
       target_version: '1.0.1',
-      outcome: 'still_pending'
+      outcome: 'still_pending',
+      bakFallbacks: expect.any(Number)
     })
     const correlatedEvents = [
       ...outcomes,

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -812,6 +812,16 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       target_version: '1.0.1',
       outcome: 'still_pending'
     })
+    const correlatedEvents = [
+      ...outcomes,
+      ...findEmitCalls('comfy.desktop.app_update.startup_decision'),
+      ...findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    ]
+    expect(
+      new Set(
+        correlatedEvents.map((call) => (call[1] as Record<string, unknown>).update_attempt_id)
+      )
+    ).toEqual(new Set(['attempt-1']))
   })
 
   it('reports when an old-version relaunch lost its staged-update marker', async () => {

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -60,6 +60,7 @@ let sidecarMarker: {
 } | null = null
 let sidecarPersists = true
 let sidecarReadable = true
+let sidecarClears = true
 
 vi.mock('./startup-attempt-marker', () => ({
   readStartupAttemptMarker: vi.fn(() => {
@@ -80,7 +81,7 @@ vi.mock('./startup-attempt-marker', () => ({
     }
   ),
   clearStartupAttemptMarker: vi.fn(() => {
-    sidecarMarker = null
+    if (sidecarClears) sidecarMarker = null
   })
 }))
 
@@ -361,6 +362,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     sidecarMarker = null
     sidecarPersists = true
     sidecarReadable = true
+    sidecarClears = true
     mockAppVersion = '1.0.0'
     delete process.env.E2E
     // Non-system, non-darwin platform so isSystemPackageInstall() is false and
@@ -855,6 +857,28 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(sidecarMarker).toBeNull()
   })
 
+  it('does not repeat installed when marker deletion fails', async () => {
+    sidecarMarker = {
+      version: '1.0.1',
+      attemptedAt: new Date().toISOString(),
+      attemptId: 'attempt-installed'
+    }
+    sidecarClears = false
+    mockAppVersion = '1.0.1'
+    const updater = await bootUpdater()
+
+    await updater.applyPendingUpdateOnStartup()
+    await updater.applyPendingUpdateOnStartup()
+
+    const outcomes = findEmitCalls('comfy.desktop.app_update.previous_attempt_outcome')
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]?.[1]).toMatchObject({
+      update_attempt_id: 'attempt-installed',
+      outcome: 'installed'
+    })
+    expect(sidecarMarker).toMatchObject({ reportedOutcome: 'installed' })
+  })
+
   it('applyPendingUpdateOnStartup() holds the install until the splash minimum elapses', async () => {
     vi.useFakeTimers()
     try {
@@ -1084,6 +1108,7 @@ describe('version guard: reject non-newer offers (issue #1161)', () => {
     sidecarMarker = null
     sidecarPersists = true
     sidecarReadable = true
+    sidecarClears = true
     mockAppVersion = '1.0.24'
     fakeUpdater = {
       on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -17,8 +17,7 @@ vi.mock('electron', () => ({
       return ''
     },
     getVersion: () => mockAppVersion,
-    releaseSingleInstanceLock: vi.fn(),
-    once: vi.fn()
+    releaseSingleInstanceLock: vi.fn()
   },
   ipcMain: {
     handle: vi.fn()
@@ -44,6 +43,7 @@ vi.mock('../settings', () => ({
 vi.mock('./quit-state', () => ({
   clearQuitReason: vi.fn(),
   setQuitReason: vi.fn(),
+  getQuitReason: vi.fn(() => 'none'),
   isSessionEnding: vi.fn(() => false)
 }))
 
@@ -52,7 +52,12 @@ vi.mock('./quit-state', () => ({
 // resolves to '' here; an in-memory store keeps these suites hermetic while
 // letting tests seed a marker, make it unreadable, or force persistence
 // failure.
-let sidecarMarker: { version: string; attemptedAt: string } | null = null
+let sidecarMarker: {
+  version: string
+  attemptedAt: string
+  attemptId?: string
+  reportedOutcome?: string
+} | null = null
 let sidecarPersists = true
 let sidecarReadable = true
 
@@ -61,11 +66,19 @@ vi.mock('./startup-attempt-marker', () => ({
     if (!sidecarReadable) return { state: 'unavailable' }
     return sidecarMarker ? { state: 'present', marker: sidecarMarker } : { state: 'absent' }
   }),
-  recordStartupAttempt: vi.fn((version: string) => {
+  recordStartupAttempt: vi.fn((version: string, attemptId?: string) => {
     if (!sidecarPersists) return false
-    sidecarMarker = { version, attemptedAt: new Date().toISOString() }
+    sidecarMarker = { version, attemptedAt: new Date().toISOString(), attemptId }
     return true
   }),
+  recordStartupAttemptOutcome: vi.fn(
+    (
+      marker: { version: string; attemptedAt: string; attemptId?: string },
+      reportedOutcome: string
+    ) => {
+      sidecarMarker = { ...marker, reportedOutcome }
+    }
+  ),
   clearStartupAttemptMarker: vi.fn(() => {
     sidecarMarker = null
   })
@@ -202,7 +215,8 @@ describe('app-update telemetry dedup (volume regression)', () => {
     vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
     vi.doMock('./telemetry', () => ({
       emit: emitTelemetryMock,
-      bucketError: (s: string) => s
+      bucketError: (s: string) => s,
+      deriveAppChannel: () => 'stable'
     }))
     vi.doMock('../settings', () => ({
       get: vi.fn((key: string) => (key === 'autoInstallUpdates' ? isAutoInstallOn : undefined))
@@ -331,6 +345,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   let emitMock: ReturnType<typeof vi.fn>
   let sessionEnding: boolean
   let readyVersion: string | null
+  let quitReason: 'none' | 'user-quit' | 'update-install'
 
   const originalPlat = Object.getOwnPropertyDescriptor(process, 'platform')!
 
@@ -342,6 +357,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     listeners = {}
     sessionEnding = false
     readyVersion = null
+    quitReason = 'none'
     sidecarMarker = null
     sidecarPersists = true
     sidecarReadable = true
@@ -372,11 +388,15 @@ describe('startup update install + session-end guard (issue #1065)', () => {
 
     vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
     vi.doMock('electron-updater', () => ({ autoUpdater: electronUpdaterMock }))
-    vi.doMock('./telemetry', () => ({ emit: emitMock, bucketError: (s: string) => s }))
+    vi.doMock('./telemetry', () => ({
+      emit: emitMock,
+      bucketError: (s: string) => s,
+      deriveAppChannel: () => 'stable'
+    }))
     vi.doMock('./quit-state', () => ({
       clearQuitReason: vi.fn(),
       setQuitReason: vi.fn(),
-      getQuitReason: vi.fn(() => 'none'),
+      getQuitReason: vi.fn(() => quitReason),
       isSessionEnding: vi.fn(() => sessionEnding)
     }))
     vi.doMock('../settings', () => ({
@@ -685,8 +705,12 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(installs).toHaveLength(1)
     expect(installs[0]?.[1]).toMatchObject({
       version: '1.0.1',
-      bakFallbacks: expect.any(Number)
+      bakFallbacks: expect.any(Number),
+      update_attempt_id: expect.any(String)
     })
+    expect(sidecarMarker?.attemptId).toBe(
+      (installs[0]?.[1] as Record<string, unknown>).update_attempt_id
+    )
   })
 
   it('correlates updater transitions with one privacy-safe attempt id and release context', async () => {
@@ -711,6 +735,40 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(complete).toMatchObject({ update_attempt_id: available.update_attempt_id })
   })
 
+  it('keeps one attempt id in memory when settings writes are declined', async () => {
+    const settings = await import('../settings')
+    vi.mocked(settings.set).mockImplementation(() => {})
+    await bootUpdater()
+    for (const cb of listeners['update-available'] || []) cb({ version: '1.0.1' })
+    for (const cb of listeners['update-downloaded'] || []) cb({ version: '1.0.1' })
+
+    const available = findEmitCalls('comfy.desktop.app_update.available')[0]?.[1] as Record<
+      string,
+      unknown
+    >
+    expect(findEmitCalls('comfy.desktop.app_update.download_complete')[0]?.[1]).toMatchObject({
+      update_attempt_id: available.update_attempt_id
+    })
+  })
+
+  it('records the accepted quit once with the final quit reason', async () => {
+    const updater = await bootUpdater()
+    for (const cb of listeners['update-downloaded'] || []) cb({ version: '1.0.1' })
+    quitReason = 'user-quit'
+
+    updater.recordProcessExit()
+    updater.recordProcessExit()
+
+    const exits = findEmitCalls('comfy.desktop.app_update.process_exit')
+    expect(exits).toHaveLength(1)
+    expect(exits[0]?.[1]).toMatchObject({
+      target_version: '1.0.1',
+      quit_reason: 'user-quit',
+      download_in_progress: false,
+      update_attempt_id: expect.any(String)
+    })
+  })
+
   it('emits the staged-update startup decision with marker and updater state', async () => {
     settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
     readyVersion = null
@@ -733,9 +791,12 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     })
   })
 
-  it('reports a previous startup attempt terminal outcome once on the next launch', async () => {
-    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
-    settingsStore['lastStartupUpdateAttemptId'] = 'attempt-1'
+  it('reports a previous startup status once per launch', async () => {
+    sidecarMarker = {
+      version: '1.0.1',
+      attemptedAt: new Date().toISOString(),
+      attemptId: 'attempt-1'
+    }
     settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
     const updater = await bootUpdater()
 
@@ -751,9 +812,12 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     })
   })
 
-  it('classifies an old-version relaunch with no staged target as rolled back', async () => {
-    settingsStore['lastStartupUpdateAttemptVersion'] = '1.0.1'
-    settingsStore['lastStartupUpdateAttemptId'] = 'attempt-rollback'
+  it('reports when an old-version relaunch lost its staged-update marker', async () => {
+    sidecarMarker = {
+      version: '1.0.1',
+      attemptedAt: new Date().toISOString(),
+      attemptId: 'attempt-rollback'
+    }
     const updater = await bootUpdater()
 
     await updater.applyPendingUpdateOnStartup()
@@ -762,8 +826,33 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       findEmitCalls('comfy.desktop.app_update.previous_attempt_outcome')[0]?.[1]
     ).toMatchObject({
       update_attempt_id: 'attempt-rollback',
-      outcome: 'rolled_back'
+      outcome: 'staged_marker_missing'
     })
+  })
+
+  it('reports installed after an earlier still-pending observation', async () => {
+    sidecarMarker = {
+      version: '1.0.1',
+      attemptedAt: new Date().toISOString(),
+      attemptId: 'attempt-recovered'
+    }
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    settingsStore['pendingDesktopUpdateAttemptId'] = 'attempt-recovered'
+    settingsStore['pendingDesktopUpdateAttemptVersion'] = '1.0.1'
+    const updater = await bootUpdater()
+
+    await updater.applyPendingUpdateOnStartup()
+    mockAppVersion = '1.0.1'
+    await updater.applyPendingUpdateOnStartup()
+
+    const outcomes = findEmitCalls('comfy.desktop.app_update.previous_attempt_outcome')
+    expect(outcomes.map((call) => (call[1] as Record<string, unknown>).outcome)).toEqual([
+      'still_pending',
+      'installed'
+    ])
+    expect(outcomes[1]?.[1]).toMatchObject({ update_attempt_id: 'attempt-recovered' })
+    expect(settingsStore['pendingDesktopUpdateAttemptId']).toBeUndefined()
+    expect(sidecarMarker).toBeNull()
   })
 
   it('applyPendingUpdateOnStartup() holds the install until the splash minimum elapses', async () => {
@@ -1004,7 +1093,11 @@ describe('version guard: reject non-newer offers (issue #1161)', () => {
       checkForUpdates: vi.fn(async () => ({ updateInfo: null }))
     }
     vi.doMock('@todesktop/runtime', () => ({ default: { autoUpdater: fakeUpdater } }))
-    vi.doMock('./telemetry', () => ({ emit: emitMock, bucketError: (s: string) => s }))
+    vi.doMock('./telemetry', () => ({
+      emit: emitMock,
+      bucketError: (s: string) => s,
+      deriveAppChannel: () => 'stable'
+    }))
     vi.doMock('../settings', () => ({
       get: vi.fn((key: string) =>
         key === 'autoInstallUpdates' ? (settingsStore[key] ?? true) : settingsStore[key]

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -999,6 +999,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   if (sidecar.state === 'present' && sidecar.marker.attemptId) {
     const previousAttemptId = sidecar.marker.attemptId
     const previousAttemptVersion = sidecar.marker.version
+    _updateAttempt = { id: previousAttemptId, version: previousAttemptVersion }
     const outcome = !isStrictlyNewerVersion(previousAttemptVersion, running)
       ? 'installed'
       : pendingVersion === previousAttemptVersion

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -10,11 +10,12 @@ import {
   clearStartupAttemptMarker,
   readStartupAttemptMarker,
   recordStartupAttempt,
+  recordStartupAttemptOutcome,
   type StartupAttemptMarkerRead
 } from './startup-attempt-marker'
 import { clearQuitReason, getQuitReason, isSessionEnding, setQuitReason } from './quit-state'
 import { _broadcastToRenderer } from './ipc/shared'
-import { emit as emitTelemetry } from './telemetry'
+import { deriveAppChannel, emit as emitTelemetry } from './telemetry'
 import { buildErrorFields, errorTail } from '../../shared/errorEvent'
 
 /**
@@ -85,12 +86,24 @@ let _userInitiatedDownload = false
 const _stateChangeCallbacks = new Set<(state: AppUpdateState) => void>()
 let _listenersBound = false
 
+interface UpdateAttempt {
+  id: string
+  version: string
+}
+
+let _updateAttempt: UpdateAttempt | null = null
+
 function updateAttemptId(targetVersion: string | null, create = false): string | null {
+  if (_updateAttempt?.version === targetVersion) return _updateAttempt.id
   const existing = settings.get('pendingDesktopUpdateAttemptId')
   const existingVersion = settings.get('pendingDesktopUpdateAttemptVersion')
-  if (typeof existing === 'string' && existing && existingVersion === targetVersion) return existing
+  if (typeof existing === 'string' && existing && existingVersion === targetVersion) {
+    _updateAttempt = { id: existing, version: targetVersion }
+    return existing
+  }
   if (!create || !targetVersion) return null
   const id = randomUUID()
+  _updateAttempt = { id, version: targetVersion }
   try {
     settings.set('pendingDesktopUpdateAttemptId', id)
     settings.set('pendingDesktopUpdateAttemptVersion', targetVersion)
@@ -98,15 +111,16 @@ function updateAttemptId(targetVersion: string | null, create = false): string |
   return id
 }
 
-function appUpdateChannel(version: string): string {
-  const normalized = version.toLowerCase()
-  if (normalized.includes('-beta')) return 'beta'
-  if (normalized.includes('-canary')) return 'canary'
-  if (normalized.includes('-alpha')) return 'alpha'
-  return normalized.includes('-') ? 'unknown' : 'stable'
+function clearUpdateAttempt(attemptId: string): void {
+  if (_updateAttempt?.id === attemptId) _updateAttempt = null
+  if (settings.get('pendingDesktopUpdateAttemptId') !== attemptId) return
+  try {
+    settings.set('pendingDesktopUpdateAttemptId', undefined)
+    settings.set('pendingDesktopUpdateAttemptVersion', undefined)
+  } catch {}
 }
 
-/** Common low-cardinality, privacy-safe context for the complete updater chain. */
+/** Common privacy-safe context for the complete updater chain. */
 function emitUpdateTelemetry(
   event: string,
   targetVersion: string | null,
@@ -119,7 +133,7 @@ function emitUpdateTelemetry(
     update_attempt_id: updateAttemptId(targetVersion, createAttempt),
     platform: process.platform,
     os_version: osRelease(),
-    app_channel: appUpdateChannel(app.getVersion()),
+    app_channel: deriveAppChannel(app.getVersion()),
     is_packaged: app.isPackaged,
     updater_provider: 'todesktop',
     updater_mode: app.isPackaged ? 'packaged' : 'development',
@@ -805,6 +819,23 @@ export function recordStartupInstallBackstopRecovered(): void {
   )
 }
 
+let _processExitRecorded = false
+
+/** Record the updater state after the app's quit checks have accepted the quit. */
+export function recordProcessExit(): void {
+  if (_processExitRecorded) return
+  const targetVersion = _appUpdateState.version ?? _autoDownloadTriggeredFor
+  if (!targetVersion && !_activeUpdateOperation) return
+  _processExitRecorded = true
+  emitUpdateTelemetry('comfy.desktop.app_update.process_exit', targetVersion, {
+    quit_reason: getQuitReason(),
+    download_in_progress:
+      _activeUpdateOperation?.operation === 'download' ||
+      _autoDownloadTriggeredFor !== null ||
+      _userInitiatedDownload
+  })
+}
+
 /** Upper bound on how long the startup-install check may delay boot. The
  *  installer was already downloaded in a previous session, so this only
  *  re-validates the cached file against the release feed (no re-download); the
@@ -956,51 +987,55 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   // preserving genuinely-newer attempts so the loop-breaker below stays armed.
   const running = app.getVersion()
   const lastAttempt = settings.get('lastStartupUpdateAttemptVersion')
-  if (lastAttempt && !isStrictlyNewerVersion(lastAttempt, running)) {
-    settings.set('lastStartupUpdateAttemptVersion', undefined)
-  }
   const pendingVersion = settings.get('pendingDownloadedUpdateVersion')
-  if (pendingVersion && !isStrictlyNewerVersion(pendingVersion, running)) {
-    settings.set('pendingDownloadedUpdateVersion', undefined)
-  }
-
-  // Close the previous cross-launch attempt exactly once. This turns an app
-  // restart into a terminal updater observation instead of ending the trace at
-  // `install_triggered` when the old process exits.
-  const previousAttemptId = settings.get('lastStartupUpdateAttemptId')
-  const previousAttemptVersion = lastAttempt
-  if (
-    typeof previousAttemptId === 'string' &&
-    previousAttemptId &&
-    settings.get('lastReportedStartupUpdateAttemptId') !== previousAttemptId
-  ) {
-    const outcome =
-      typeof previousAttemptVersion === 'string' &&
-      !isStrictlyNewerVersion(previousAttemptVersion, running)
-        ? 'installed'
-        : pendingVersion === previousAttemptVersion
-          ? 'still_pending'
-          : typeof previousAttemptVersion === 'string' && !pendingVersion
-            ? 'rolled_back'
-            : 'unknown'
-    emitUpdateTelemetry(
-      'comfy.desktop.app_update.previous_attempt_outcome',
-      previousAttemptVersion ?? null,
-      {
-        update_attempt_id: previousAttemptId,
-        outcome
-      }
-    )
-    settings.set('lastReportedStartupUpdateAttemptId', previousAttemptId)
-    if (outcome === 'installed') {
-      settings.set('pendingDesktopUpdateAttemptId', undefined)
-      settings.set('pendingDesktopUpdateAttemptVersion', undefined)
-    }
-  }
   // Read the sidecar once and pass it down: each read is synchronous and can
   // block up to the transient-lock retry budget when the file is locked, and
   // this codepath runs before the first window appears.
   let sidecar = readStartupAttemptMarker()
+
+  // The sidecar is the durable cross-launch identity source because late
+  // settings.json writes may be unavailable or restored from backup. A pending
+  // result stays open so a later successful explicit install remains visible.
+  if (sidecar.state === 'present' && sidecar.marker.attemptId) {
+    const previousAttemptId = sidecar.marker.attemptId
+    const previousAttemptVersion = sidecar.marker.version
+    const outcome = !isStrictlyNewerVersion(previousAttemptVersion, running)
+      ? 'installed'
+      : pendingVersion === previousAttemptVersion
+        ? 'still_pending'
+        : !pendingVersion
+          ? 'staged_marker_missing'
+          : 'unknown'
+    if (sidecar.marker.reportedOutcome !== outcome) {
+      emitUpdateTelemetry(
+        'comfy.desktop.app_update.previous_attempt_outcome',
+        previousAttemptVersion,
+        {
+          update_attempt_id: previousAttemptId,
+          outcome,
+          bak_fallbacks: getSafeFileDiagnostics().bakFallbacks
+        }
+      )
+      if (outcome !== 'installed') recordStartupAttemptOutcome(sidecar.marker, outcome)
+    }
+    if (outcome === 'installed') clearUpdateAttempt(previousAttemptId)
+  }
+
+  if (lastAttempt && !isStrictlyNewerVersion(lastAttempt, running)) {
+    settings.set('lastStartupUpdateAttemptVersion', undefined)
+  }
+  if (pendingVersion && !isStrictlyNewerVersion(pendingVersion, running)) {
+    settings.set('pendingDownloadedUpdateVersion', undefined)
+  }
+  const pendingAttemptId = settings.get('pendingDesktopUpdateAttemptId')
+  const pendingAttemptVersion = settings.get('pendingDesktopUpdateAttemptVersion')
+  if (
+    typeof pendingAttemptId === 'string' &&
+    typeof pendingAttemptVersion === 'string' &&
+    !isStrictlyNewerVersion(pendingAttemptVersion, running)
+  ) {
+    clearUpdateAttempt(pendingAttemptId)
+  }
   if (sidecar.state === 'present' && !isStrictlyNewerVersion(sidecar.marker.version, running)) {
     clearStartupAttemptMarker()
     sidecar = { state: 'absent' }
@@ -1089,7 +1124,8 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   // WITHOUT writing any marker - installing unguarded risks an unbounded
   // reinstall loop (issue #1367), and a lone settings marker would block every
   // future auto-install of this version instead of retrying next launch.
-  if (!recordStartupAttempt(state.version)) {
+  const attemptId = updateAttemptId(state.version, true)
+  if (!attemptId || !recordStartupAttempt(state.version, attemptId)) {
     emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', state.version, {
       reason: 'marker_not_durable',
       version: state.version,
@@ -1099,7 +1135,6 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   }
   try {
     settings.set('lastStartupUpdateAttemptVersion', decision.version)
-    settings.set('lastStartupUpdateAttemptId', updateAttemptId(decision.version, true) ?? undefined)
   } catch {
     // The sidecar is already durable, so the loop-breaker holds without the
     // settings copy.
@@ -1128,18 +1163,6 @@ export function register(): void {
   // only while the OS is shutting down. `electronAutoUpdater` is the same
   // singleton the ToDesktop runtime drives, so this affects the real updater.
   syncInstallOnQuitPolicy()
-
-  app.once('before-quit', () => {
-    const targetVersion = _appUpdateState.version ?? _autoDownloadTriggeredFor
-    if (!targetVersion && !_activeUpdateOperation) return
-    emitUpdateTelemetry('comfy.desktop.app_update.process_exit', targetVersion, {
-      quit_reason: getQuitReason(),
-      download_in_progress:
-        _activeUpdateOperation?.operation === 'download' ||
-        _autoDownloadTriggeredFor !== null ||
-        _userInitiatedDownload
-    })
-  })
 
   ipcMain.handle('check-for-update', async () => {
     try {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1,4 +1,6 @@
 import { app, ipcMain } from 'electron'
+import { randomUUID } from 'node:crypto'
+import { release as osRelease } from 'node:os'
 import semver from 'semver'
 import todesktop from '@todesktop/runtime'
 import { autoUpdater as electronAutoUpdater } from 'electron-updater'
@@ -10,7 +12,7 @@ import {
   recordStartupAttempt,
   type StartupAttemptMarkerRead
 } from './startup-attempt-marker'
-import { clearQuitReason, isSessionEnding, setQuitReason } from './quit-state'
+import { clearQuitReason, getQuitReason, isSessionEnding, setQuitReason } from './quit-state'
 import { _broadcastToRenderer } from './ipc/shared'
 import { emit as emitTelemetry } from './telemetry'
 import { buildErrorFields, errorTail } from '../../shared/errorEvent'
@@ -82,6 +84,48 @@ function _shouldEmitAppUpdateOnce(event: string, version: string | null): boolea
 let _userInitiatedDownload = false
 const _stateChangeCallbacks = new Set<(state: AppUpdateState) => void>()
 let _listenersBound = false
+
+function updateAttemptId(targetVersion: string | null, create = false): string | null {
+  const existing = settings.get('pendingDesktopUpdateAttemptId')
+  const existingVersion = settings.get('pendingDesktopUpdateAttemptVersion')
+  if (typeof existing === 'string' && existing && existingVersion === targetVersion) return existing
+  if (!create || !targetVersion) return null
+  const id = randomUUID()
+  try {
+    settings.set('pendingDesktopUpdateAttemptId', id)
+    settings.set('pendingDesktopUpdateAttemptVersion', targetVersion)
+  } catch {}
+  return id
+}
+
+function appUpdateChannel(version: string): string {
+  const normalized = version.toLowerCase()
+  if (normalized.includes('-beta')) return 'beta'
+  if (normalized.includes('-canary')) return 'canary'
+  if (normalized.includes('-alpha')) return 'alpha'
+  return normalized.includes('-') ? 'unknown' : 'stable'
+}
+
+/** Common low-cardinality, privacy-safe context for the complete updater chain. */
+function emitUpdateTelemetry(
+  event: string,
+  targetVersion: string | null,
+  properties: Record<string, string | number | boolean | null | undefined> = {},
+  createAttempt = false
+): void {
+  emitTelemetry(event, {
+    running_version: app.getVersion(),
+    target_version: targetVersion,
+    update_attempt_id: updateAttemptId(targetVersion, createAttempt),
+    platform: process.platform,
+    os_version: osRelease(),
+    app_channel: appUpdateChannel(app.getVersion()),
+    is_packaged: app.isPackaged,
+    updater_provider: 'todesktop',
+    updater_mode: app.isPackaged ? 'packaged' : 'development',
+    ...properties
+  })
+}
 
 function _setUpdateState(next: AppUpdateState): void {
   _appUpdateState = next
@@ -274,7 +318,7 @@ function isStrictlyNewerVersion(offered: string | null | undefined, current: str
 function shouldIgnoreNonNewerVersion(version: string, stage: string): boolean {
   if (isStrictlyNewerVersion(version, app.getVersion())) return false
   if (_shouldEmitAppUpdateOnce('comfy.desktop.app_update.ignored_not_newer', version)) {
-    emitTelemetry('comfy.desktop.app_update.ignored_not_newer', {
+    emitUpdateTelemetry('comfy.desktop.app_update.ignored_not_newer', version, {
       version,
       current: app.getVersion(),
       stage
@@ -326,13 +370,10 @@ function emitDesktopUpdateError(
     : error instanceof Error
       ? error
       : null
-  emitTelemetry('comfy.desktop.app_update.error', {
+  emitUpdateTelemetry('comfy.desktop.app_update.error', targetVersion, {
     component: 'desktop_application',
     operation,
     stage: operation === 'apply_restart' ? 'install' : operation,
-    running_version: app.getVersion(),
-    target_version: targetVersion,
-    updater_provider: 'todesktop',
     error_source: options.source,
     setting_use_chinese_mirrors: settings.get('useChineseMirrors') === true,
     ...buildErrorFields(errorObject ?? message),
@@ -358,10 +399,15 @@ function bindUpdaterEvents(): void {
     if (shouldIgnoreNonNewerVersion(version, 'available')) return
     const autoInstall = isAutoInstallEnabled()
     if (_shouldEmitAppUpdateOnce('comfy.desktop.app_update.available', version)) {
-      emitTelemetry('comfy.desktop.app_update.available', {
+      emitUpdateTelemetry(
+        'comfy.desktop.app_update.available',
         version,
-        auto_update_setting: autoInstall ? 'on' : 'off'
-      })
+        {
+          version,
+          auto_update_setting: autoInstall ? 'on' : 'off'
+        },
+        true
+      )
     }
     if (autoInstall) {
       const active = currentUpdateOperation()
@@ -384,7 +430,12 @@ function bindUpdaterEvents(): void {
       if (_autoDownloadTriggeredFor !== version) {
         _autoDownloadTriggeredFor = version
         if (_shouldEmitAppUpdateOnce('comfy.desktop.app_update.download_started', version)) {
-          emitTelemetry('comfy.desktop.app_update.download_started', { version, initiator: 'auto' })
+          emitUpdateTelemetry(
+            'comfy.desktop.app_update.download_started',
+            version,
+            { version, initiator: 'auto' },
+            true
+          )
         }
       }
       return
@@ -400,7 +451,7 @@ function bindUpdaterEvents(): void {
     if (shouldIgnoreNonNewerVersion(version, 'downloaded')) return
     _autoDownloadTriggeredFor = null
     if (_shouldEmitAppUpdateOnce('comfy.desktop.app_update.download_complete', version)) {
-      emitTelemetry('comfy.desktop.app_update.download_complete', { version })
+      emitUpdateTelemetry('comfy.desktop.app_update.download_complete', version, { version }, true)
     }
     // Persist that an installer is staged on disk. electron-updater caches the
     // download across restarts; this marker lets the startup-install path apply
@@ -531,7 +582,7 @@ async function checkForUpdate(
     const updater = getAutoUpdater()
     if (!updater) {
       if (USER_INITIATED_CHECK_TRIGGERS.has(source)) {
-        emitTelemetry('comfy.desktop.app_update.checked', {
+        emitUpdateTelemetry('comfy.desktop.app_update.checked', null, {
           trigger: source,
           result: 'updater_unavailable'
         })
@@ -553,7 +604,15 @@ async function checkForUpdate(
       USER_INITIATED_CHECK_TRIGGERS.has(source) &&
       _shouldEmitAppUpdateOnce('comfy.desktop.app_update.checked', version)
     ) {
-      emitTelemetry('comfy.desktop.app_update.checked', { trigger: source, result: 'available' })
+      emitUpdateTelemetry(
+        'comfy.desktop.app_update.checked',
+        version,
+        {
+          trigger: source,
+          result: 'available'
+        },
+        true
+      )
     }
     return version ? { available: true, version } : { available: false }
   } catch (err) {
@@ -628,10 +687,15 @@ export function onUpdateStateChanged(cb: (state: AppUpdateState) => void): () =>
  */
 export async function downloadUpdate(): Promise<void> {
   _userInitiatedDownload = true
-  emitTelemetry('comfy.desktop.app_update.download_started', {
-    version: _appUpdateState.version,
-    initiator: 'user'
-  })
+  emitUpdateTelemetry(
+    'comfy.desktop.app_update.download_started',
+    _appUpdateState.version,
+    {
+      version: _appUpdateState.version,
+      initiator: 'user'
+    },
+    true
+  )
   try {
     const result = await runCheck('download-button')
     if (!result.available && _appUpdateState.kind !== 'ready') {
@@ -679,7 +743,7 @@ export function installUpdate(userInitiated = true): void {
     _broadcastToRenderer('app-update:user-action-failed', { message: UPDATER_UNAVAILABLE_MESSAGE })
     return
   }
-  emitTelemetry('comfy.desktop.app_update.install_triggered', {
+  emitUpdateTelemetry('comfy.desktop.app_update.install_triggered', _appUpdateState.version, {
     version: _appUpdateState.version,
     auto_update_setting: isAutoInstallEnabled() ? 'on' : 'off'
   })
@@ -731,6 +795,14 @@ export function installUpdate(userInitiated = true): void {
  */
 export function _test_setUpdateState(next: AppUpdateState): void {
   _setUpdateState(next)
+}
+
+/** Record recovery when the startup installer did not enter Electron's quit path. */
+export function recordStartupInstallBackstopRecovered(): void {
+  emitUpdateTelemetry(
+    'comfy.desktop.app_update.startup_install_backstop_recovered',
+    _appUpdateState.version ?? settings.get('pendingDownloadedUpdateVersion') ?? null
+  )
 }
 
 /** Upper bound on how long the startup-install check may delay boot. The
@@ -891,6 +963,40 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   if (pendingVersion && !isStrictlyNewerVersion(pendingVersion, running)) {
     settings.set('pendingDownloadedUpdateVersion', undefined)
   }
+
+  // Close the previous cross-launch attempt exactly once. This turns an app
+  // restart into a terminal updater observation instead of ending the trace at
+  // `install_triggered` when the old process exits.
+  const previousAttemptId = settings.get('lastStartupUpdateAttemptId')
+  const previousAttemptVersion = lastAttempt
+  if (
+    typeof previousAttemptId === 'string' &&
+    previousAttemptId &&
+    settings.get('lastReportedStartupUpdateAttemptId') !== previousAttemptId
+  ) {
+    const outcome =
+      typeof previousAttemptVersion === 'string' &&
+      !isStrictlyNewerVersion(previousAttemptVersion, running)
+        ? 'installed'
+        : pendingVersion === previousAttemptVersion
+          ? 'still_pending'
+          : typeof previousAttemptVersion === 'string' && !pendingVersion
+            ? 'rolled_back'
+            : 'unknown'
+    emitUpdateTelemetry(
+      'comfy.desktop.app_update.previous_attempt_outcome',
+      previousAttemptVersion ?? null,
+      {
+        update_attempt_id: previousAttemptId,
+        outcome
+      }
+    )
+    settings.set('lastReportedStartupUpdateAttemptId', previousAttemptId)
+    if (outcome === 'installed') {
+      settings.set('pendingDesktopUpdateAttemptId', undefined)
+      settings.set('pendingDesktopUpdateAttemptVersion', undefined)
+    }
+  }
   // Read the sidecar once and pass it down: each read is synchronous and can
   // block up to the transient-lock retry budget when the file is locked, and
   // this codepath runs before the first window appears.
@@ -901,6 +1007,22 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   }
 
   const decision = evaluateStartupInstall(sidecar)
+  if (pendingVersion && isStrictlyNewerVersion(pendingVersion, running)) {
+    emitUpdateTelemetry(
+      'comfy.desktop.app_update.startup_decision',
+      pendingVersion,
+      {
+        decision: decision.attempt ? 'install' : 'skip',
+        reason: decision.attempt ? 'ready_check' : decision.reason,
+        pending_version: pendingVersion,
+        updater_state: getCurrentUpdateState().kind ?? 'unknown',
+        marker_state: sidecar.state,
+        marker_source: !decision.attempt ? (decision.loopBreakerSource ?? null) : null,
+        bak_fallbacks: getSafeFileDiagnostics().bakFallbacks
+      },
+      true
+    )
+  }
   if (!decision.attempt) {
     // Only the skips that mean "a staged update exists but we declined it"
     // carry canary signal; normal boots (no pending / feature off) stay silent.
@@ -909,13 +1031,17 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
       decision.reason === 'session_ending' ||
       decision.reason === 'marker_unavailable'
     ) {
-      emitTelemetry('comfy.desktop.app_update.startup_install_skipped', {
-        reason: decision.reason,
-        version: settings.get('pendingDownloadedUpdateVersion') ?? null,
-        // Which marker home tripped a loop_breaker skip (see loopBreakerSource).
-        source: decision.loopBreakerSource ?? null,
-        bakFallbacks: getSafeFileDiagnostics().bakFallbacks
-      })
+      emitUpdateTelemetry(
+        'comfy.desktop.app_update.startup_install_skipped',
+        settings.get('pendingDownloadedUpdateVersion') ?? null,
+        {
+          reason: decision.reason,
+          version: settings.get('pendingDownloadedUpdateVersion') ?? null,
+          // Which marker home tripped a loop_breaker skip (see loopBreakerSource).
+          source: decision.loopBreakerSource ?? null,
+          bakFallbacks: getSafeFileDiagnostics().bakFallbacks
+        }
+      )
     }
     return false
   }
@@ -931,7 +1057,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   // install — a concurrent check could surface a different (or no) ready
   // version, which must not bypass the loop-breaker recorded for `decision.version`.
   if (state.kind !== 'ready' || state.version !== decision.version) {
-    emitTelemetry('comfy.desktop.app_update.startup_install_skipped', {
+    emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', decision.version, {
       reason: 'not_ready',
       version: decision.version
     })
@@ -950,7 +1076,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   // The session may have started ending while we awaited the check / held the
   // splash up.
   if (isSessionEnding()) {
-    emitTelemetry('comfy.desktop.app_update.startup_install_skipped', {
+    emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', state.version, {
       reason: 'session_ending',
       version: state.version
     })
@@ -964,7 +1090,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   // reinstall loop (issue #1367), and a lone settings marker would block every
   // future auto-install of this version instead of retrying next launch.
   if (!recordStartupAttempt(state.version)) {
-    emitTelemetry('comfy.desktop.app_update.startup_install_skipped', {
+    emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', state.version, {
       reason: 'marker_not_durable',
       version: state.version,
       bakFallbacks: getSafeFileDiagnostics().bakFallbacks
@@ -972,12 +1098,13 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
     return false
   }
   try {
-    settings.set('lastStartupUpdateAttemptVersion', state.version)
+    settings.set('lastStartupUpdateAttemptVersion', decision.version)
+    settings.set('lastStartupUpdateAttemptId', updateAttemptId(decision.version, true) ?? undefined)
   } catch {
     // The sidecar is already durable, so the loop-breaker holds without the
     // settings copy.
   }
-  emitTelemetry('comfy.desktop.app_update.startup_install', {
+  emitUpdateTelemetry('comfy.desktop.app_update.startup_install', state.version, {
     version: state.version,
     // Non-zero means reads were served from `.bak` this session (primary
     // missing, empty, or locked past retries - issue #1367's environment);
@@ -1001,6 +1128,18 @@ export function register(): void {
   // only while the OS is shutting down. `electronAutoUpdater` is the same
   // singleton the ToDesktop runtime drives, so this affects the real updater.
   syncInstallOnQuitPolicy()
+
+  app.once('before-quit', () => {
+    const targetVersion = _appUpdateState.version ?? _autoDownloadTriggeredFor
+    if (!targetVersion && !_activeUpdateOperation) return
+    emitUpdateTelemetry('comfy.desktop.app_update.process_exit', targetVersion, {
+      quit_reason: getQuitReason(),
+      download_in_progress:
+        _activeUpdateOperation?.operation === 'download' ||
+        _autoDownloadTriggeredFor !== null ||
+        _userInitiatedDownload
+    })
+  })
 
   ipcMain.handle('check-for-update', async () => {
     try {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1014,7 +1014,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
         {
           update_attempt_id: previousAttemptId,
           outcome,
-          bak_fallbacks: getSafeFileDiagnostics().bakFallbacks
+          bakFallbacks: getSafeFileDiagnostics().bakFallbacks
         }
       )
       recordStartupAttemptOutcome(sidecar.marker, outcome)
@@ -1054,7 +1054,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
         updater_state: getCurrentUpdateState().kind ?? 'unknown',
         marker_state: sidecar.state,
         marker_source: !decision.attempt ? (decision.loopBreakerSource ?? null) : null,
-        bak_fallbacks: getSafeFileDiagnostics().bakFallbacks
+        bakFallbacks: getSafeFileDiagnostics().bakFallbacks
       },
       true
     )

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -1016,7 +1016,7 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
           bak_fallbacks: getSafeFileDiagnostics().bakFallbacks
         }
       )
-      if (outcome !== 'installed') recordStartupAttemptOutcome(sidecar.marker, outcome)
+      recordStartupAttemptOutcome(sidecar.marker, outcome)
     }
     if (outcome === 'installed') clearUpdateAttempt(previousAttemptId)
   }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -83,10 +83,6 @@ export interface KnownSettings {
    *  Contains no device or user material and may span process launches. */
   pendingDesktopUpdateAttemptId?: string
   pendingDesktopUpdateAttemptVersion?: string
-  /** Correlation id copied when a startup install is launched. */
-  lastStartupUpdateAttemptId?: string
-  /** Attempt whose next-launch terminal outcome was already emitted. */
-  lastReportedStartupUpdateAttemptId?: string
   /** Windows-only gate (default on) for applying a staged Desktop update on the
    *  next launch instead of letting electron-updater install it on quit. Ignored
    *  on macOS/Linux, whose updaters don't have the shutdown install-corruption
@@ -268,8 +264,6 @@ const SETTINGS_SCHEMA = {
   lastStartupUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
   pendingDesktopUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
   pendingDesktopUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
-  lastStartupUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
-  lastReportedStartupUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
   installUpdatesOnStartup: {
     // Windows-only, default-on. Off-Windows the gate is inert, so report `null`
     // ("not applicable") to keep it distinct from an explicit opt-out. Exact

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -79,6 +79,14 @@ export interface KnownSettings {
    *  the same version on the next boot — the user can still install it manually
    *  via the update pill. Cleared once that version is actually running. */
   lastStartupUpdateAttemptVersion?: string
+  /** Opaque, locally-generated correlation id for the staged updater attempt.
+   *  Contains no device or user material and may span process launches. */
+  pendingDesktopUpdateAttemptId?: string
+  pendingDesktopUpdateAttemptVersion?: string
+  /** Correlation id copied when a startup install is launched. */
+  lastStartupUpdateAttemptId?: string
+  /** Attempt whose next-launch terminal outcome was already emitted. */
+  lastReportedStartupUpdateAttemptId?: string
   /** Windows-only gate (default on) for applying a staged Desktop update on the
    *  next launch instead of letting electron-updater install it on quit. Ignored
    *  on macOS/Linux, whose updaters don't have the shutdown install-corruption
@@ -258,6 +266,10 @@ const SETTINGS_SCHEMA = {
   },
   pendingDownloadedUpdateVersion: { nullable: true, telemetry: { policy: 'omit' } },
   lastStartupUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  pendingDesktopUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
+  pendingDesktopUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  lastStartupUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
+  lastReportedStartupUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
   installUpdatesOnStartup: {
     // Windows-only, default-on. Off-Windows the gate is inert, so report `null`
     // ("not applicable") to keep it distinct from an explicit opt-out. Exact


### PR DESCRIPTION
## Signal provenance & investigation

This PR is the instrumentation outcome of signal **sig-20260826-08** (Desktop auto-updates break the app and force manual uninstall/reinstall).

- **Evidence:** aggregate survey source reported six independent mentions of one Desktop auto-update symptom ([#user-research digest](https://comfy-org.slack.com/archives/C07NJ6417J7/p1787591418252599)); corroborating update-error volume visible in pulse.comfy.org, Datadog/RUM monitors, PostHog, Typeform, #bug-dump, #qol-wishlist, #feedback.
    - Relatedness confidence: medium — reports cluster on one symptom but are digest-level.
    - Overall confidence: low-medium; caveat: no respondent records, versions, channels, logs, or install artifacts in the aggregate.
- **Repro verdict:** `needs-info` — reproduction attempted and **not achieved on any available VM**; the six reports carry no Desktop/app versions, OS, update channel, failure stage, or logs, so an exact repro cannot be constructed from current evidence.
- **RCA verdict:** cause not isolatable from existing telemetry — update events cannot be correlated across launches, which is exactly the observability gap this PR closes. Full RCA doc: `signals/rca/sig-20260826-desktop-autoupdate.md` (ECS signal workspace).
- **Strategy:** telemetry-first as the cheap, early, additive step — once merged, the new attempt-ID correlation identifies where update flows break and later verifies whether any fix actually ships.

## Summary

- add privacy-safe update-attempt IDs that persist across Desktop launches
- attach running/target release, channel, platform, OS, packaging mode, and updater provider to updater events
- record staged-update decisions, quit-with-download state, and exactly-once next-launch outcomes
- route startup-install backstop recovery through the same updater telemetry context

The existing consent-gated telemetry installation ID remains the stable installation correlation key. The new attempt ID is a locally generated UUID and contains no device or user material.

This implements the repository-owned portion of DESK2-152. Provisioning the production sink and saved operational detector remains external because this repository has no dashboard/query provisioning surface.

## Change breakdown

| Category | Files | Paths | Added | Deleted | Share of changed lines |
| --- | ---: | --- | ---: | ---: | ---: |
| Product code | 3 | `src/main/index.ts`, `src/main/lib/updater.ts`, `src/main/settings.ts` | 182 | 31 | 72% |
| Tests | 1 | `src/main/lib/updater.test.ts` | 80 | 1 | 28% |
| Documentation | 0 | - | 0 | 0 | 0% |
| Other | 0 | - | 0 | 0 | 0% |

Total changed lines are added lines plus deleted lines: 294. Generated files, lockfiles, vendored code, and merge-only changes: none.

## Validation

- `pnpm exec vitest run src/main/lib/updater.test.ts --maxWorkers=4`: 70 passed
- `pnpm run typecheck`: passed
- `pnpm run lint`: passed
- `pnpm run format:check`: passed
- `git diff --check`: passed

Mutation verification: changed the persisted-ID reuse arm to generate a fresh UUID on every updater transition. Event counts stayed unchanged; the correlation regression test failed at `src/main/lib/updater.test.ts:711` because `available` and `download_complete` carried different attempt IDs. Restored the implementation and the focused detector passed.

Draft only. Desktop team review and production sink/query provisioning are still required; this PR must not be self-merged.
