### PR TITLE
fix(cloud): show the Try Cloud offer to new/unsigned users

### DIFF
--- a/src/renderer/src/composables/useCloudGate.test.ts
+++ b/src/renderer/src/composables/useCloudGate.test.ts
@@ -113,6 +113,15 @@ describe('the gate fails closed', () => {
     await gate.resolve()
     expect(gate.canOffer.value).toBe(false)
   })
+
+  // A tier-fetch error is NOT a new-user `'unknown'` — we don't know if they're
+  // paying, so advertising "free" would be wrong. Fail closed.
+  it('stays shut when the tier lookup throws', async () => {
+    stubApi({ getCloudUserTier: vi.fn().mockRejectedValue(new Error('offline')) })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(false)
+  })
 })
 
 describe('the offer targets non-paying users', () => {
@@ -123,19 +132,11 @@ describe('the offer targets non-paying users', () => {
     expect(gate.canOffer.value).toBe(true)
   })
 
-  // The "Try Cloud free" copy targets new/unsigned users, whose tier reads
-  // `'unknown'` until the cloud page signs in. They must see the offer.
-  it('offers when the tier is still unknown (fresh, unsigned launch)', async () => {
+  // The "Try Cloud free" copy targets new/unsigned users, whose tier resolves to
+  // `'unknown'` until the cloud page signs in. A *resolved* unknown must offer —
+  // distinct from a fetch error, which fails closed above.
+  it('offers when the tier resolves to unknown (fresh, unsigned launch)', async () => {
     stubApi({ getCloudUserTier: vi.fn().mockResolvedValue('unknown') })
-    const gate = setup()
-    await gate.resolve()
-    expect(gate.canOffer.value).toBe(true)
-  })
-
-  // A tier lookup failure falls back to `'unknown'`, which is not `'paid'`, so
-  // the offer still shows — the flag + cloud-install checks are what fail closed.
-  it('offers when the tier lookup throws (falls back to unknown)', async () => {
-    stubApi({ getCloudUserTier: vi.fn().mockRejectedValue(new Error('offline')) })
     const gate = setup()
     await gate.resolve()
     expect(gate.canOffer.value).toBe(true)

--- a/src/renderer/src/composables/useCloudGate.test.ts
+++ b/src/renderer/src/composables/useCloudGate.test.ts
@@ -107,18 +107,38 @@ describe('the gate fails closed', () => {
     expect(gate.canOffer.value).toBe(false)
   })
 
-  it('stays shut when a signal throws', async () => {
+  it('stays shut when the flag fetch throws', async () => {
     stubApi({ getCloudFreeRunsEnabled: vi.fn().mockRejectedValue(new Error('offline')) })
     const gate = setup()
     await gate.resolve()
     expect(gate.canOffer.value).toBe(false)
   })
+})
 
-  it('stays shut when the tier lookup throws', async () => {
+describe('the offer targets non-paying users', () => {
+  it('offers to a confirmed free user', async () => {
+    stubApi({ getCloudUserTier: vi.fn().mockResolvedValue('free') })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(true)
+  })
+
+  // The "Try Cloud free" copy targets new/unsigned users, whose tier reads
+  // `'unknown'` until the cloud page signs in. They must see the offer.
+  it('offers when the tier is still unknown (fresh, unsigned launch)', async () => {
+    stubApi({ getCloudUserTier: vi.fn().mockResolvedValue('unknown') })
+    const gate = setup()
+    await gate.resolve()
+    expect(gate.canOffer.value).toBe(true)
+  })
+
+  // A tier lookup failure falls back to `'unknown'`, which is not `'paid'`, so
+  // the offer still shows — the flag + cloud-install checks are what fail closed.
+  it('offers when the tier lookup throws (falls back to unknown)', async () => {
     stubApi({ getCloudUserTier: vi.fn().mockRejectedValue(new Error('offline')) })
     const gate = setup()
     await gate.resolve()
-    expect(gate.canOffer.value).toBe(false)
+    expect(gate.canOffer.value).toBe(true)
   })
 })
 

--- a/src/renderer/src/composables/useCloudGate.ts
+++ b/src/renderer/src/composables/useCloudGate.ts
@@ -9,8 +9,9 @@ import type { CloudUserTier, Installation } from '../types/ipc'
 export interface CloudGate {
   freeRunsEnabled: Ref<boolean>
   userTier: Ref<CloudUserTier>
-  /** True once the flag and tier both allow an offer AND a cloud installation
-   *  exists to launch. Never true before `resolve()` has run. */
+  /** True once the free-runs flag is on, the user isn't a confirmed paying
+   *  customer, AND a cloud installation exists to launch. Never true before
+   *  `resolve()` has run. */
   canOffer: ComputedRef<boolean>
   resolve: () => Promise<void>
   openCloud: () => Promise<boolean>
@@ -55,8 +56,13 @@ export function useCloudGate(options: { immediate?: boolean } = {}): CloudGate {
     cloudInstall.value = install
   }
 
+  // Offer to everyone who isn't a confirmed paying customer — the "Try Cloud
+  // free" copy targets new/unsigned users, whose tier reads `'unknown'` until
+  // the cloud page signs in. Gating on `=== 'free'` hid it from exactly that
+  // audience on a fresh launch; `!== 'paid'` covers `'free'` and `'unknown'`
+  // while still suppressing it for paid users, where the "free" copy is wrong.
   const canOffer = computed(
-    () => freeRunsEnabled.value && userTier.value === 'free' && cloudInstall.value !== null
+    () => freeRunsEnabled.value && userTier.value !== 'paid' && cloudInstall.value !== null
   )
 
   /** Opens Cloud in its own window, leaving this install untouched. Runs the

--- a/src/renderer/src/composables/useCloudGate.ts
+++ b/src/renderer/src/composables/useCloudGate.ts
@@ -31,6 +31,10 @@ export function useCloudGate(options: { immediate?: boolean } = {}): CloudGate {
 
   const freeRunsEnabled = ref(false)
   const userTier = ref<CloudUserTier>('unknown')
+  // Distinguishes a resolved `'unknown'` (new/unsigned user — offer them) from a
+  // failed tier fetch (we don't know their tier — fail closed). Both would read
+  // `'unknown'` otherwise, and blindly advertising "free" on an error is wrong.
+  const tierResolved = ref(false)
   const cloudInstall = ref<Installation | null>(null)
 
   /** A miss re-reads through main, since the store is empty on a cold start. */
@@ -45,24 +49,40 @@ export function useCloudGate(options: { immediate?: boolean } = {}): CloudGate {
     return all.find(isCloud) ?? null
   }
 
+  async function resolveTier(): Promise<{ tier: CloudUserTier; resolved: boolean }> {
+    try {
+      return { tier: await window.api.getCloudUserTier(), resolved: true }
+    } catch {
+      // Fetch failed — leave `resolved` false so the offer fails closed rather
+      // than treating an error as a new-user `'unknown'`.
+      return { tier: 'unknown', resolved: false }
+    }
+  }
+
   async function resolve(): Promise<void> {
-    const [enabled, tier, install] = await Promise.all([
+    const [enabled, tierResult, install] = await Promise.all([
       settled(() => window.api.getCloudFreeRunsEnabled(), false),
-      settled(() => window.api.getCloudUserTier(), 'unknown' as CloudUserTier),
+      resolveTier(),
       findCloudInstall()
     ])
     freeRunsEnabled.value = enabled
-    userTier.value = tier
+    userTier.value = tierResult.tier
+    tierResolved.value = tierResult.resolved
     cloudInstall.value = install
   }
 
-  // Offer to everyone who isn't a confirmed paying customer — the "Try Cloud
+  // Offer to a non-paying user whose tier we actually resolved. The "Try Cloud
   // free" copy targets new/unsigned users, whose tier reads `'unknown'` until
-  // the cloud page signs in. Gating on `=== 'free'` hid it from exactly that
-  // audience on a fresh launch; `!== 'paid'` covers `'free'` and `'unknown'`
-  // while still suppressing it for paid users, where the "free" copy is wrong.
+  // the cloud page signs in — gating on `=== 'free'` hid it from exactly them on
+  // a fresh launch. `!== 'paid'` covers `'free'` and a resolved `'unknown'`,
+  // while `tierResolved` fails closed on a tier-fetch error (an unknown tier we
+  // couldn't confirm), and paid users stay excluded since the copy says "free".
   const canOffer = computed(
-    () => freeRunsEnabled.value && userTier.value !== 'paid' && cloudInstall.value !== null
+    () =>
+      freeRunsEnabled.value &&
+      tierResolved.value &&
+      userTier.value !== 'paid' &&
+      cloudInstall.value !== null
   )
 
   /** Opens Cloud in its own window, leaving this install untouched. Runs the


### PR DESCRIPTION
The "Try Cloud free" CTA on the loading/chooser screens never appeared on a fresh build, even with a cloud install present. Root cause: the offer gated on `userTier === 'free'`, but tier stays `'unknown'` until the cloud page signs in and hits `/customers/me` — so on a first launch (no persisted tier yet) the check fails for exactly the new, unsigned users the "free" copy is aimed at.

## Summary

Gate the offer on `userTier !== 'paid'` (covers `'free'` and a *resolved* `'unknown'`), and require that the tier fetch actually **resolved**. A resolved `'unknown'` (new/unsigned user) offers; a tier-fetch **error** fails closed — an error isn't a new-user unknown, and we shouldn't advertise "free" when we can't confirm the tier. Confirmed paying customers stay excluded. The free-runs flag and cloud-install checks remain fail-closed guards too.

The CTA is genuinely functional for a brand-new user: every boot seeds a "Comfy Cloud" install unconditionally, and clicking it opens `cloud.comfy.org`, which runs its own sign-up. So showing it pre-sign-in is the top of the acquisition funnel, not a dead end.

Context from #desktop: the team already decided to keep this CTA on generally (unintrusive in the top-right) and only suppress it on existing-install boot. This is the missing half — making it show for the new users it targets.

## Changes

- `useCloudGate.ts`: `canOffer` now checks `tierResolved && userTier !== 'paid'`; tier fetch tracks resolved-vs-errored separately instead of collapsing an error into `'unknown'`.
- `useCloudGate.test.ts`: added a resolved-`'unknown'` offers case and a tier-error fails-closed case; kept the paid-user and flag-off cases.

## Review focus

- The tier signal splits into two states now: a **resolved** `'unknown'` offers (target audience), an **errored** fetch fails closed. If you'd rather solve the `'unknown'` timing a different way (e.g. resolve tier earlier), flag it.

## Testing

- `useCloudGate` unit tests pass (21). Red/green verified both directions: the resolved-`'unknown'` case fails on the old `=== 'free'` logic; the tier-error case fails without the `tierResolved` guard.
- `InstallShowcase` (CTA consumer) tests green.
- Full local gauntlet: typecheck (node/web/e2e/integration), lint, format all pass.