### PR TITLE
fix(linux): reject x64 runtimes on ARM64

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -156,7 +156,7 @@ jobs:
             exit 1
           fi
 
-      - name: Stage Windows bootstrap-python for ToDesktop target overrides
+      - name: Stage bootstrap-python for ToDesktop target overrides
         shell: bash
         run: |
           set -euo pipefail
@@ -166,6 +166,8 @@ jobs:
             mkdir -p "$(dirname "$target")"
             mv "$source" "$target"
           done
+          mkdir -p todesktop-targets/linux-x64
+          mv bootstrap-python/linux-x64 todesktop-targets/linux-x64/bootstrap-python
 
       - name: Build with ToDesktop
         shell: bash

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -168,6 +168,10 @@ jobs:
           done
           mkdir -p todesktop-targets/linux-x64
           mv bootstrap-python/linux-x64 todesktop-targets/linux-x64/bootstrap-python
+          # ToDesktop requires matching resource paths across architectures.
+          # Keep the ARM64 directory nonempty for upload, without a Python binary.
+          mkdir -p todesktop-targets/linux-arm64/bootstrap-python
+          printf '%s\n' 'Bootstrap Python is not available for Linux ARM64.' > todesktop-targets/linux-arm64/bootstrap-python/README.txt
 
       - name: Build with ToDesktop
         shell: bash

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -85,7 +85,9 @@ linux:
   extraResources:
     - from: resources/apparmor-profile
       to: apparmor-profile
-    - from: bootstrap-python/linux-x64
+    # Resolve against the target architecture. No linux-arm64 bootstrap exists
+    # yet, so ARM64 packages omit it instead of shipping an unusable x64 binary.
+    - from: bootstrap-python/linux-${arch}
       to: bootstrap-python
       filter:
         - '**/*'

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "init": "pnpm install && pnpm run bootstrap",
     "init:dev": "pnpm run init && pnpm run dev",
-    "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
+    "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-'+process.arch;if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
     "dev": "electron-vite dev",
-    "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-x64';if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('node scripts/build-bootstrap-python.mjs',{stdio:'inherit'})}\"",
+    "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-'+process.arch;if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('node scripts/build-bootstrap-python.mjs',{stdio:'inherit'})}\"",
     "dev:bootstrap": "node -e \"process.env.COMFY_FORCE_BOOTSTRAP_GIT='1';require('child_process').execSync('electron-vite dev',{stdio:'inherit',env:process.env})\"",
     "build": "pnpm run typecheck && electron-vite build",
     "start": "electron-vite preview",

--- a/scripts/build-bootstrap-python.mjs
+++ b/scripts/build-bootstrap-python.mjs
@@ -101,11 +101,12 @@ const STRIP_FILES = new Set([
 
 function detectPlatform() {
   const sys = process.platform
-  // Windows is the only platform with two bootstrap builds; the running
-  // Node's architecture is the one the resulting python.exe must match.
+  // The running Node's architecture is the one the resulting Python must
+  // match. Do not silently substitute linux-x64 on ARM64: that produces a
+  // bootstrap which exists but cannot execute on the target machine.
   if (sys === 'win32') return process.arch === 'arm64' ? 'win-arm64' : 'win-x64'
   if (sys === 'darwin') return 'mac-arm64'
-  if (sys === 'linux') return 'linux-x64'
+  if (sys === 'linux' && process.arch === 'x64') return 'linux-x64'
   throw new Error(`Unsupported platform: ${sys} ${process.arch}`)
 }
 

--- a/src/main/sources/standalone/arm64Packaging.test.ts
+++ b/src/main/sources/standalone/arm64Packaging.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs'
+import path from 'path'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+interface ExtraResource {
+  from: string
+  to: string
+}
+
+interface ToDesktopConfig {
+  targetOverrides?: {
+    linux?: Record<string, { extraResources?: ExtraResource[] }>
+  }
+}
+
+describe('Linux ARM64 packaging', () => {
+  it('keeps the x64 bootstrap out of the ToDesktop ARM64 target', () => {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'todesktop.json'), 'utf-8')
+    ) as ToDesktopConfig
+    const linuxTargets = config.targetOverrides?.linux
+    const x64Resources = linuxTargets?.x64?.extraResources ?? []
+    const arm64Resources = linuxTargets?.arm64?.extraResources ?? []
+    const x64Bootstrap = x64Resources.find((resource) => resource.to === 'bootstrap-python')
+
+    expect(x64Bootstrap).toEqual({
+      from: './todesktop-targets/linux-x64/bootstrap-python',
+      to: 'bootstrap-python'
+    })
+    expect(path.posix.basename(x64Bootstrap!.from)).toBe(x64Bootstrap!.to)
+    expect(arm64Resources.some((resource) => resource.to === 'bootstrap-python')).toBe(false)
+  })
+
+  it('stages the Linux x64 bootstrap at the target-specific ToDesktop path', () => {
+    const workflow = fs.readFileSync(
+      path.join(process.cwd(), '.github', 'workflows', 'build-release.yml'),
+      'utf-8'
+    )
+
+    expect(workflow).toContain(
+      'mv bootstrap-python/linux-x64 todesktop-targets/linux-x64/bootstrap-python'
+    )
+  })
+
+  it('resolves local electron-builder bootstraps from the target architecture', () => {
+    const config = parse(
+      fs.readFileSync(path.join(process.cwd(), 'electron-builder.yml'), 'utf-8')
+    ) as { linux?: { extraResources?: ExtraResource[] } }
+    const bootstrap = config.linux?.extraResources?.find(
+      (resource) => resource.to === 'bootstrap-python'
+    )
+
+    expect(bootstrap?.from).toBe('bootstrap-python/linux-${arch}')
+  })
+})

