### PR TITLE
Fix startup update loop when the staged installer is corrupt or still downloading

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1252,6 +1252,8 @@
     "instanceRunningReplace": "Close & Launch",
     "modelFolderRelaunchTitle": "Restarting ComfyUI",
     "modelFolderRelaunchDesc": "New model folders were detected from custom nodes. Restarting so ComfyUI can use them right away.",
+    "updateCheckTitle": "Checking for update",
+    "updateCheckDesc": "A downloaded update is being verified. This takes just a few seconds.",
     "updateInstallTitle": "Updating Comfy Desktop",
     "updateInstallDesc": "A new version was downloaded and is about to install. The app will close briefly and reopen automatically.",
     "updateInstallCountdown": "Restarting in {seconds}s…",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1252,6 +1252,8 @@
     "instanceRunningReplace": "关闭并启动",
     "modelFolderRelaunchTitle": "正在重启 ComfyUI",
     "modelFolderRelaunchDesc": "检测到来自自定义节点的新模型文件夹。正在重启，以便 ComfyUI 立即使用它们。",
+    "updateCheckTitle": "正在检查更新",
+    "updateCheckDesc": "正在验证已下载的更新，只需几秒钟。",
     "updateInstallTitle": "正在更新 Comfy Desktop",
     "updateInstallDesc": "已下载新版本，即将开始安装。应用将短暂关闭并自动重新打开。",
     "updateInstallCountdown": "{seconds} 秒后重启…",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,15 @@
-import { app, Menu, ipcMain, net, dialog, crashReporter, nativeTheme, powerMonitor } from 'electron'
-import type { BrowserWindow, WebContentsView } from 'electron'
+import {
+  app,
+  Menu,
+  ipcMain,
+  net,
+  dialog,
+  crashReporter,
+  nativeTheme,
+  powerMonitor,
+  BrowserWindow
+} from 'electron'
+import type { WebContentsView } from 'electron'
 import type { Tray } from 'electron'
 import path from 'path'
 import fs from 'fs'
@@ -2252,7 +2262,17 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       } catch (err) {
         console.error('openStartupSurface failed after update splash:', err)
       } finally {
-        if (updateSplash && !updateSplash.window.isDestroyed()) updateSplash.window.destroy()
+        // Destroying the splash while it is the only window fires
+        // `window-all-closed` and quits the app, so if the surface handoff
+        // failed and no other window exists, keep the splash up: a stalled
+        // splash beats a silent exit that would also kill any in-flight
+        // background re-download.
+        const otherWindowExists = BrowserWindow.getAllWindows().some(
+          (w) => w !== updateSplash?.window && !w.isDestroyed()
+        )
+        if (updateSplash && !updateSplash.window.isDestroyed() && otherWindowExists) {
+          updateSplash.window.destroy()
+        }
       }
     }
     if (installingUpdate) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2222,10 +2222,6 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
     // while the bounded check runs; if it commits to installing, the app quits
     // here and the installer relaunches it — so we skip opening the normal UI.
     const updateSplash = updater.hasPendingStartupUpdate() ? showUpdateInstallSplash() : undefined
-    // Timestamp the splash so the install can keep it up for a readable minimum
-    // (the bounded check usually resolves instantly, which would otherwise flash
-    // the splash by before the app quits to install).
-    const updateSplashShownAt = updateSplash ? Date.now() : undefined
     // Track whether the install actually started quitting the app. Quit intent
     // (`quitReason`) alone isn't proof — `restartAndInstall` can return without
     // quitting if the staged installer is gone — so key the backstop off a real
@@ -2235,7 +2231,30 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       updateInstallQuitStarted = true
     }
     app.once('before-quit', onUpdateInstallQuit)
