### PR TITLE
feat(telemetry): capture typed asset scanner errors

### DIFF
--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -162,11 +162,13 @@ describe('createHardwareTap', () => {
   it('forwards a typed asset scanner error without its raw path', () => {
     const tap = createHardwareTap({ installationId: 'inst-1', release: 'v0.4.0' })
     tap.ingest(
-      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied\n',
+      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied path=/private/user/models/locked.safetensors\n',
       'stderr'
     )
+    expect(captured).toHaveLength(0)
+
     tap.ingest(
-      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied path=/private/user/models/locked.safetensors\n',
+      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied\n',
       'stderr'
     )
     tap.ingest(

--- a/src/main/lib/hardwareTap.test.ts
+++ b/src/main/lib/hardwareTap.test.ts
@@ -159,6 +159,40 @@ describe('createHardwareTap', () => {
     })
   })
 
+  it('forwards a typed asset scanner error without its raw path', () => {
+    const tap = createHardwareTap({ installationId: 'inst-1', release: 'v0.4.0' })
+    tap.ingest(
+      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied\n',
+      'stderr'
+    )
+    tap.ingest(
+      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied path=/private/user/models/locked.safetensors\n',
+      'stderr'
+    )
+    tap.ingest(
+      '[WARNING] Asset scan error: phase=discovery_stat error_type=permission_denied\n',
+      'stderr'
+    )
+
+    const errors = captured.filter(
+      (entry) => entry.event === 'comfy.desktop.comfyui.asset_scan_error'
+    )
+    expect(errors).toEqual([
+      {
+        event: 'comfy.desktop.comfyui.asset_scan_error',
+        ctx: {
+          installation_id: 'inst-1',
+          variant: null,
+          release: 'v0.4.0',
+          scan_phase: 'discovery_stat',
+          error_type: 'permission_denied'
+        }
+      }
+    ])
+    expect(JSON.stringify(errors)).not.toContain('private')
+    expect(JSON.stringify(errors)).not.toContain('locked.safetensors')
+  })
+
   it('restores every model log signal in one array-backed delta', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-18T12:00:00Z'))

--- a/src/main/lib/hardwareTap.ts
+++ b/src/main/lib/hardwareTap.ts
@@ -16,6 +16,8 @@
  *     requested loads, dynamic-VRAM prepares, and multi-GPU deepclones. Its
  *     aligned arrays preserve model class, trigger, target device, count, and
  *     UTC observation date without emitting one event per tuple.
+ *   - `comfy.desktop.comfyui.asset_scan_error` forwards typed scanner failures
+ *     without file paths or exception messages.
  *
  * Log strings parsed (current ComfyUI main branch):
  *   - "Device: cuda:0 NVIDIA GeForce RTX 4090 : native"   (model_management.py)
@@ -53,6 +55,8 @@ const CUDA_DEVICE_LINE = /^Set cuda device to:\s*(\d+)/i
 // separate line that precedes a nameless `Device: privateuseone` line, so it's
 // the only way to recover the model for those vendors.
 const DIRECTML_LINE = /^Using directml with device:\s*(.+)$/i
+const ASSET_SCAN_ERROR_LINE =
+  /^Asset scan error: phase=(reference_stat|discovery_stat|enrichment_stat|hashing) error_type=(permission_denied|os_error)$/
 
 /** Emit one array-backed delta instead of an event for every model tuple. */
 const MODEL_USAGE_FLUSH_INTERVAL_MS = 60 * 60_000
@@ -132,6 +136,7 @@ export function createHardwareTap(opts: {
   let cudaDeviceSet: number | null = null
   let directmlDeviceName: string | null = null
   const devices: AcceleratorInfo[] = []
+  const emittedAssetScanErrors = new Set<string>()
   const modelUsage = createModelUsageSummary()
   let modelUsageFlushTimer: ReturnType<typeof setInterval> | null = null
 
@@ -210,6 +215,22 @@ export function createHardwareTap(opts: {
     // anchored parsers below match both the prefixed and bare log formats.
     const trimmed = stripLogLevelPrefix(stripAnsi(line).trim())
     if (trimmed.length === 0) return
+
+    const scanError = trimmed.match(ASSET_SCAN_ERROR_LINE)
+    if (scanError) {
+      const scanPhase = scanError[1]!
+      const errorType = scanError[2]!
+      const key = `${scanPhase}:${errorType}`
+      if (!emittedAssetScanErrors.has(key)) {
+        emittedAssetScanErrors.add(key)
+        telemetry.emit('comfy.desktop.comfyui.asset_scan_error', {
+          ...baseContext,
+          scan_phase: scanPhase,
+          error_type: errorType
+        })
+      }
+      return
+    }
 
     if (!acceleratorEmitted) {
       const vram = parseVramLine(trimmed)
@@ -300,6 +321,7 @@ export function createHardwareTap(opts: {
       cudaDeviceSet = null
       directmlDeviceName = null
       devices.length = 0
+      emittedAssetScanErrors.clear()
       // Drop any incomplete lines from the previous (now-dead) process streams.
       pendingBySource.stdout = ''
       pendingBySource.stderr = ''

--- a/src/shared/datadogMirroredEvents.test.ts
+++ b/src/shared/datadogMirroredEvents.test.ts
@@ -13,6 +13,7 @@ describe('isDatadogMirroredEvent', () => {
   // boots and double its RUM volume for no monitor benefit.
   it('mirrors boot_failed but not boot_started / boot_completed', () => {
     expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_failed')).toBe(true)
+    expect(isDatadogMirroredEvent('comfy.desktop.comfyui.asset_scan_error')).toBe(true)
     expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_started')).toBe(false)
     expect(isDatadogMirroredEvent('comfy.desktop.comfyui.boot_completed')).toBe(false)
   })

--- a/src/shared/datadogMirroredEvents.ts
+++ b/src/shared/datadogMirroredEvents.ts
@@ -57,6 +57,8 @@ export const DATADOG_MIRRORED_EVENT_NAMES: ReadonlySet<string> = new Set([
   // boot_phase timings so a monitor can alert on boot-failure rate per
   // release / variant and the phase breakdown explains where it stalled.
   'comfy.desktop.comfyui.boot_failed',
+  // Asset scanner failures parsed from ComfyUI's typed, path-free log marker.
+  'comfy.desktop.comfyui.asset_scan_error',
   // Migration pipeline failures (Desktop-1 -> standalone).
   'comfy.desktop.migrate.flow.error',
   'comfy.desktop.migrate.user_files.error',


### PR DESCRIPTION
## Summary
- parse ComfyUI's strict typed scanner-error marker through the existing Desktop hardware tap
- emit a deduplicated `comfy.desktop.comfyui.asset_scan_error` event with release context, scanner phase, and error type only
- reject path-bearing malformed markers and register the event for Datadog mirroring

## Evidence
- `pnpm exec vitest run src/main/lib/hardwareTap.test.ts src/shared/datadogMirroredEvents.test.ts` — 59 passed
- `pnpm exec prettier --check src/main/lib/hardwareTap.ts src/main/lib/hardwareTap.test.ts src/shared/datadogMirroredEvents.ts src/shared/datadogMirroredEvents.test.ts` — clean
- `pnpm exec eslint src/main/lib/hardwareTap.ts src/main/lib/hardwareTap.test.ts src/shared/datadogMirroredEvents.ts src/shared/datadogMirroredEvents.test.ts` — clean
- `pnpm typecheck` — clean
- `git diff --check origin/main...HEAD` — clean
- `git diff --numstat origin/main...HEAD` — product 24 additions (39.3%); tests 37 additions (60.7%)

Risk: R1 — additive telemetry-only listener and allowlist entry.

<!-- authored-by:agent lane-scanner-error-1-1220 -->