### PR TITLE
feat(telemetry): bridge hosted frontend errors

### DIFF
--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -36,6 +36,10 @@ export type ComfyDesktop2TelemetryProperties = Record<
   string,
   ComfyDesktop2TelemetryValue | ComfyDesktop2TelemetryValue[]
 >
+export interface ComfyDesktop2Error {
+  message: string
+  stack?: string
+}
 export type ComfyDesktop2FirebaseAuthState =
   | {
       status: 'pending'
@@ -65,6 +69,8 @@ export interface ComfyDesktop2LogsBridge {
 }
 export interface ComfyDesktop2TelemetryBridge {
   capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void
+  /** Capture a hosted-frontend exception through Desktop's privacy and release-context boundary. */
+  captureException?(error: ComfyDesktop2Error, properties?: ComfyDesktop2TelemetryProperties): void
   /** Report the hosted view's complete Firebase state for process-wide consensus. */
   reportFirebaseAuthState?(state: ComfyDesktop2FirebaseAuthState): void
 }

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "type": "module",
   "main": "./index.js",

--- a/src/main/lib/ipc/registerTelemetryHandlers.test.ts
+++ b/src/main/lib/ipc/registerTelemetryHandlers.test.ts
@@ -315,7 +315,15 @@ describe('registerTelemetryHandlers', () => {
 
     listener('telemetry:captureException')(
       { sender: { id: 8 } },
-      { message: 'boom', properties: { client: 'web', deployment: 'cloud' } }
+      {
+        message: 'boom',
+        stack: 'Error: boom\n at app.ts:1:1',
+        properties: {
+          client: 'web',
+          deployment: 'cloud',
+          error_type: 'workspace_auth_gate_initialization_failure'
+        }
+      }
     )
 
     const [err, sent] = mocks.captureExceptionAndForward.mock.calls[0]! as [
@@ -323,6 +331,8 @@ describe('registerTelemetryHandlers', () => {
       Record<string, unknown>
     ]
     expect(err.message).toBe('boom')
+    expect(err.stack).toBe('Error: boom\n at app.ts:1:1')
+    expect(sent.error_type).toBe('workspace_auth_gate_initialization_failure')
     expect(sent.deployment).toBe('local')
     expect(sent.client).toBeUndefined()
   })

--- a/src/main/lib/telemetry.test.ts
+++ b/src/main/lib/telemetry.test.ts
@@ -372,11 +372,13 @@ describe('telemetry default event properties', () => {
     setupTelemetry({ appVersion: '1.0.0', appEnv: 'prod', bind: 'id' })
     exceptions.length = 0
 
-    telemetry.captureException(new Error('boom'), { foo: 'bar' })
+    telemetry.captureException(new Error('boom'), {
+      error_type: 'workspace_auth_gate_initialization_failure'
+    })
 
     expect(exceptions).toHaveLength(1)
     expect(exceptions[0]!.properties).toMatchObject({
-      foo: 'bar',
+      error_type: 'workspace_auth_gate_initialization_failure',
       app_version: '1.0.0',
       client: 'desktop',
       $process_person_profile: false

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -35,6 +35,25 @@ function hostedBridge(): HostedFrontendBridge {
 describe('comfyPreload model access bridge', () => {
   beforeEach(() => {
     mocks.invoke.mockReset()
+    mocks.send.mockReset()
+  })
+
+  it('forwards hosted frontend exceptions through the scrubbed Desktop telemetry channel', () => {
+    const bridge = hostedBridge()
+    const error = { message: 'boom', stack: 'Error: boom\n at app.ts:1:1' }
+
+    bridge.Telemetry.captureException!(error, {
+      error_type: 'workspace_auth_gate_initialization_failure',
+      level: 'error'
+    })
+
+    expect(mocks.send).toHaveBeenCalledWith('telemetry:captureException', {
+      ...error,
+      properties: {
+        error_type: 'workspace_auth_gate_initialization_failure',
+        level: 'error'
+      }
+    })
   })
 
   it('forwards the repository URL through the desktop2 IPC contract', async () => {

--- a/src/preload/comfyPreload.test.ts
+++ b/src/preload/comfyPreload.test.ts
@@ -40,7 +40,8 @@ describe('comfyPreload model access bridge', () => {
 
   it('forwards hosted frontend exceptions through the scrubbed Desktop telemetry channel', () => {
     const bridge = hostedBridge()
-    const error = { message: 'boom', stack: 'Error: boom\n at app.ts:1:1' }
+    const error = new Error('boom')
+    error.stack = 'Error: boom\n at app.ts:1:1'
 
     bridge.Telemetry.captureException!(error, {
       error_type: 'workspace_auth_gate_initialization_failure',
@@ -48,7 +49,8 @@ describe('comfyPreload model access bridge', () => {
     })
 
     expect(mocks.send).toHaveBeenCalledWith('telemetry:captureException', {
-      ...error,
+      message: error.message,
+      stack: error.stack,
       properties: {
         error_type: 'workspace_auth_gate_initialization_failure',
         level: 'error'

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -91,7 +91,12 @@ const reportFirebaseAuthState: NonNullable<
 const captureException: NonNullable<ComfyDesktop2TelemetryBridge['captureException']> = (
   error,
   properties
-): void => sendTelemetry('telemetry:captureException', { ...error, properties })
+): void =>
+  sendTelemetry('telemetry:captureException', {
+    message: error.message,
+    ...(error.stack ? { stack: error.stack } : {}),
+    properties
+  })
 
 const Telemetry: ComfyDesktop2TelemetryBridge = {
   capture: (event, properties): void => sendTelemetry('telemetry:capture', { event, properties }),

--- a/src/preload/comfyPreload.ts
+++ b/src/preload/comfyPreload.ts
@@ -88,8 +88,14 @@ const reportFirebaseAuthState: NonNullable<
   ComfyDesktop2TelemetryBridge['reportFirebaseAuthState']
 > = (state): void => sendTelemetry('telemetry:firebaseAuthState', state)
 
+const captureException: NonNullable<ComfyDesktop2TelemetryBridge['captureException']> = (
+  error,
+  properties
+): void => sendTelemetry('telemetry:captureException', { ...error, properties })
+
 const Telemetry: ComfyDesktop2TelemetryBridge = {
   capture: (event, properties): void => sendTelemetry('telemetry:capture', { event, properties }),
+  captureException,
   reportFirebaseAuthState
 }
 

--- a/src/types/comfyDesktopBridge.ts
+++ b/src/types/comfyDesktopBridge.ts
@@ -38,6 +38,11 @@ export type ComfyDesktop2TelemetryProperties = Record<
   ComfyDesktop2TelemetryValue | ComfyDesktop2TelemetryValue[]
 >
 
+export interface ComfyDesktop2Error {
+  message: string
+  stack?: string
+}
+
 export type ComfyDesktop2FirebaseAuthState =
   | { status: 'pending' }
   | { status: 'signed_out' }
@@ -63,6 +68,8 @@ export interface ComfyDesktop2LogsBridge {
 
 export interface ComfyDesktop2TelemetryBridge {
   capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void
+  /** Capture a hosted-frontend exception through Desktop's privacy and release-context boundary. */
+  captureException?(error: ComfyDesktop2Error, properties?: ComfyDesktop2TelemetryProperties): void
   /** Report the hosted view's complete Firebase state for process-wide consensus. */
   reportFirebaseAuthState?(state: ComfyDesktop2FirebaseAuthState): void
 }


### PR DESCRIPTION
Adds a privacy-safe hosted-error bridge. Desktop remains authoritative for consent, scrubbing, deployment, and release context.

<details><summary>Full context for agent readers</summary>

## Product

- Adds optional `Telemetry.captureException()` to the hosted frontend bridge.
- Routes errors through the existing `telemetry:captureException` main-process boundary.
- Sends only error message/stack plus primitive telemetry properties; Desktop scrubs those fields before SDK delivery.
- Preserves host-authoritative `app_version`, channel, environment, client, and deployment properties.
- Bumps `@comfyorg/comfyui-desktop-bridge-types` to 0.2.1 so the optional contract can publish after merge.

## Tests

- 139 focused tests pass across preload, IPC boundary, and main telemetry.
- Full commit-hook typecheck, lint, and format checks pass.
- Generated bridge declaration check passes.

## Coordination

Frontend consumption is a separate companion PR. Older Desktop builds remain compatible because the new bridge member is optional.

Program row: `tele-desktop-1` (Desktop telemetry delivery).

</details>


Justification: Merged without pre-merge approval under release time pressure, authorized offline by the author, as the required companion to Comfy-Org/ComfyUI_frontend#16917 which lands in the same window. No human has reviewed this PR, and no approval of any revision exists. Risk is limited: +61/-4 across 7 files, additive host-side telemetry bridge with no existing call site changed, 15/15 checks green. Post-merge peer review is owed.
