### PR TITLE
Fix model downloads on filesystems without hard links

### DIFF
--- a/src/main/lib/modelDownloadStaging.ts
+++ b/src/main/lib/modelDownloadStaging.ts
@@ -154,6 +154,7 @@ export function removeStagedArtifacts(finalPath: string): boolean {
  *  I/O or permission failure (which must fail the parking outright). */
 export const LINK_UNSUPPORTED_CODES: ReadonlySet<string> = new Set([
   'EPERM', // Windows exFAT/FAT32 and some network filesystems
+  'EISDIR', // Node/libuv reports hard-link attempts on Windows exFAT this way
   'ENOTSUP',
   'EOPNOTSUPP',
   'ENOSYS',
@@ -321,8 +322,8 @@ export async function filesHaveSameBytes(a: string, b: string): Promise<boolean>
  * Install verified staged bytes at the final name without overwriting a file
  * that appeared there independently. An identical final is accepted and the
  * staged copy is removed; a different final is preserved and reported as a
- * conflict. Filesystems without atomic hard-link support fail closed and keep
- * the staged bytes for retry.
+ * conflict. Filesystems without hard-link support use an exclusive claim before
+ * renaming the verified bytes, matching the recovery path in startup scanning.
  */
 export async function installStagedAtFinal(
   stagingPath: string,
@@ -352,11 +353,33 @@ export async function installStagedAtFinal(
       return
     }
     if (!LINK_UNSUPPORTED_CODES.has(code ?? '')) throw err
-    if (fs.existsSync(finalPath)) {
-      await conflictOrAccept()
-      return
+    // exFAT/FAT32 and some network filesystems cannot hard-link. Claim the
+    // final name atomically before renaming so an existing model is never
+    // silently replaced. Startup scanning already recognizes and parks this
+    // zero-byte marker if the app exits between these two operations.
+    try {
+      fs.closeSync(fs.openSync(finalPath, 'wx'))
+    } catch (claimErr) {
+      if ((claimErr as NodeJS.ErrnoException).code === 'EEXIST') {
+        await conflictOrAccept()
+        return
+      }
+      throw claimErr
     }
-    throw new Error('atomic no-replace install is not supported by this filesystem', { cause: err })
+    try {
+      fs.renameSync(stagingPath, finalPath)
+    } catch (renameErr) {
+      // Move the marker aside instead of deleting it: another process may
+      // have opened or written it after our exclusive create. Parking keeps
+      // any such bytes under an inert, non-model name for manual recovery.
+      parkFileNoClobber(finalPath, (n) =>
+        n === 0
+          ? finalPath + '.claimed' + STAGING_SUFFIX
+          : finalPath + `.claimed-${n}` + STAGING_SUFFIX
+      )
+      throw renameErr
+    }
+    return
   }
   try {
     fs.unlinkSync(stagingPath)

--- a/src/main/lib/modelDownloadTransport.test.ts
+++ b/src/main/lib/modelDownloadTransport.test.ts
@@ -1102,14 +1102,12 @@ describe('final destination conflicts', () => {
     expect(fs.readFileSync(stagingPathFor(finalPath), 'utf-8')).toBe('0123456789')
   })
 
-  it('fails closed when hard links are unsupported', async () => {
+  it('installs via an exclusive claim when hard links are unsupported', async () => {
     const linkSpy = vi.spyOn(fs, 'linkSync').mockImplementation(() => {
-      const err = new Error('EPERM: operation not permitted') as NodeJS.ErrnoException
-      err.code = 'EPERM'
+      const err = new Error('EISDIR: illegal operation on a directory') as NodeJS.ErrnoException
+      err.code = 'EISDIR'
       throw err
     })
-    const openSpy = vi.spyOn(fs, 'openSync')
-    const renameSpy = vi.spyOn(fs, 'renameSync')
     try {
       const handle = startModelTransfer(baseOpts())
       const req = requests[0]!
@@ -1118,16 +1116,11 @@ describe('final destination conflicts', () => {
       res.emit('data', Buffer.from('0123456789'))
       res.emit('end')
       const outcome = await handle.done
-      expect(outcome.outcome).toBe('error')
-      expect((outcome as { error: string }).error).toMatch(/atomic no-replace/)
-      expect(fs.existsSync(finalPath)).toBe(false)
-      expect(fs.readFileSync(stagingPathFor(finalPath), 'utf-8')).toBe('0123456789')
-      expect(fs.existsSync(stagingMetaPathFor(finalPath))).toBe(true)
-      expect(openSpy).not.toHaveBeenCalledWith(finalPath, 'wx')
-      expect(renameSpy).not.toHaveBeenCalledWith(stagingPathFor(finalPath), finalPath)
+      expect(outcome).toEqual({ outcome: 'completed', savePath: finalPath, finalBytes: 10 })
+      expect(fs.readFileSync(finalPath, 'utf-8')).toBe('0123456789')
+      expect(fs.existsSync(stagingPathFor(finalPath))).toBe(false)
+      expect(fs.existsSync(stagingMetaPathFor(finalPath))).toBe(false)
     } finally {
-      renameSpy.mockRestore()
-      openSpy.mockRestore()
       linkSpy.mockRestore()
     }
   })
@@ -1185,13 +1178,27 @@ describe('final destination conflicts', () => {
     }
   })
 
-  it('a link-less filesystem never creates a final-name claim marker', async () => {
+  it('parks a link-less claim marker when the final rename fails', async () => {
     const linkSpy = vi.spyOn(fs, 'linkSync').mockImplementation(() => {
-      const err = new Error('EPERM: operation not permitted') as NodeJS.ErrnoException
-      err.code = 'EPERM'
+      const err = new Error('EISDIR: illegal operation on a directory') as NodeJS.ErrnoException
+      err.code = 'EISDIR'
       throw err
     })
-    const openSpy = vi.spyOn(fs, 'openSync')
+    const realRename = fs.renameSync.bind(fs)
+    const renameSpy = vi
+      .spyOn(fs, 'renameSync')
+      .mockImplementation((oldPath: fs.PathLike, newPath: fs.PathLike) => {
+        if (String(oldPath) === stagingPathFor(finalPath) && String(newPath) === finalPath) {
+          // Simulate another process writing into the claim before a locked
+          // staging file makes the install rename fail. Those bytes must not
+          // be deleted by cleanup.
+          fs.writeFileSync(finalPath, 'external bytes')
+          const err = new Error('EACCES: permission denied') as NodeJS.ErrnoException
+          err.code = 'EACCES'
+          throw err
+        }
+        realRename(oldPath, newPath)
+      })
     try {
       const handle = startModelTransfer(baseOpts())
       const req = requests[0]!
@@ -1203,9 +1210,10 @@ describe('final destination conflicts', () => {
       expect(outcome.outcome).toBe('error')
       expect(fs.existsSync(finalPath)).toBe(false)
       expect(fs.readFileSync(stagingPathFor(finalPath), 'utf-8')).toBe('0123456789')
-      expect(openSpy).not.toHaveBeenCalledWith(finalPath, 'wx')
+      expect(fs.readFileSync(finalPath + '.claimed.part', 'utf-8')).toBe('external bytes')
+      expect(fs.existsSync(stagingMetaPathFor(finalPath))).toBe(true)
     } finally {
-      openSpy.mockRestore()
+      renameSpy.mockRestore()
       linkSpy.mockRestore()
     }
   })


### PR DESCRIPTION
## Summary

- Finalize verified staged model downloads on exFAT, FAT32, and other filesystems that do not support hard links.
- Treat the `EISDIR` returned by Node/libuv for hard-link attempts on Windows exFAT as a link capability gap.
- Preserve destination no-clobber behavior by claiming the final name with `wx` before renaming.
- Park a failed claim under an inert `.claimed.part` name instead of deleting it, preserving bytes if another process wrote to the claim.

Related to #1450.

## Behavior

The normal hard-link path is unchanged. When the filesystem rejects hard links with a known capability error, Desktop now uses the existing exclusive-claim recovery design and atomically renames the already-verified `.part` bytes onto that claim. Existing final files are still compared and never overwritten by the fallback.

## Tests

- `modelDownloadStaging.test.ts` and `modelDownloadTransport.test.ts`: 123 passed.
- Node TypeScript typecheck passed.
- ESLint and Prettier checks passed for both changed files.
- Real Windows exFAT smoke test: reproduced `EISDIR` before the change and finalized the same staged file successfully after it.
- Full Vitest sweep plus isolated environment reruns: 4,717 passed. One unrelated Google OAuth test still times out reaching `identitytoolkit.googleapis.com` from this environment.

## Change breakdown

Total: 2 files, +57/-26, 83 changed lines.

### Product code

- 1 file: `src/main/lib/modelDownloadStaging.ts`
- +29/-6, 35 changed lines (42.2%)

### Test code

- 1 file: `src/main/lib/modelDownloadTransport.test.ts`
- +28/-20, 48 changed lines (57.8%)

### Other categories

- Documentation: none
- Configuration: none
- Generated files: none
- Lockfiles: none
- Vendored code: none