-    const installingUpdate = await updater.applyPendingUpdateOnStartup(updateSplashShownAt)
+    // Guarded so an unexpected throw still lands in the normal-boot path below;
+    // the splash handoff there is what keeps the app alive.
+    let installingUpdate = false
+    try {
+      installingUpdate = await updater.applyPendingUpdateOnStartup(
+        updateSplash ? { onInstallCommitted: () => updateSplash.showInstallCountdown() } : undefined
+      )
+    } catch (err) {
+      console.error('applyPendingUpdateOnStartup failed:', err)
+    }
+    // Open the normal UI and only then take the splash down. The order matters:
+    // while the splash is the only window, destroying it before another window
+    // exists fires `window-all-closed`, which quits the app. That quit killed
+    // any in-flight background re-download of an invalid staged installer,
+    // leaving a partial file that re-triggered the same splash on every boot.
+    const openSurfaceAndDismissSplash = async (): Promise<void> => {
+      try {
+        await openStartupSurface()
+      } catch (err) {
+        console.error('openStartupSurface failed after update splash:', err)
+      } finally {
+        if (updateSplash && !updateSplash.window.isDestroyed()) updateSplash.window.destroy()
+      }
+    }
     if (installingUpdate) {
       // Safety net: a successful install quits the app within a tick (firing
       // before-quit). If that didn't happen the install didn't proceed — recover
@@ -2246,21 +2265,24 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
         if (updateInstallQuitStarted) return
         app.removeListener('before-quit', onUpdateInstallQuit)
         clearQuitReason()
-        if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
         updater.recordStartupInstallBackstopRecovered()
-        void openStartupSurface()
-        hostReentryGate.open()
+        void openSurfaceAndDismissSplash().then(() => {
+          hostReentryGate.open()
+        })
       }, STARTUP_INSTALL_QUIT_BACKSTOP_MS)
     } else {
       app.removeListener('before-quit', onUpdateInstallQuit)
-      if (updateSplash && !updateSplash.isDestroyed()) updateSplash.destroy()
       // The install-less chooser host is the primary surface. Each
       // install gets its own ComfyUI window via openComfyWindow()
       // when launched, and the chooser host is the entry-point for
       // picking / creating installs. When the user last left an instance
       // window (and the reopen setting is on), restore that instance
       // in-place on top of the freshly-opened chooser host.
-      void openStartupSurface()
+      if (updateSplash) {
+        await openSurfaceAndDismissSplash()
+      } else {
+        void openStartupSurface()
+      }
       // Startup recovery (awaited inside `ipc.register()` above) has settled
       // and we've committed to opening the normal UI, so OS-driven reentry
       // (second-instance / dock activate) can open windows directly again.

--- a/src/main/lib/updateSplash.ts
+++ b/src/main/lib/updateSplash.ts
@@ -3,25 +3,37 @@ import { SPLASH_PURPLE } from './theme'
 import { showSplashPage } from './relaunchPage'
 import * as i18n from './i18n'
 
-/** Countdown shown on the update splash before the app quits to install, so the
- *  user has a few seconds to read what's about to happen. Keep in sync with the
- *  updater's `STARTUP_INSTALL_MIN_SPLASH_MS` (the splash is held that long), so
- *  the countdown finishes right as the install begins. */
+/** Countdown shown on the update splash once the install is committed, before
+ *  the app quits to run it, so the user has a few seconds to read what's about
+ *  to happen. Keep in sync with the updater's `STARTUP_INSTALL_MIN_SPLASH_MS`
+ *  (the post-commit hold), so the countdown finishes right as the install
+ *  begins. */
 export const UPDATE_INSTALL_COUNTDOWN_SECONDS = 5
 
+/** Handle for the startup-update splash. `showInstallCountdown` swaps the copy
+ *  from "checking for update" to the install countdown; the updater calls it at
+ *  the moment the install is committed, so the countdown never shows for a boot
+ *  that ends up skipping the install. The returned promise settles once the
+ *  countdown page is rendered (or its render failed), letting the caller start
+ *  the pre-quit hold only when the countdown is actually visible. */
+export interface UpdateInstallSplash {
+  window: BrowserWindow
+  showInstallCountdown: () => Promise<void>
+}
+
 /**
- * "Updating…" window shown while a previously-downloaded Desktop update is
- * applied at startup (see `applyPendingUpdateOnStartup`). It tells the user an
- * update is about to install and runs a short countdown (so they aren't
- * surprised by the restart) while the bounded install check runs; the app quits
- * shortly after and the installer relaunches it. If the install doesn't proceed,
- * the caller destroys this window and opens the normal UI.
+ * Splash window shown while a previously-downloaded Desktop update is checked
+ * and possibly applied at startup (see `applyPendingUpdateOnStartup`). It opens
+ * with "checking" copy while the bounded readiness check runs; if the install
+ * commits, the caller swaps in the install countdown via `showInstallCountdown`
+ * and the app quits shortly after (the installer relaunches it). If the install
+ * doesn't proceed, the caller destroys this window after opening the normal UI.
  *
  * Self-contained (renders the shared brand splash into its own webContents), so
  * it has no dependency on the host-window / panel renderer wiring that isn't up
  * yet this early in boot.
  */
-export function showUpdateInstallSplash(): BrowserWindow {
+export function showUpdateInstallSplash(): UpdateInstallSplash {
   const win = new BrowserWindow({
     width: 480,
     height: 400,
@@ -44,11 +56,29 @@ export function showUpdateInstallSplash(): BrowserWindow {
     win.focus()
   })
 
-  void showSplashPage(win.webContents, SPLASH_PURPLE, {
-    title: i18n.t('launch.updateInstallTitle'),
-    desc: i18n.t('launch.updateInstallDesc'),
-    countdownSeconds: UPDATE_INSTALL_COUNTDOWN_SECONDS
-  })
+  // Renders are chained so the countdown swap can't race the initial checking
+  // page while it is still loading (a second loadURL aborts the first, which
+  // would reject its promise). The splash is best-effort chrome, so render
+  // failures are swallowed rather than propagated into the update flow.
+  let render: Promise<void> = showSplashPage(win.webContents, SPLASH_PURPLE, {
+    title: i18n.t('launch.updateCheckTitle'),
+    desc: i18n.t('launch.updateCheckDesc')
+  }).catch(() => {})
 
-  return win
+  return {
+    window: win,
+    showInstallCountdown: () => {
+      render = render
+        .then(() => {
+          if (win.isDestroyed()) return
+          return showSplashPage(win.webContents, SPLASH_PURPLE, {
+            title: i18n.t('launch.updateInstallTitle'),
+            desc: i18n.t('launch.updateInstallDesc'),
+            countdownSeconds: UPDATE_INSTALL_COUNTDOWN_SECONDS
+          })
+        })
+        .catch(() => {})
+      return render
+    }
+  }
 }

--- a/src/main/lib/updater.test.ts
+++ b/src/main/lib/updater.test.ts
@@ -894,7 +894,7 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     expect(sidecarMarker).toMatchObject({ reportedOutcome: 'installed' })
   })
 
-  it('applyPendingUpdateOnStartup() holds the install until the splash minimum elapses', async () => {
+  it('applyPendingUpdateOnStartup() holds the install after committing so the countdown plays out', async () => {
     vi.useFakeTimers()
     try {
       settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
@@ -902,11 +902,14 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       const updater = await import('./updater')
       updater.register()
 
-      // Splash just went up, so the full minimum (5000ms) must elapse first.
-      const pending = updater.applyPendingUpdateOnStartup(Date.now())
+      // A splash is up: the commit hook fires once the install is confirmed,
+      // then the full post-commit hold (5000ms) must elapse before the install.
+      const onInstallCommitted = vi.fn()
+      const pending = updater.applyPendingUpdateOnStartup({ onInstallCommitted })
 
-      // Let the (instant) ready check settle, but stay short of the floor.
+      // Let the (instant) ready check settle, but stay short of the hold.
       await vi.advanceTimersByTimeAsync(4000)
+      expect(onInstallCommitted).toHaveBeenCalledTimes(1)
       expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
 
       // Cross the floor — the install now fires.
@@ -928,7 +931,9 @@ describe('startup update install + session-end guard (issue #1065)', () => {
     vi.useFakeTimers()
     try {
       settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
-      readyVersion = null // e.g. cached installer invalid / offline
+      // The check finds the update upstream but it never reaches 'ready' and
+      // never starts re-downloading (e.g. the updater stalls silently).
+      fakeUpdater.checkForUpdates = vi.fn(async () => ({ updateInfo: { version: '1.0.1' } }))
       const updater = await import('./updater')
       updater.register()
       const pending = updater.applyPendingUpdateOnStartup()
@@ -938,6 +943,8 @@ describe('startup update install + session-end guard (issue #1065)', () => {
       await vi.advanceTimersByTimeAsync(5100)
       expect(await pending).toBe(false)
       expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+      const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+      expect(skipped[0]?.[1]).toMatchObject({ reason: 'not_ready', wait_outcome: 'timeout' })
     } finally {
       vi.useRealTimers()
     }
@@ -969,22 +976,165 @@ describe('startup update install + session-end guard (issue #1065)', () => {
   })
 
   it('emits startup_install_skipped with not_ready when the check cannot confirm a ready update', async () => {
-    vi.useFakeTimers()
-    try {
-      settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
-      readyVersion = null
-      const updater = await import('./updater')
-      updater.register()
-      const pending = updater.applyPendingUpdateOnStartup()
-      // Past the 5000ms bounded-check timeout (buffer avoids boundary races).
-      await vi.advanceTimersByTimeAsync(5100)
-      await pending
-      const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
-      expect(skipped).toHaveLength(1)
-      expect(skipped[0]?.[1]).toMatchObject({ reason: 'not_ready', version: '1.0.1' })
-    } finally {
-      vi.useRealTimers()
-    }
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = null // the mock check reports no update available
+    const updater = await bootUpdater()
+    // The wait settles as soon as the check reports nothing available, without
+    // burning the full bounded-wait deadline (no timer advancing needed).
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0]?.[1]).toMatchObject({
+      reason: 'not_ready',
+      version: '1.0.1',
+      wait_outcome: 'check_failed',
+      consecutive_not_ready: 1,
+      abandoned: false
+    })
+    // The staged marker survives a first strike; only the counter advances.
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.1')
+    expect(settingsStore['startupInstallNotReadyVersion']).toBe('1.0.1')
+    expect(settingsStore['startupInstallNotReadyCount']).toBe(1)
+  })
+
+  it('bails out fast when the staged installer is invalid and a re-download starts', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    // The feed still offers the update, but the cached installer was rejected:
+    // the check resolves without an 'update-downloaded' (no ready state) and
+    // electron-updater starts re-downloading the installer.
+    fakeUpdater.checkForUpdates = vi.fn(async () => ({ updateInfo: { version: '1.0.1' } }))
+    const updater = await bootUpdater()
+    const pending = updater.applyPendingUpdateOnStartup()
+    // First raw download-progress tick: proof of the re-download. The wait must
+    // settle on it immediately so the user gets into the app while the download
+    // continues in the background.
+    for (const cb of listeners['download-progress'] || []) cb({ percent: 1 })
+    expect(await pending).toBe(false)
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+    // No attempt marker: nothing was installed, so the loop-breaker stays
+    // unarmed and a completed download can install on a later boot.
+    expect(settingsStore['lastStartupUpdateAttemptVersion']).toBeUndefined()
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.1')
+    const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0]?.[1]).toMatchObject({
+      reason: 'not_ready',
+      version: '1.0.1',
+      wait_outcome: 'downloading',
+      consecutive_not_ready: 1,
+      abandoned: false
+    })
+  })
+
+  it('abandons the staged version after repeated not-ready boots', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    readyVersion = null // never becomes ready on any boot
+    const updater = await bootUpdater()
+
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(settingsStore['startupInstallNotReadyCount']).toBe(1)
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.1')
+
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(settingsStore['startupInstallNotReadyCount']).toBe(2)
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.1')
+
+    // Third consecutive strike: the staged marker is abandoned so later boots
+    // stop showing the update splash for an install that never becomes ready.
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBeUndefined()
+    expect(settingsStore['startupInstallNotReadyVersion']).toBeUndefined()
+    expect(settingsStore['startupInstallNotReadyCount']).toBeUndefined()
+
+    const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    expect(skipped).toHaveLength(3)
+    expect(skipped[2]?.[1]).toMatchObject({
+      reason: 'not_ready',
+      consecutive_not_ready: 3,
+      abandoned: true
+    })
+
+    // With the marker gone, the next boot is a normal one (no splash, no wait).
+    expect(updater.hasPendingStartupUpdate()).toBe(false)
+  })
+
+  it('does not abandon a version restaged during the wait', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    settingsStore['startupInstallNotReadyVersion'] = '1.0.1'
+    settingsStore['startupInstallNotReadyCount'] = 2
+    // On what would be 1.0.1's third strike, a newer installer finishes
+    // downloading during the check: update-downloaded restages the pending
+    // marker to 1.0.2 and flips the state to ready for 1.0.2.
+    fakeUpdater.checkForUpdates = vi.fn(async () => {
+      for (const cb of listeners['update-downloaded'] || []) cb({ version: '1.0.2' })
+      return { updateInfo: { version: '1.0.2' } }
+    })
+    const updater = await bootUpdater()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    // The restaged 1.0.2 marker must survive 1.0.1's strikes.
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.2')
+    expect(settingsStore['startupInstallNotReadyVersion']).toBeUndefined()
+    expect(settingsStore['startupInstallNotReadyCount']).toBeUndefined()
+    const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    expect(skipped[0]?.[1]).toMatchObject({
+      reason: 'not_ready',
+      version: '1.0.1',
+      wait_outcome: 'version_mismatch',
+      abandoned: false
+    })
+  })
+
+  it('skips without starting the countdown when the session begins ending during the check', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    // The OS session starts ending while the ready check is in flight.
+    fakeUpdater.checkForUpdates = vi.fn(async () => {
+      sessionEnding = true
+      for (const cb of listeners['update-downloaded'] || []) cb({ version: '1.0.1' })
+      return { updateInfo: { version: '1.0.1' } }
+    })
+    const updater = await bootUpdater()
+    const onInstallCommitted = vi.fn()
+    expect(await updater.applyPendingUpdateOnStartup({ onInstallCommitted })).toBe(false)
+    // The user must never watch an install countdown for an aborted install.
+    expect(onInstallCommitted).not.toHaveBeenCalled()
+    expect(fakeUpdater.restartAndInstall).not.toHaveBeenCalled()
+    // No attempt marker was written, so the install retries on the next boot.
+    expect(settingsStore['lastStartupUpdateAttemptVersion']).toBeUndefined()
+    const skipped = findEmitCalls('comfy.desktop.app_update.startup_install_skipped')
+    expect(skipped[0]?.[1]).toMatchObject({ reason: 'session_ending', version: '1.0.1' })
+  })
+
+  it('a different staged version restarts the not-ready strike count', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.2'
+    settingsStore['startupInstallNotReadyVersion'] = '1.0.1'
+    settingsStore['startupInstallNotReadyCount'] = 2
+    readyVersion = null
+    const updater = await bootUpdater()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(settingsStore['startupInstallNotReadyVersion']).toBe('1.0.2')
+    expect(settingsStore['startupInstallNotReadyCount']).toBe(1)
+    expect(settingsStore['pendingDownloadedUpdateVersion']).toBe('1.0.2')
+  })
+
+  it('clears the not-ready strike counter when the staged update installs', async () => {
+    settingsStore['pendingDownloadedUpdateVersion'] = '1.0.1'
+    settingsStore['startupInstallNotReadyVersion'] = '1.0.1'
+    settingsStore['startupInstallNotReadyCount'] = 2
+    readyVersion = '1.0.1'
+    const updater = await bootUpdater()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(true)
+    expect(settingsStore['startupInstallNotReadyVersion']).toBeUndefined()
+    expect(settingsStore['startupInstallNotReadyCount']).toBeUndefined()
+  })
+
+  it('clears a stale not-ready counter once its version is no longer newer', async () => {
+    settingsStore['startupInstallNotReadyVersion'] = '1.0.0'
+    settingsStore['startupInstallNotReadyCount'] = 2
+    mockAppVersion = '1.0.0' // that version is now running
+    const updater = await bootUpdater()
+    expect(await updater.applyPendingUpdateOnStartup()).toBe(false)
+    expect(settingsStore['startupInstallNotReadyVersion']).toBeUndefined()
+    expect(settingsStore['startupInstallNotReadyCount']).toBeUndefined()
   })
 
   it('clears stale markers once the staged version is actually running', async () => {

--- a/src/main/lib/updater.ts
+++ b/src/main/lib/updater.ts
@@ -84,6 +84,12 @@ function _shouldEmitAppUpdateOnce(event: string, version: string | null): boolea
  *  the prompt) and on `update-error`. */
 let _userInitiatedDownload = false
 const _stateChangeCallbacks = new Set<(state: AppUpdateState) => void>()
+/** Observers notified on every raw `download-progress` tick, regardless of who
+ *  initiated the download. The cached `AppUpdateState` only flips to
+ *  `'downloading'` for user-initiated downloads, so the startup-install wait
+ *  needs this raw signal to detect that electron-updater rejected the cached
+ *  installer and started re-downloading it. */
+const _downloadProgressObservers = new Set<() => void>()
 let _listenersBound = false
 
 interface UpdateAttempt {
@@ -539,6 +545,7 @@ function bindUpdaterEvents(): void {
   // until `update-downloaded` flips to `'ready'`, preserving the
   // existing zero-noise auto-install UX.
   updater.on('download-progress', (info: unknown) => {
+    for (const cb of _downloadProgressObservers) cb()
     const p = asRecord(info)
     if (!p) return
     const percent = typeof p.percent === 'number' ? p.percent : null
@@ -842,17 +849,22 @@ export function recordProcessExit(): void {
  *  cap keeps a slow / offline network from ever hanging the launch. */
 const STARTUP_UPDATE_CHECK_TIMEOUT_MS = 5000
 
-/** Minimum time the "Updating…" splash stays up before the install quits the
- *  app. The bounded check above usually resolves near-instantly (the installer
- *  was already downloaded and cached), which would otherwise flash the splash
- *  for a fraction of a second before the app quits — feeling like a glitch
- *  rather than an intentional update. This floor (measured from when the splash
- *  was shown, so the check's own elapsed time counts toward it) keeps the splash
- *  up long enough for the user to read it and watch the countdown finish. Keep
- *  in sync with `UPDATE_INSTALL_COUNTDOWN_SECONDS` (updateSplash.ts), the
- *  countdown the splash shows over this window. Only applies when a splash is
- *  actually up (startup-install path). */
+/** How long the splash stays up between committing to the install and quitting
+ *  the app to run it. Measured from the commit point (when the splash swaps to
+ *  its install-countdown copy), so the countdown the user is watching runs its
+ *  full length regardless of how long the readiness check took. Keep in sync
+ *  with `UPDATE_INSTALL_COUNTDOWN_SECONDS` (updateSplash.ts). Only applies when
+ *  a splash is actually up (startup-install path). */
 const STARTUP_INSTALL_MIN_SPLASH_MS = 5000
+
+/** Consecutive boots that may skip the same staged version as not-ready before
+ *  the staged marker is abandoned. Each such boot costs the user a splash plus
+ *  the bounded wait, so a staged installer that never becomes ready (corrupt or
+ *  partial on disk, with re-downloads that never complete before the app exits)
+ *  must not show that splash forever. Abandoning only clears the marker: if a
+ *  background re-download later completes, `update-downloaded` re-stages the
+ *  version and the next boot installs it normally. */
+const STARTUP_INSTALL_NOT_READY_LIMIT = 3
 
 /** Why a startup install was or wasn't attempted. The skip reasons that carry
  *  canary signal (`loop_breaker`, `session_ending`, `not_ready`) are reported via
@@ -937,33 +949,53 @@ export function hasPendingStartupUpdate(): boolean {
   return evaluateStartupInstall(readStartupAttemptMarker()).attempt
 }
 
+/** How the bounded startup update check settled. Only `'ready'` can lead to an
+ *  install; the others mean "bail into the normal UI now" and say why:
+ *  `'downloading'` = the cached installer was rejected and electron-updater
+ *  started re-downloading it (finishing takes minutes, not the seconds the boot
+ *  wait allows), `'check_failed'` = the feed check found no applicable update
+ *  (offline, feed error, or the update was pulled), `'timeout'` = the deadline
+ *  passed without any of the above. */
+type StartupUpdateWaitOutcome = 'ready' | 'downloading' | 'check_failed' | 'timeout'
+
 /**
- * Kick off a startup update check and resolve once the update reaches the
- * `'ready'` state or the deadline passes. Don't rely on `runCheck` resolving to
- * imply readiness — the `'ready'` transition happens in the `update-downloaded`
- * handler, which (depending on the updater) can fire slightly after the check
- * promise settles. Subscribing first closes that race.
+ * Kick off a startup update check and resolve with how it settled. Don't rely
+ * on `runCheck` resolving to imply readiness - the `'ready'` transition happens
+ * in the `update-downloaded` handler, which (depending on the updater) can fire
+ * slightly after the check promise settles. Subscribing first closes that race.
+ *
+ * Resolves as soon as the outcome is knowable instead of always burning the
+ * full deadline: a `download-progress` tick proves the staged installer was
+ * invalid and a full re-download is underway (which cannot finish within a
+ * boot-time budget), and a check that finds no applicable update means the
+ * ready state can never be reached this launch.
  */
-function waitForReadyState(timeoutMs: number): Promise<void> {
-  if (getCurrentUpdateState().kind === 'ready') return Promise.resolve()
-  return new Promise<void>((resolve) => {
+function waitForStartupUpdateOutcome(timeoutMs: number): Promise<StartupUpdateWaitOutcome> {
+  if (getCurrentUpdateState().kind === 'ready') return Promise.resolve('ready')
+  return new Promise<StartupUpdateWaitOutcome>((resolve) => {
     let done = false
-    const finish = (): void => {
+    const finish = (outcome: StartupUpdateWaitOutcome): void => {
       if (done) return
       done = true
       unsub()
+      _downloadProgressObservers.delete(onDownloadProgress)
       clearTimeout(timer)
-      resolve()
+      resolve(outcome)
     }
     const unsub = onUpdateStateChanged((s) => {
-      if (s.kind === 'ready') finish()
+      if (s.kind === 'ready') finish('ready')
     })
-    const timer = setTimeout(finish, timeoutMs)
+    const onDownloadProgress = (): void => finish('downloading')
+    _downloadProgressObservers.add(onDownloadProgress)
+    const timer = setTimeout(() => finish('timeout'), timeoutMs)
     runCheck('startup-install')
-      .then(() => {
-        if (getCurrentUpdateState().kind === 'ready') finish()
+      .then((result) => {
+        if (getCurrentUpdateState().kind === 'ready') finish('ready')
+        else if (!result.available) finish('check_failed')
+        // Otherwise an update exists upstream but isn't ready yet; keep
+        // waiting for a ready transition, a re-download tick, or the deadline.
       })
-      .catch(() => {})
+      .catch(() => finish('check_failed'))
   })
 }
 
@@ -977,12 +1009,16 @@ function waitForReadyState(timeoutMs: number): Promise<void> {
  * usual) when there's nothing to do, the check can't confirm a ready update, or
  * the loop-breaker is engaged.
  *
- * `splashShownAt` is the timestamp (from `Date.now()`) when the caller put up
- * the "Updating…" splash; when provided, the install is held until the splash
- * has been visible for at least `STARTUP_INSTALL_MIN_SPLASH_MS` so it doesn't
- * flash by before the app quits.
+ * `hooks.onInstallCommitted` is called once the staged update is confirmed
+ * ready and the install WILL proceed, before the pre-install splash hold
+ * starts. The caller uses it to swap the splash from its "checking" copy to the
+ * install countdown, so the countdown only ever shows for a real install.
  */
-export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promise<boolean> {
+export interface StartupInstallHooks {
+  onInstallCommitted?: () => void | Promise<void>
+}
+
+export async function applyPendingUpdateOnStartup(hooks?: StartupInstallHooks): Promise<boolean> {
   // Clear markers that no longer point at a strictly-newer target, while
   // preserving genuinely-newer attempts so the loop-breaker below stays armed.
   const running = app.getVersion()
@@ -1027,6 +1063,11 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   }
   if (pendingVersion && !isStrictlyNewerVersion(pendingVersion, running)) {
     settings.set('pendingDownloadedUpdateVersion', undefined)
+  }
+  const notReadyVersion = settings.get('startupInstallNotReadyVersion')
+  if (notReadyVersion && !isStrictlyNewerVersion(notReadyVersion, running)) {
+    settings.set('startupInstallNotReadyVersion', undefined)
+    settings.set('startupInstallNotReadyCount', undefined)
   }
   const pendingAttemptId = settings.get('pendingDesktopUpdateAttemptId')
   const pendingAttemptVersion = settings.get('pendingDesktopUpdateAttemptVersion')
@@ -1083,34 +1124,99 @@ export async function applyPendingUpdateOnStartup(splashShownAt?: number): Promi
   }
 
   // The installer is cached on disk from a previous session; this check
-  // re-validates it (no re-download) and populates the updater's ready state.
-  // Bounded so a slow/offline network can't hang boot — if it doesn't resolve
-  // to a ready update in time, we open the UI and try again next launch.
-  await waitForReadyState(STARTUP_UPDATE_CHECK_TIMEOUT_MS)
+  // usually just re-validates it (no re-download) and populates the updater's
+  // ready state. Bounded so a slow/offline network can't hang boot - if it
+  // doesn't resolve to a ready update in time, we open the UI and try again
+  // next launch. When the cached installer turns out invalid, electron-updater
+  // deletes it and starts a re-download; the wait detects that and bails
+  // immediately so the user gets into the app while the download continues in
+  // the background (a completed download re-stages the update for next boot).
+  const waitOutcome = await waitForStartupUpdateOutcome(STARTUP_UPDATE_CHECK_TIMEOUT_MS)
 
   const state = getCurrentUpdateState()
   // Require the ready version to be the exact staged version we decided to
-  // install — a concurrent check could surface a different (or no) ready
+  // install - a concurrent check could surface a different (or no) ready
   // version, which must not bypass the loop-breaker recorded for `decision.version`.
   if (state.kind !== 'ready' || state.version !== decision.version) {
+    // Bound how many consecutive boots may skip this same version as not-ready.
+    // Without a bound, a permanently-invalid staged installer (e.g. a corrupt
+    // or partial file whose re-download never completes before the app exits)
+    // would show the update splash on every boot forever. After the limit, the
+    // staged marker is abandoned; a later completed download re-stages it.
+    const seenVersion = settings.get('startupInstallNotReadyVersion')
+    const seenCount = settings.get('startupInstallNotReadyCount')
+    const consecutive =
+      (seenVersion === decision.version && typeof seenCount === 'number' ? seenCount : 0) + 1
+    // `update-downloaded` can restage the pending marker DURING the wait (e.g. a
+    // newer version finished downloading). Strikes only apply while the marker
+    // still belongs to the version this boot decided to install; a restaged
+    // marker must never be abandoned on the old version's strikes.
+    const pendingNow = settings.get('pendingDownloadedUpdateVersion')
+    const markerStillOurs = pendingNow === decision.version
+    const abandoned = markerStillOurs && consecutive >= STARTUP_INSTALL_NOT_READY_LIMIT
+    try {
+      if (abandoned) {
+        settings.set('pendingDownloadedUpdateVersion', undefined)
+        settings.set('startupInstallNotReadyVersion', undefined)
+        settings.set('startupInstallNotReadyCount', undefined)
+      } else if (markerStillOurs) {
+        settings.set('startupInstallNotReadyVersion', decision.version)
+        settings.set('startupInstallNotReadyCount', consecutive)
+      } else {
+        // A different version is staged now; the old version's strikes are
+        // obsolete and the new version starts with a clean count.
+        settings.set('startupInstallNotReadyVersion', undefined)
+        settings.set('startupInstallNotReadyCount', undefined)
+      }
+    } catch {
+      // Best-effort: if settings can't persist, next boot just repeats the
+      // bounded wait, which is the pre-counter behavior.
+    }
     emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', decision.version, {
       reason: 'not_ready',
-      version: decision.version
+      version: decision.version,
+      // Ready state with the wrong version means a concurrent check surfaced a
+      // different update than the one staged for install.
+      wait_outcome:
+        waitOutcome === 'ready' || state.kind === 'ready' ? 'version_mismatch' : waitOutcome,
+      consecutive_not_ready: consecutive,
+      abandoned
     })
     return false
   }
-  // Hold the "Updating…" splash on screen for a readable minimum before the
-  // install quits the app. The check above often resolves instantly (cached
-  // installer), so without this the splash would flash by in a fraction of a
-  // second. Measured from when the splash was shown, so the check's own elapsed
-  // time counts toward the floor.
-  if (splashShownAt !== undefined) {
-    const remaining = STARTUP_INSTALL_MIN_SPLASH_MS - (Date.now() - splashShownAt)
-    if (remaining > 0) await new Promise<void>((resolve) => setTimeout(resolve, remaining))
+  // The staged update is confirmed and the install will proceed; the not-ready
+  // strike counter no longer applies to this version.
+  try {
+    settings.set('startupInstallNotReadyVersion', undefined)
+    settings.set('startupInstallNotReadyCount', undefined)
+  } catch {
+    // Stale counter keys are also cleaned up by the marker hygiene above.
   }
 
-  // The session may have started ending while we awaited the check / held the
-  // splash up.
+  // The session may have started ending while we awaited the check. Skip
+  // before the commit hook so the user is never shown an install countdown
+  // for an install that must not happen.
+  if (isSessionEnding()) {
+    emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', state.version, {
+      reason: 'session_ending',
+      version: state.version
+    })
+    return false
+  }
+
+  // Commit point for the caller's splash: swap it from "checking" to the
+  // install countdown (awaited so the hold starts only once the countdown is
+  // actually on screen), then hold so the countdown plays out before the app
+  // quits. The hold is measured from here (not from when the splash appeared)
+  // so it matches the countdown the user just started watching. Keep
+  // `STARTUP_INSTALL_MIN_SPLASH_MS` in sync with
+  // `UPDATE_INSTALL_COUNTDOWN_SECONDS` (updateSplash.ts).
+  if (hooks) {
+    await hooks.onInstallCommitted?.()
+    await new Promise<void>((resolve) => setTimeout(resolve, STARTUP_INSTALL_MIN_SPLASH_MS))
+  }
+
+  // The session may have started ending while the splash countdown played.
   if (isSessionEnding()) {
     emitUpdateTelemetry('comfy.desktop.app_update.startup_install_skipped', state.version, {
       reason: 'session_ending',

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -79,6 +79,15 @@ export interface KnownSettings {
    *  the same version on the next boot — the user can still install it manually
    *  via the update pill. Cleared once that version is actually running. */
   lastStartupUpdateAttemptVersion?: string
+  /** Staged version whose startup install was skipped because the update never
+   *  reached the ready state (installer still re-downloading, corrupt, or the
+   *  check failed), plus how many consecutive boots did so. After a few strikes
+   *  the stale staged marker is cleared so boots stop showing the update splash
+   *  for an install that never becomes ready. Both cleared when the version
+   *  installs, when the counter's version is no longer newer than the running
+   *  build, or when a different version gets staged. */
+  startupInstallNotReadyVersion?: string
+  startupInstallNotReadyCount?: number
   /** Opaque, locally-generated correlation id for the staged updater attempt.
    *  Contains no device or user material and may span process launches. */
   pendingDesktopUpdateAttemptId?: string
@@ -262,6 +271,8 @@ const SETTINGS_SCHEMA = {
   },
   pendingDownloadedUpdateVersion: { nullable: true, telemetry: { policy: 'omit' } },
   lastStartupUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  startupInstallNotReadyVersion: { nullable: true, telemetry: { policy: 'omit' } },
+  startupInstallNotReadyCount: { nullable: true, telemetry: { policy: 'omit' } },
   pendingDesktopUpdateAttemptId: { nullable: true, telemetry: { policy: 'omit' } },
   pendingDesktopUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
   installUpdatesOnStartup: {


### PR DESCRIPTION
Fixes the infinite Windows startup update loop where every boot shows the "Comfy Desktop is going to install an update" splash, the app exits immediately, and the next boot repeats forever with the loop breaker never engaging.

Refs #1367
Refs #1472

## Root cause (three compounding bugs)

Reproduced live on a machine stuck in the loop. The staged installer cached on disk was a partial file (~46 MB of a ~700 MB NSIS installer), and:

1. **The startup readiness wait raced the re-download.** When electron-updater rejects the cached installer during the startup check, it deletes it and silently starts a full re-download. The old `waitForReadyState(5000)` had no way to see that; it just burned its 5s deadline and reported not-ready on every boot.
2. **The `not_ready` skip never armed the loop breaker.** The loop breaker only arms on the install-attempt path, so a permanently-invalid staged installer could skip forever without ever tripping it.
3. **The skip path quit the app and killed the re-download.** After a skip, `index.ts` destroyed the update splash before `openStartupSurface()` had created any other window. With zero windows, `window-all-closed` fired and quit the app - killing the in-flight re-download at a partial size, which re-staged an invalid installer for the next boot. That is what closed the loop.

## Behavior changes

- The splash now opens with "Checking for update" copy and only swaps to the install countdown at the moment the install is actually committed. The pre-quit hold is measured from that commit point, so the countdown the user watches always plays out fully, and never shows for a boot that skips the install.
- The bounded startup wait resolves as soon as the outcome is knowable instead of always burning the full 5s: a raw `download-progress` tick proves the cached installer was rejected and a re-download started (bail into the app immediately; the download continues in the background and re-stages the update for next boot), and a check that finds no applicable update means ready is unreachable this launch.
- With a corrupt/partial staged installer, the user now gets into the app quickly while the re-download proceeds in the background, instead of being quit out of the app on a loop.
- Repeated `not_ready` skips of the same staged version are bounded by a 3-strike counter (new settings keys `startupInstallNotReadyVersion` / `startupInstallNotReadyCount`, telemetry-omitted). After the limit, the stale staged marker is abandoned; a later completed download re-stages it. A marker restaged to a different version during the wait is never clobbered by the old version's strikes.
- The normal UI is opened before the splash is destroyed (in both the skip path and the install backstop), so the app can no longer self-quit through `window-all-closed` while a background re-download is in flight.
- `not_ready` skip telemetry now carries `wait_outcome` (`downloading` / `check_failed` / `timeout` / `version_mismatch`), `consecutive_not_ready`, and `abandoned`.

## Test coverage

Updated the existing startup-install tests for the new hook-based splash handoff, and added regression tests for: bailing on a re-download tick, the 3-strike abandon, strike restart on a different staged version, counter cleanup on install and via marker hygiene, a version restaged mid-wait surviving the old version's strikes, and the session ending during the check never showing the countdown.

## Change breakdown

Total changed lines: 511 (417 added, 94 deleted) across 7 files.

**Product code** - 4 files, 242 added / 73 deleted (315 lines, 62% of total):
- `src/main/lib/updater.ts` (+152/-46)
- `src/main/lib/updateSplash.ts` (+47/-17)
- `src/main/index.ts` (+32/-10)
- `src/main/settings.ts` (+11/-0)

**Test code** - 1 file, 171 added / 21 deleted (192 lines, 37% of total):
- `src/main/lib/updater.test.ts` (+171/-21)

**Localization** - 2 files, 4 added / 0 deleted (1% of total):
- `locales/en.json` (+2), `locales/zh.json` (+2) - new "checking for update" splash strings

## Verification

- `pnpm run typecheck` (all 4 configs), `pnpm run lint`, `pnpm exec prettier --check`, and the full `pnpm run test` suite (4695 tests, 272 files) all pass.
- Independent code review performed; findings fixed: an abandon could clobber a marker restaged during the wait, the countdown could start before the install was committed (and could race the initial splash render), and a throw from the apply call could strand the splash with no window handoff.

## Side note from the investigation

The affected machine could not resolve `us.i.posthog.com` (DNS failure), so the `not_ready` canary telemetry from looping machines may be undercounted.
