### PR TITLE
fix(release): raise upload limit and bump to 1.0.47-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.47-rc.2",
+  "version": "1.0.47-rc.3",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/todesktop.json
+++ b/todesktop.json
@@ -1,7 +1,7 @@
 {
   "id": "241130tqe9q3y",
   "schemaVersion": 1,
-  "uploadSizeLimit": 60,
+  "uploadSizeLimit": 750,
   "appPath": ".",
   "appFiles": ["**", "!electron-builder.yml", "!out/**/*.map", "!bootstrap-python/**"],
   "appId": "com.todesktop.241012ess7yxs0e",


### PR DESCRIPTION
## Summary

- bump `package.json` from `1.0.47-rc.2` to `1.0.47-rc.3`
- publish an RC containing native Windows ARM64 support for NVIDIA RTX Spark systems
- raise the ToDesktop source-upload limit from 60 MB to 750 MB so the architecture-specific bootstrap resources can reach the remote build

## Feature behavior

- Native Windows ARM64 builds ship architecture-matched bootstrap Python and Visual C++ runtime components.
- The install wizard selects `beta-win-nvidia-arm64` only for a native ARM64 Desktop build; Windows x64, including Prism-emulated Desktop, continues to use x64 environments.
- The ARM64 environment uses the validated CUDA 13.4 NVIDIA bundle and avoids incompatible x64-only index-served torch stacks.

## Fixes

- Fix the `v1.0.47-rc.2` ToDesktop submission failure. CLI 1.28.1 included the multi-architecture bootstrap `extraResources` in a 609 MB source archive, exceeding the previous 60 MB configured limit.

## How merging this PR ships the build

1. `Release From Version PR` tags the merge commit as `v1.0.47-rc.3`.
2. The tag dispatches `ToDesktop Build & Release` using these notes.
3. The resulting Windows ARM64 installer is published as a pre-release alongside the existing platform builds.

## Test coverage

- Both changed JSON files parse successfully.
- The ARM64 implementation passed format, lint, typecheck, unit, integration, and macOS/Windows/Linux E2E checks before merge.
- This release PR is gated by the full CI suite; it does not modify tests.

## Install

- 👉 [comfy.org/download](https://comfy.org/download)

## Change breakdown

Total changed lines: 4 (2 added, 2 deleted).

| Category | Files | Added | Deleted | Share |
| --- | ---: | ---: | ---: | ---: |
| Product code | 0 | 0 | 0 | 0% |
| Test code | 0 | 0 | 0 | 0% |
| Configuration | 2: `package.json`, `todesktop.json` | 2 | 2 | 100% |

No documentation, generated files, lockfiles, or vendored code are changed.