--- a/src/main/sources/standalone/arm64Packaging.test.ts
+++ b/src/main/sources/standalone/arm64Packaging.test.ts
@@ -15,7 +15,7 @@ interface ToDesktopConfig {
 }
 
 describe('Linux ARM64 packaging', () => {
-  it('keeps the x64 bootstrap out of the ToDesktop ARM64 target', () => {
+  it('uses matching ToDesktop resource paths with a separate ARM64 placeholder', () => {
     const config = JSON.parse(
       fs.readFileSync(path.join(process.cwd(), 'todesktop.json'), 'utf-8')
     ) as ToDesktopConfig
@@ -23,13 +23,23 @@ describe('Linux ARM64 packaging', () => {
     const x64Resources = linuxTargets?.x64?.extraResources ?? []
     const arm64Resources = linuxTargets?.arm64?.extraResources ?? []
     const x64Bootstrap = x64Resources.find((resource) => resource.to === 'bootstrap-python')
+    const arm64Bootstrap = arm64Resources.find((resource) => resource.to === 'bootstrap-python')
+
+    // ToDesktop permits architecture-specific sources, but every target must
+    // have the same destinations and source basenames, in the same order.
+    const resourcePaths = (resources: ExtraResource[]): string[] =>
+      resources.map((resource) => path.posix.join(resource.to, path.posix.basename(resource.from)))
+    expect(resourcePaths(arm64Resources)).toEqual(resourcePaths(x64Resources))
 
     expect(x64Bootstrap).toEqual({
       from: './todesktop-targets/linux-x64/bootstrap-python',
       to: 'bootstrap-python'
     })
     expect(path.posix.basename(x64Bootstrap!.from)).toBe(x64Bootstrap!.to)
-    expect(arm64Resources.some((resource) => resource.to === 'bootstrap-python')).toBe(false)
+    expect(arm64Bootstrap).toEqual({
+      from: './todesktop-targets/linux-arm64/bootstrap-python',
+      to: 'bootstrap-python'
+    })
   })
 
   it('stages the Linux x64 bootstrap at the target-specific ToDesktop path', () => {

--- a/src/main/sources/standalone/envPaths.test.ts
+++ b/src/main/sources/standalone/envPaths.test.ts
@@ -122,9 +122,9 @@ describe('getTorchVersion', () => {
   })
 })
 
-// --- Windows ARM64 vendor ids (win-nvidia-arm64: NVIDIA RTX Spark) ---
+// --- Architecture-specific vendor ids (for example win-nvidia-arm64) ---
 
-describe('Windows ARM64 vendor ids', () => {
+describe('architecture-specific vendor ids', () => {
   const realPlatform = process.platform
   const realArch = process.arch
   function setHost(platform: NodeJS.Platform, arch: NodeJS.Architecture): void {
@@ -191,9 +191,21 @@ describe('Windows ARM64 vendor ids', () => {
       expect(variantMatchesHostArch('mac-mps-arm64')).toBe(false)
     })
 
-    it('linux has no per-architecture bundles', () => {
+    it('an x64 Linux app sees only the current unsuffixed x64 bundles', () => {
       setHost('linux', 'x64')
       expect(variantMatchesHostArch('linux-nvidia')).toBe(true)
+      expect(variantMatchesHostArch('linux-nvidia-arm64')).toBe(false)
+    })
+
+    it('an ARM64 Linux app rejects x64 bundles and accepts only explicit ARM64 bundles', () => {
+      setHost('linux', 'arm64')
+      expect(variantMatchesHostArch('linux-nvidia')).toBe(false)
+      expect(variantMatchesHostArch('linux-nvidia-arm64')).toBe(true)
+    })
+
+    it('rejects bundles on unsupported CPU architectures', () => {
+      setHost('linux', 'arm')
+      expect(variantMatchesHostArch('linux-nvidia')).toBe(false)
       expect(variantMatchesHostArch('linux-nvidia-arm64')).toBe(false)
     })
   })

--- a/src/main/sources/standalone/envPaths.ts
+++ b/src/main/sources/standalone/envPaths.ts
@@ -41,12 +41,12 @@ export function stripPlatform(variantId: string): string {
   return variantId.replace(/^(?:beta-)?(win|mac|linux)-/, '')
 }
 
-/** Vendor-id suffix naming a native Windows ARM64 bundle (`win-nvidia-arm64`).
- *  Windows is the only platform with per-architecture bundles: macOS bundles
- *  are ARM64 without a suffix (`mac-mps`) and everything else is x64. */
+/** Vendor-id suffix naming an architecture-specific ARM64 bundle
+ *  (`win-nvidia-arm64`, or a future `linux-nvidia-arm64`). macOS bundles are
+ *  ARM64 without a suffix (`mac-mps`). */
 export const ARM64_SUFFIX = '-arm64'
 
-/** True for a vendor id that names a native Windows ARM64 bundle. */
+/** True for a vendor id that names a native ARM64 bundle. */
 export function isArm64Variant(variantId: string): boolean {
   return variantId.endsWith(ARM64_SUFFIX)
 }
@@ -66,13 +66,17 @@ export function variantAccel(variantId: string): string {
  * ARM64 interpreter cannot run under x64, and an x64 app on an ARM64 machine
  * runs under Prism emulation, where the x64 bundle is the one that works.
  * `process.arch` reports the app binary's architecture, which is exactly the
- * architecture the bundle has to match. Non-Windows platforms have no
- * suffixed bundles, so every unsuffixed id matches there.
+ * architecture the bundle has to match. macOS is the exception: its only
+ * supported architecture is ARM64 and its bundle remains unsuffixed. Linux
+ * currently publishes only unsuffixed x64 bundles, so an ARM64 Linux app must
+ * reject them until `-arm64` bundles are available.
  */
 export function variantMatchesHostArch(variantId: string): boolean {
   const isArm64 = isArm64Variant(variantId)
-  if (process.platform !== 'win32') return !isArm64
-  return isArm64 === (process.arch === 'arm64')
+  if (process.platform === 'darwin') return !isArm64
+  if (process.arch === 'arm64') return isArm64
+  if (process.arch === 'x64') return !isArm64
+  return false
 }
 
 /** True when a vendor id targets the running platform, with or without the

--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -668,7 +668,7 @@ describe('standalone.getFieldOptions variant version display', () => {
   })
 })
 
-// --- Architecture filter: Windows publishes x64 and ARM64 bundles under one prefix ---
+// --- Architecture filter: suffixed ARM64 bundles must match the running app ---
 
 describe('standalone.getFieldOptions architecture filter', () => {
   const realPlatform = process.platform
@@ -755,6 +755,19 @@ describe('standalone.getFieldOptions architecture filter', () => {
     setupCatalog(['win-nvidia', 'win-cpu'])
     const releases = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
     expect(releases).toEqual([])
+  })
+
+  it('an ARM64 Linux app gets no release options when R2 only has x64 bundles', async () => {
+    setHost('linux', 'arm64')
+    setupCatalog(['linux-nvidia', 'linux-amd'])
+    const releases = await standalone.getFieldOptions!('release', {}, { includeLatestStable: true })
+    expect(releases).toEqual([])
+  })
+
+  it('an ARM64 Linux app accepts only explicitly suffixed ARM64 bundles', async () => {
+    setHost('linux', 'arm64')
+    setupCatalog(['linux-nvidia', 'linux-nvidia-arm64'])
+    expect(await variantIds()).toEqual(['linux-nvidia-arm64'])
   })
 
   it('macOS keeps its unsuffixed ARM64 bundle', async () => {

--- a/src/main/sources/standalone/index.ts
+++ b/src/main/sources/standalone/index.ts
@@ -419,9 +419,10 @@ export const standalone: SourcePlugin = {
       // a stale persisted ETag can otherwise hide a freshly-shipped standalone
       // release and strand new installs on whatever the previous run cached.
       const latest = (await fetchJSON(`${R2_BASE_URL}/latest.json`, { refresh: true })) as R2Latest
-      // Platform prefix AND architecture: Windows publishes separate x64 and
-      // ARM64 bundles under one prefix, and only the host's own architecture
-      // can run (see `variantMatchesHost`).
+      // Platform prefix AND architecture: only the host's own architecture can
+      // run. Windows publishes x64 and ARM64 today; Linux ARM64 intentionally
+      // gets no options until an explicitly suffixed bundle is published (see
+      // `variantMatchesHost`).
       const vendorIds = Object.keys(latest).filter((id) => variantMatchesHost(id))
       if (vendorIds.length === 0) return []
 

--- a/todesktop.json
+++ b/todesktop.json
@@ -75,6 +75,24 @@
           }
         ]
       }
+    },
+    "linux": {
+      "x64": {
+        "extraResources": [
+          { "from": "./lib", "to": "lib" },
+          { "from": "resources/apparmor-profile", "to": "apparmor-profile" },
+          {
+            "from": "./todesktop-targets/linux-x64/bootstrap-python",
+            "to": "bootstrap-python"
+          }
+        ]
+      },
+      "arm64": {
+        "extraResources": [
+          { "from": "./lib", "to": "lib" },
+          { "from": "resources/apparmor-profile", "to": "apparmor-profile" }
+        ]
+      }
     }
   },
   "platformOverrides": {
@@ -91,13 +109,6 @@
       "extraResources": [
         { "from": "./lib", "to": "lib" },
         { "from": "./bootstrap-python/mac-arm64", "to": "bootstrap-python" }
-      ]
-    },
-    "linux": {
-      "extraResources": [
-        { "from": "./lib", "to": "lib" },
-        { "from": "resources/apparmor-profile", "to": "apparmor-profile" },
-        { "from": "./bootstrap-python/linux-x64", "to": "bootstrap-python" }
       ]
     }
   }

--- a/todesktop.json
+++ b/todesktop.json
@@ -90,7 +90,11 @@
       "arm64": {
         "extraResources": [
           { "from": "./lib", "to": "lib" },
-          { "from": "resources/apparmor-profile", "to": "apparmor-profile" }
+          { "from": "resources/apparmor-profile", "to": "apparmor-profile" },
+          {
+            "from": "./todesktop-targets/linux-arm64/bootstrap-python",
+            "to": "bootstrap-python"
+          }
         ]
       }
     }


### PR DESCRIPTION
## Summary

Stops Linux ARM64 builds from receiving or selecting x86-64 Python runtimes while retaining the ARM64 Desktop shell for cloud and remote use.

## Feature behavior

- Splits ToDesktop Linux resources by target architecture. x64 keeps bootstrap Python; ARM64 receives a README-only placeholder with no Python executable. Both targets declare matching resource destinations and source basenames, as required by ToDesktop.
- Stages both Linux resource directories before the ToDesktop upload. Existing Windows bootstrap staging is preserved.
- Resolves the local electron-builder bootstrap path by target architecture and makes bootstrap auto-detection reject unsupported Linux architectures instead of substituting linux-x64.
- Requires an explicit -arm64 standalone variant on Linux ARM64. A catalog containing only x64 bundles yields no local installation options.

## Test coverage and validation

- Packaging regression coverage checks matching ToDesktop resource paths with distinct architecture-specific bootstrap sources, release staging, and electron-builder resource selection.
- Architecture-selection coverage exercises Linux x64, Linux ARM64, unsupported CPU architectures, and standalone release/variant filtering.
- Focused validation after the packaging repair: 72 tests passed across envPaths, standalone index, and ARM64 packaging.
- Executed the release workflow's staging commands in a temporary fixture: Linux x64 retained its Python fixture, Linux ARM64 contained only README.txt, and both Windows bootstraps retained their contents.
- Repository pre-commit gates: all four typechecks, lint, and formatting passed.
- git diff --check passed.
- The earlier full unit run reported 273 files and 4,725 tests passed. No remote ToDesktop build was submitted for the packaging repair.

## Change breakdown

Total changed lines: 178 (149 added, 29 deleted).

### Product code

- 3 files; +20 / -14; 34 changed lines; 19.1% of total.
- scripts/build-bootstrap-python.mjs
- src/main/sources/standalone/envPaths.ts
- src/main/sources/standalone/index.ts

### Test code

- 3 files; +95 / -4; 99 changed lines; 55.6% of total.
- src/main/sources/standalone/arm64Packaging.test.ts
- src/main/sources/standalone/envPaths.test.ts
- src/main/sources/standalone/index.test.ts

### Configuration and CI

- 4 files; +34 / -11; 45 changed lines; 25.3% of total.
- .github/workflows/build-release.yml
- electron-builder.yml
- package.json
- todesktop.json

### Documentation

- 0 files; +0 / -0; 0 changed lines; 0%.

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.
