### PR TITLE
fix(release): align Windows target resource paths and bump rc.4

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -156,6 +156,17 @@ jobs:
             exit 1
           fi
 
+      - name: Stage Windows bootstrap-python for ToDesktop target overrides
+        shell: bash
+        run: |
+          set -euo pipefail
+          for arch in x64 arm64; do
+            source="bootstrap-python/win-${arch}"
+            target="todesktop-targets/windows-${arch}/bootstrap-python"
+            mkdir -p "$(dirname "$target")"
+            mv "$source" "$target"
+          done
+
       - name: Build with ToDesktop
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-desktop-2",
-  "version": "1.0.47-rc.3",
+  "version": "1.0.47-rc.4",
   "description": "Comfy Desktop",
   "author": {
     "name": "Comfy Org",

--- a/todesktop.json
+++ b/todesktop.json
@@ -3,7 +3,13 @@
   "schemaVersion": 1,
   "uploadSizeLimit": 750,
   "appPath": ".",
-  "appFiles": ["**", "!electron-builder.yml", "!out/**/*.map", "!bootstrap-python/**"],
+  "appFiles": [
+    "**",
+    "!electron-builder.yml",
+    "!out/**/*.map",
+    "!bootstrap-python/**",
+    "!todesktop-targets/**"
+  ],
   "appId": "com.todesktop.241012ess7yxs0e",
   "icon": "./assets/Comfy_Logo_x512.png",
   "packageManager": "pnpm",
@@ -54,13 +60,19 @@
       "x64": {
         "extraResources": [
           { "from": "./lib", "to": "lib" },
-          { "from": "./bootstrap-python/win-x64", "to": "bootstrap-python" }
+          {
+            "from": "./todesktop-targets/windows-x64/bootstrap-python",
+            "to": "bootstrap-python"
+          }
         ]
       },
       "arm64": {
         "extraResources": [
           { "from": "./lib", "to": "lib" },
-          { "from": "./bootstrap-python/win-arm64", "to": "bootstrap-python" }
+          {
+            "from": "./todesktop-targets/windows-arm64/bootstrap-python",
+            "to": "bootstrap-python"
+          }
         ]
       }
     }
@@ -69,7 +81,10 @@
     "windows": {
       "extraResources": [
         { "from": "./lib", "to": "lib" },
-        { "from": "./bootstrap-python/win-x64", "to": "bootstrap-python" }
+        {
+          "from": "./todesktop-targets/windows-x64/bootstrap-python",
+          "to": "bootstrap-python"
+        }
       ]
     },
     "mac": {


### PR DESCRIPTION
## Release blocker

ToDesktop rejected the Windows build because corresponding `targetOverrides.windows` resources must use the same destination and source basename. The x64 and ARM64 bootstrap sources ended in `win-x64` and `win-arm64`.

## Behavior

- Stage both verified Windows bootstrap runtimes under architecture-specific parents whose leaf directory is `bootstrap-python`.
- Point x64, ARM64, and the Windows fallback override at the staged paths.
- Exclude the staging tree from normal app files so it is uploaded only as an extra resource.
- Bump the RC to `1.0.47-rc.4` for a clean release tag and ToDesktop build.

## Validation

- Parsed `package.json` and `todesktop.json` successfully.
- `git diff --check` passes.
- Confirmed corresponding target override entries now share `to: bootstrap-python` and source basename `bootstrap-python`.

## Change breakdown

Total changed lines: **36** (31 added, 5 deleted).

### Product code

- 0 files; +0 / -0; 0% of changed lines.

### Test code

- 0 files; +0 / -0; 0% of changed lines.

### Configuration and release automation

- 3 files; +31 / -5; 100% of changed lines.
- `.github/workflows/build-release.yml`
- `package.json`
- `todesktop.json`

### Documentation, generated files, lockfiles, and vendored code

- 0 files; +0 / -0; 0% of changed lines.