### PR TITLE
feat(comfybuilder): enforce governed Desktop installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "@datadog/browser-rum": "6.28.1",
+    "@noble/hashes": "^2.3.0",
     "@todesktop/runtime": "^2.1.3",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@datadog/browser-rum':
         specifier: 6.28.1
         version: 6.28.1
+      '@noble/hashes':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@todesktop/runtime':
         specifier: ^2.1.3
         version: 2.1.3
@@ -835,6 +838,10 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4439,6 +4446,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/main/comfybuilder/fixtures/model-ledger-v1.json
+++ b/src/main/comfybuilder/fixtures/model-ledger-v1.json
@@ -1,0 +1,22 @@
+{
+  "ledger": {
+    "ledgerVersion": 1,
+    "entries": [
+      {
+        "path": "/opt/comfy/ComfyUI/models/checkpoints/shared-fixture.safetensors",
+        "size": 17,
+        "mtimeNs": "1735689600123456789",
+        "inode": "424242",
+        "dev": "2049",
+        "digest": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "modelLedgerKey": [
+    "/opt/comfy/ComfyUI/models/checkpoints/shared-fixture.safetensors",
+    17,
+    "1735689600123456789",
+    "424242",
+    "2049"
+  ]
+}

--- a/src/main/comfybuilder/governance.test.ts
+++ b/src/main/comfybuilder/governance.test.ts
@@ -1,0 +1,664 @@
+// @vitest-environment node
+import { createHash, generateKeyPairSync, sign as signBytes } from 'node:crypto'
+import type { KeyObject } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/download', () => ({ download: vi.fn() }))
+vi.mock('../lib/extract', () => ({ extractNested: vi.fn() }))
+
+import { download } from '../lib/download'
+import { extractNested } from '../lib/extract'
+import {
+  GOVERNANCE_MARKER_FIELD,
+  buildGovernanceMarker,
+  checkGovernedInstallPolicy,
+  decodeBase64UrlStrict,
+  governancePolicyPath,
+  governedModelDigests,
+  parseGovernanceConstants,
+  readGovernanceMarker,
+  verifyGovernanceEnvelope,
+  verifyInstalledGovernancePolicy
+} from './governance'
+import type { GovernanceMarker } from './governance'
+import { installArtifact } from './install'
+import type { Artifact } from './types'
+
+const DOMAIN_SEPARATOR = Buffer.from('comfyui-governance-v1\0', 'utf-8')
+const BUILD_IDENTITY = 'build-7|release-3|artifact-9|linux/nvidia/cu124|sha256:abcd'
+const MODEL_DIGESTS = [`blake3:${'1'.repeat(64)}`, `blake3:${'2'.repeat(64)}`]
+
+/** The three constants Builder's archive rewriter patches, in the exact
+ *  `NAME = <literal>` shape `finalizearchive/rewrite.go` emits. */
+function governanceSource(
+  values: { required: boolean; buildIdentity: string; publicKey: string } | null
+): string {
+  const required = values ? (values.required ? 'True' : 'False') : 'False'
+  const identity = JSON.stringify(values?.buildIdentity ?? '')
+  const key = JSON.stringify(values?.publicKey ?? '')
+  return [
+    'import json',
+    '',
+    `GOVERNANCE_REQUIRED = ${required}`,
+    `GOVERNANCE_BUILD_IDENTITY = ${identity}`,
+    `GOVERNANCE_PUBLIC_KEY = ${key}`,
+    'GOVERNANCE_MIN_POLICY_GENERATION = 0',
+    ''
+  ].join('\n')
+}
+
+function base64url(raw: Buffer): string {
+  return raw.toString('base64url')
+}
+
+interface Signer {
+  readonly publicKey: string
+  readonly privateKey: KeyObject
+}
+
+function makeSigner(): Signer {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const raw = publicKey.export({ format: 'der', type: 'spki' }).subarray(12)
+  return { publicKey: base64url(Buffer.from(raw)), privateKey }
+}
+
+/** A full 13-key payload, matching what `manifestsign.Build` emits, so the
+ *  verifier is exercised against the real wire shape rather than a stub. */
+function makePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    audience: 'comfyui-core',
+    versionId: 'version-42',
+    buildIdentity: BUILD_IDENTITY,
+    sourcesDigest: `sha256:${'a'.repeat(64)}`,
+    policyGeneration: 3,
+    activeForms: ['customNode', 'model'],
+    customNodeMode: 'allowlist',
+    packs: [],
+    deniedPacks: [],
+    disabledNodes: [],
+    disabledPartnerNodes: [],
+    models: MODEL_DIGESTS,
+    ...overrides
+  }
+}
+
+function makeEnvelope(signer: Signer, payload: Record<string, unknown>): string {
+  const payloadBytes = Buffer.from(JSON.stringify(payload), 'utf-8')
+  const signature = signBytes(
+    null,
+    Buffer.concat([DOMAIN_SEPARATOR, payloadBytes]),
+    signer.privateKey
+  )
+  return JSON.stringify({
+    schema: 1,
+    payload: base64url(payloadBytes),
+    signature: base64url(signature)
+  })
+}
+
+let root: string
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-governance-'))
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+/** Lay down the two files a governed archive ships: the patched constants and
+ *  the signed policy envelope. */
+function writeInstallTree(
+  installPath: string,
+  opts: {
+    constants?: { required: boolean; buildIdentity: string; publicKey: string } | null
+    source?: string
+    envelope?: string | null
+  }
+): void {
+  fs.mkdirSync(path.join(installPath, 'venv'), { recursive: true })
+  fs.mkdirSync(path.join(installPath, 'ComfyUI', 'app'), { recursive: true })
+  fs.writeFileSync(
+    path.join(installPath, 'ComfyUI', 'app', 'governance.py'),
+    opts.source ?? governanceSource(opts.constants ?? null)
+  )
+  if (opts.envelope != null) {
+    const policy = governancePolicyPath(installPath)
+    fs.mkdirSync(path.dirname(policy), { recursive: true })
+    fs.writeFileSync(policy, opts.envelope)
+  }
+}
+
+describe('verifyGovernanceEnvelope', () => {
+  it('accepts a well-formed envelope and exposes payload.models for the ledger writer', () => {
+    const signer = makeSigner()
+    const envelope = makeEnvelope(signer, makePayload())
+
+    const result = verifyGovernanceEnvelope(Buffer.from(envelope, 'utf-8'), {
+      publicKey: signer.publicKey,
+      buildIdentity: BUILD_IDENTITY
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.payload.activeForms).toEqual(['customNode', 'model'])
+    expect(result.payload.customNodeMode).toBe('allowlist')
+    expect([...result.payload.models].sort()).toEqual([...MODEL_DIGESTS].sort())
+  })
+
+  it('rejects an envelope whose signature has one flipped byte', () => {
+    const signer = makeSigner()
+    const parsed = JSON.parse(makeEnvelope(signer, makePayload())) as Record<string, string>
+    const signature = Buffer.from(parsed.signature!, 'base64url')
+    signature[0] = signature[0]! ^ 0x01
+    const tampered = JSON.stringify({ ...parsed, signature: base64url(signature) })
+
+    const result = verifyGovernanceEnvelope(Buffer.from(tampered, 'utf-8'), {
+      publicKey: signer.publicKey,
+      buildIdentity: BUILD_IDENTITY
+    })
+
+    expect(result).toMatchObject({ ok: false })
+  })
+
+  it('rejects a payload re-signed under a different key', () => {
+    const signer = makeSigner()
+    const attacker = makeSigner()
+    const envelope = makeEnvelope(attacker, makePayload())
+
+    expect(
+      verifyGovernanceEnvelope(Buffer.from(envelope, 'utf-8'), {
+        publicKey: signer.publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).toMatchObject({ ok: false })
+  })
+
+  it('rejects a validly signed envelope for a different build identity', () => {
+    const signer = makeSigner()
+    const envelope = makeEnvelope(signer, makePayload({ buildIdentity: 'some-other-build' }))
+
+    expect(
+      verifyGovernanceEnvelope(Buffer.from(envelope, 'utf-8'), {
+        publicKey: signer.publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).toMatchObject({ ok: false })
+  })
+
+  // Core rejects both of these outright, so passing one through would replace
+  // Desktop's stated refusal with a launch that dies at ComfyUI startup.
+  it.each([
+    ['a payload for another audience', { audience: 'somebody-else' }],
+    ['a payload with no audience', { audience: undefined }],
+    ['a payload with an unsupported schemaVersion', { schemaVersion: 2 }],
+    ['a payload with a non-numeric schemaVersion', { schemaVersion: '1' }]
+  ])('rejects %s', (_name, overrides) => {
+    const signer = makeSigner()
+    const envelope = makeEnvelope(signer, makePayload(overrides))
+
+    expect(
+      verifyGovernanceEnvelope(Buffer.from(envelope, 'utf-8'), {
+        publicKey: signer.publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).toMatchObject({ ok: false })
+  })
+
+  it.each([
+    ['an extra envelope key', (e: Record<string, unknown>) => ({ ...e, extra: 1 })],
+    ['a missing signature', ({ signature: _drop, ...rest }: Record<string, unknown>) => rest],
+    ['a non-1 schema', (e: Record<string, unknown>) => ({ ...e, schema: 2 })],
+    ['a padded payload', (e: Record<string, unknown>) => ({ ...e, payload: `${e.payload}=` })],
+    [
+      'a standard-alphabet signature',
+      (e: Record<string, unknown>) => ({
+        ...e,
+        signature: Buffer.from(e.signature as string, 'base64url').toString('base64')
+      })
+    ]
+  ])('rejects %s', (_name, mutate) => {
+    const signer = makeSigner()
+    const parsed = JSON.parse(makeEnvelope(signer, makePayload())) as Record<string, unknown>
+
+    expect(
+      verifyGovernanceEnvelope(Buffer.from(JSON.stringify(mutate(parsed)), 'utf-8'), {
+        publicKey: signer.publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).toMatchObject({ ok: false })
+  })
+
+  it.each([
+    ['a 31-byte key', base64url(Buffer.alloc(31))],
+    ['a padded key', `${base64url(Buffer.alloc(32))}=`],
+    ['an empty key', '']
+  ])('rejects %s recorded in the marker', (_name, publicKey) => {
+    const signer = makeSigner()
+    const envelope = makeEnvelope(signer, makePayload())
+
+    expect(
+      verifyGovernanceEnvelope(Buffer.from(envelope, 'utf-8'), {
+        publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).toMatchObject({ ok: false })
+  })
+})
+
+describe('decodeBase64UrlStrict', () => {
+  it('rejects non-canonical encodings that decode to the same bytes', () => {
+    // `AA` and `AB` both decode to a single zero byte under a lenient decoder;
+    // accepting both would let two distinct envelopes share one signature.
+    expect(decodeBase64UrlStrict('AA')?.length).toBe(1)
+    expect(decodeBase64UrlStrict('AB')).toBeNull()
+    expect(decodeBase64UrlStrict('A')).toBeNull()
+    expect(decodeBase64UrlStrict('++//')).toBeNull()
+  })
+})
+
+describe('parseGovernanceConstants', () => {
+  it('reads the patched constants the archive rewriter emits', () => {
+    const parsed = parseGovernanceConstants(
+      governanceSource({ required: true, buildIdentity: BUILD_IDENTITY, publicKey: 'key-value' })
+    )
+    expect(parsed).toEqual({
+      required: true,
+      buildIdentity: BUILD_IDENTITY,
+      publicKey: 'key-value'
+    })
+  })
+
+  it('reads stock (ungoverned) defaults as not required', () => {
+    expect(parseGovernanceConstants(governanceSource(null))).toMatchObject({ required: false })
+  })
+
+  it.each([
+    [
+      'a shadowing second assignment',
+      `${governanceSource({ required: true, buildIdentity: 'a', publicKey: 'b' })}\nGOVERNANCE_REQUIRED = False\n`
+    ],
+    [
+      'a missing constant',
+      governanceSource({ required: true, buildIdentity: 'a', publicKey: 'b' }).replace(
+        /^GOVERNANCE_PUBLIC_KEY.*$/m,
+        ''
+      )
+    ],
+    [
+      'a non-literal value',
+      governanceSource({ required: true, buildIdentity: 'a', publicKey: 'b' }).replace(
+        /^GOVERNANCE_PUBLIC_KEY.*$/m,
+        'GOVERNANCE_PUBLIC_KEY = os.environ["KEY"]'
+      )
+    ],
+    [
+      'a non-boolean required flag',
+      governanceSource({ required: true, buildIdentity: 'a', publicKey: 'b' }).replace(
+        'GOVERNANCE_REQUIRED = True',
+        'GOVERNANCE_REQUIRED = 1'
+      )
+    ]
+  ])('fails closed on %s', (_name, source) => {
+    expect(parseGovernanceConstants(source)).toBeNull()
+  })
+})
+
+describe('buildGovernanceMarker', () => {
+  it('takes the identity and key from the archive and the forms from the VERIFIED payload', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'governed')
+    writeInstallTree(installPath, {
+      constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+      envelope: makeEnvelope(
+        signer,
+        makePayload({ activeForms: ['customNode', 'nodeId'], customNodeMode: 'blocklist' })
+      )
+    })
+
+    const marker = await buildGovernanceMarker(installPath)
+
+    expect(marker).toEqual({
+      governanceMarkerVersion: 1,
+      governed: true,
+      expectedBuildIdentity: BUILD_IDENTITY,
+      publicKey: signer.publicKey,
+      activeForms: ['customNode', 'nodeId'],
+      customNodeMode: 'blocklist'
+    })
+  })
+
+  it('records customNodeMode null when the custom-node form is inactive', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'model-only')
+    writeInstallTree(installPath, {
+      constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+      envelope: makeEnvelope(signer, makePayload({ activeForms: ['model'], customNodeMode: null }))
+    })
+
+    expect(await buildGovernanceMarker(installPath)).toMatchObject({
+      activeForms: ['model'],
+      customNodeMode: null
+    })
+  })
+
+  it('returns no marker for an ungoverned archive', async () => {
+    const installPath = path.join(root, 'ungoverned')
+    writeInstallTree(installPath, { constants: null, envelope: null })
+    expect(await buildGovernanceMarker(installPath)).toBeNull()
+  })
+
+  it('refuses a governed archive whose own shipped policy does not verify', async () => {
+    const signer = makeSigner()
+    const attacker = makeSigner()
+    const installPath = path.join(root, 'broken-policy')
+    writeInstallTree(installPath, {
+      constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+      envelope: makeEnvelope(attacker, makePayload())
+    })
+
+    await expect(buildGovernanceMarker(installPath)).rejects.toThrow(/managed installation/i)
+  })
+
+  it('refuses a governed archive that ships no policy at all', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'no-policy')
+    writeInstallTree(installPath, {
+      constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+      envelope: null
+    })
+
+    await expect(buildGovernanceMarker(installPath)).rejects.toThrow(/managed installation/i)
+  })
+
+  // An unparseable governance.py must NOT return null: null is recorded as no
+  // marker at all, which reads downstream as `absent` (an ordinary install)
+  // rather than `malformed`, handing the install the relaxations governance
+  // exists to withhold.
+  it('refuses an archive whose governance constants do not parse', async () => {
+    const installPath = path.join(root, 'unparseable-constants')
+    writeInstallTree(installPath, {
+      source: 'GOVERNANCE_REQUIRED = True\nGOVERNANCE_REQUIRED = False\n',
+      envelope: null
+    })
+
+    await expect(buildGovernanceMarker(installPath)).rejects.toThrow(/could not be parsed/i)
+  })
+
+  it('refuses an archive whose governance constants cannot be read', async () => {
+    const installPath = path.join(root, 'unreadable-constants')
+    writeInstallTree(installPath, { constants: null, envelope: null })
+    // A directory where the file belongs: open() fails with EISDIR, which is
+    // "unreadable", not "absent".
+    const sourcePath = path.join(installPath, 'ComfyUI', 'app', 'governance.py')
+    fs.rmSync(sourcePath, { force: true })
+    fs.mkdirSync(sourcePath, { recursive: true })
+
+    await expect(buildGovernanceMarker(installPath)).rejects.toThrow(/could not be read/i)
+  })
+
+  it('still reports an archive with no governance.py at all as ungoverned', async () => {
+    const installPath = path.join(root, 'pre-governance')
+    fs.mkdirSync(path.join(installPath, 'ComfyUI', 'app'), { recursive: true })
+
+    expect(await buildGovernanceMarker(installPath)).toBeNull()
+  })
+})
+
+describe('installArtifact governance marker', () => {
+  const ARCHIVE_BYTES = Buffer.from('archive-payload-bytes')
+  const ARCHIVE_SHA = createHash('sha256').update(ARCHIVE_BYTES).digest('hex')
+
+  function stubTransport(installPath: string, tree: () => void): void {
+    vi.mocked(download).mockImplementation(async (_url, dest) => {
+      fs.writeFileSync(dest, ARCHIVE_BYTES)
+      return dest
+    })
+    vi.mocked(extractNested).mockImplementation(async () => {
+      fs.mkdirSync(installPath, { recursive: true })
+      tree()
+    })
+  }
+
+  const client = { resolveDownloadUrl: vi.fn(async () => 'https://example.test/a.tar.gz') }
+  const artifact = (archiveSha256: string): Artifact => ({
+    id: 'a1',
+    os: 'linux',
+    gpu: 'cpu',
+    accelVariant: 'cpu',
+    status: 'ready',
+    archiveSha256
+  })
+
+  it('writes a marker whose fields equal the archive constants and the verified payload exactly', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'install-governed')
+    stubTransport(installPath, () =>
+      writeInstallTree(installPath, {
+        constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+        envelope: makeEnvelope(
+          signer,
+          makePayload({ activeForms: ['customNode', 'model'], customNodeMode: 'allowlist' })
+        )
+      })
+    )
+
+    const result = await installArtifact({
+      artifact: artifact(ARCHIVE_SHA),
+      client,
+      installPath,
+      cacheDir: path.join(root, 'cache')
+    })
+
+    expect(result.governance?.expectedBuildIdentity).toBe(BUILD_IDENTITY)
+    expect(result.governance?.publicKey).toBe(signer.publicKey)
+    expect(result.governance?.activeForms).toEqual(['customNode', 'model'])
+    expect(result.governance?.customNodeMode).toBe('allowlist')
+  })
+
+  it('leaves a non-governed archive unmarked', async () => {
+    const installPath = path.join(root, 'install-plain')
+    stubTransport(installPath, () => writeInstallTree(installPath, { constants: null }))
+
+    const result = await installArtifact({
+      artifact: artifact(ARCHIVE_SHA),
+      client,
+      installPath,
+      cacheDir: path.join(root, 'cache')
+    })
+
+    expect(result.governance).toBeNull()
+  })
+
+  it('writes NO marker when the archive fails its ArchiveSha256 check', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'install-badsum')
+    stubTransport(installPath, () =>
+      writeInstallTree(installPath, {
+        constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+        envelope: makeEnvelope(signer, makePayload())
+      })
+    )
+
+    await expect(
+      installArtifact({
+        artifact: artifact('f'.repeat(64)),
+        client,
+        installPath,
+        cacheDir: path.join(root, 'cache')
+      })
+    ).rejects.toMatchObject({ kind: 'checksum-mismatch' })
+
+    // Nothing was extracted, so no constants were ever read: the marker cannot
+    // exist because the digest that would make it trustworthy never matched.
+    expect(extractNested).not.toHaveBeenCalled()
+    expect(fs.existsSync(path.join(installPath, 'ComfyUI'))).toBe(false)
+  })
+})
+
+describe('readGovernanceMarker', () => {
+  const valid: GovernanceMarker = {
+    governanceMarkerVersion: 1,
+    governed: true,
+    expectedBuildIdentity: BUILD_IDENTITY,
+    publicKey: base64url(Buffer.alloc(32, 7)),
+    activeForms: ['model'],
+    customNodeMode: null
+  }
+
+  it('reads a complete marker as governed', () => {
+    expect(readGovernanceMarker({ [GOVERNANCE_MARKER_FIELD]: valid })).toEqual({
+      kind: 'governed',
+      marker: valid
+    })
+  })
+
+  it('reads an absent marker as ungoverned rather than blocking', () => {
+    expect(readGovernanceMarker({})).toEqual({ kind: 'absent' })
+    expect(readGovernanceMarker({ [GOVERNANCE_MARKER_FIELD]: undefined })).toEqual({
+      kind: 'absent'
+    })
+  })
+
+  it.each([
+    ['no activeForms', { ...valid, activeForms: undefined }],
+    ['no customNodeMode', { ...valid, customNodeMode: undefined }],
+    ['a bogus customNodeMode', { ...valid, customNodeMode: 'anything' }],
+    ['non-string activeForms', { ...valid, activeForms: [1, 2] }],
+    ['no publicKey', { ...valid, publicKey: '' }],
+    ['no build identity', { ...valid, expectedBuildIdentity: '' }],
+    ['an unknown marker version', { ...valid, governanceMarkerVersion: 2 }],
+    ['governed explicitly false', { ...valid, governed: false }],
+    ['only the version (a torn write)', { governanceMarkerVersion: 1 }],
+    ['a non-object', 'governed']
+  ])('fails closed on a marker with %s, never as ungoverned', (_name, marker) => {
+    const state = readGovernanceMarker({ [GOVERNANCE_MARKER_FIELD]: marker })
+    expect(state.kind).toBe('malformed')
+  })
+})
+
+describe('checkGovernedInstallPolicy', () => {
+  function governedInstall(
+    name: string,
+    opts: { signer: Signer; envelope?: string | null; payload?: Record<string, unknown> }
+  ): { installPath: string; [key: string]: unknown } {
+    const installPath = path.join(root, name)
+    const envelope =
+      opts.envelope === undefined
+        ? makeEnvelope(opts.signer, opts.payload ?? makePayload())
+        : opts.envelope
+    writeInstallTree(installPath, {
+      constants: {
+        required: true,
+        buildIdentity: BUILD_IDENTITY,
+        publicKey: opts.signer.publicKey
+      },
+      envelope
+    })
+    return {
+      installPath,
+      [GOVERNANCE_MARKER_FIELD]: {
+        governanceMarkerVersion: 1,
+        governed: true,
+        expectedBuildIdentity: BUILD_IDENTITY,
+        publicKey: opts.signer.publicKey,
+        activeForms: ['customNode', 'model'],
+        customNodeMode: 'allowlist'
+      }
+    }
+  }
+
+  it('is a no-op for an install with no marker', async () => {
+    const installPath = path.join(root, 'plain')
+    writeInstallTree(installPath, { constants: null })
+    expect(await checkGovernedInstallPolicy({ installPath })).toEqual({ ok: true })
+  })
+
+  it('passes a governed install whose envelope verifies', async () => {
+    const signer = makeSigner()
+    expect(await checkGovernedInstallPolicy(governedInstall('ok', { signer }))).toEqual({
+      ok: true
+    })
+  })
+
+  it('rejects an oversized policy without reading beyond the envelope limit', async () => {
+    const signer = makeSigner()
+    const install = governedInstall('oversized', { signer })
+    fs.writeFileSync(governancePolicyPath(install.installPath), Buffer.alloc(1024 * 1024 + 2, 0x20))
+
+    await expect(
+      verifyInstalledGovernancePolicy(install.installPath, {
+        publicKey: signer.publicKey,
+        buildIdentity: BUILD_IDENTITY
+      })
+    ).resolves.toEqual({ ok: false, reason: 'envelope too large' })
+  })
+
+  it('refuses when the envelope was deleted, stating the policy', async () => {
+    const signer = makeSigner()
+    const install = governedInstall('deleted', { signer })
+    fs.rmSync(governancePolicyPath(install.installPath))
+
+    const result = await checkGovernedInstallPolicy(install)
+
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.message).toContain('managed ComfyUI installation')
+    expect(result.ok === false && result.message).toContain('contact your administrator')
+  })
+
+  it('refuses when one signature byte is flipped', async () => {
+    const signer = makeSigner()
+    const install = governedInstall('tampered', { signer })
+    const policy = governancePolicyPath(install.installPath)
+    const parsed = JSON.parse(fs.readFileSync(policy, 'utf-8')) as Record<string, string>
+    const signature = Buffer.from(parsed.signature!, 'base64url')
+    signature[7] = signature[7]! ^ 0x01
+    fs.writeFileSync(policy, JSON.stringify({ ...parsed, signature: base64url(signature) }))
+
+    expect(await checkGovernedInstallPolicy(install)).toMatchObject({ ok: false })
+  })
+
+  it('refuses a marker that is present but malformed', async () => {
+    const signer = makeSigner()
+    const install = governedInstall('malformed', { signer })
+    const result = await checkGovernedInstallPolicy({
+      ...install,
+      [GOVERNANCE_MARKER_FIELD]: { governanceMarkerVersion: 1, governed: true }
+    })
+    expect(result).toMatchObject({ ok: false })
+  })
+})
+
+describe('governedModelDigests', () => {
+  it('exposes the verified payload model set for the ledger writer', async () => {
+    const signer = makeSigner()
+    const installPath = path.join(root, 'digests')
+    writeInstallTree(installPath, {
+      constants: { required: true, buildIdentity: BUILD_IDENTITY, publicKey: signer.publicKey },
+      envelope: makeEnvelope(signer, makePayload())
+    })
+
+    const digests = await governedModelDigests({
+      installPath,
+      [GOVERNANCE_MARKER_FIELD]: {
+        governanceMarkerVersion: 1,
+        governed: true,
+        expectedBuildIdentity: BUILD_IDENTITY,
+        publicKey: signer.publicKey,
+        activeForms: ['model'],
+        customNodeMode: null
+      }
+    })
+
+    expect(digests && [...digests].sort()).toEqual([...MODEL_DIGESTS].sort())
+  })
+
+  it('returns null for an ungoverned install', async () => {
+    expect(await governedModelDigests({ installPath: root })).toBeNull()
+  })
+})

--- a/src/main/comfybuilder/governance.ts
+++ b/src/main/comfybuilder/governance.ts
@@ -1,0 +1,577 @@
+/**
+ * Governance: the durable marker + the launch-time policy verifier.
+ *
+ * A governed distribution is one whose ComfyUI core was compiled with
+ * `GOVERNANCE_REQUIRED = True` and a build identity / public key baked into
+ * `ComfyUI/app/governance.py`. Core self-enforces from that compiled-in
+ * constant regardless of anything Desktop does; everything here is a SECOND
+ * layer whose only job is to turn "core refused to start, cryptically" into a
+ * clear, policy-stating refusal BEFORE a process is ever spawned.
+ *
+ * **Governed status comes from the durable marker, never from the policy
+ * file's presence.** Deriving it from whether `ComfyUI/governance/policy.signed.json`
+ * exists would be self-defeating: deleting that file - the exact attack this
+ * check exists to catch - would reclassify the install as non-governed and
+ * launch it happily. The marker is instead written into the installation
+ * record at install time (see {@link buildGovernanceMarker}), from constants
+ * read out of an archive whose `archiveSha256` has already been verified.
+ *
+ * The trust chain is therefore: signed release -> `archiveSha256` ->
+ * extracted `app/governance.py` constants -> marker in the installation
+ * record -> this launch-time check. Values read at launch from an unverified
+ * tree would inherit no trust at all, which is why the marker is captured
+ * during install rather than re-derived here.
+ */
+import { createPublicKey, verify as verifySignature } from 'crypto'
+import fs from 'fs'
+import path from 'path'
+
+/** Field name the marker occupies on the installation record. Todo 22 reads
+ *  `activeForms` / `customNodeMode` from here to pick launch arguments. */
+export const GOVERNANCE_MARKER_FIELD = 'governance'
+
+/** Bumped when the marker's shape changes; an unknown version fails closed
+ *  rather than being interpreted under today's rules. Desktop-local: the
+ *  marker never leaves the installation record. */
+export const GOVERNANCE_MARKER_VERSION = 1
+
+/** The signed envelope's wire `schema`, and the payload's `schemaVersion`.
+ *  Core hardcodes both as 1 (`app/governance.py`), so they are a SHARED
+ *  contract and must not be derived from {@link GOVERNANCE_MARKER_VERSION} -
+ *  bumping Desktop's marker shape would otherwise start rejecting every
+ *  envelope core still emits, refusing launch on every governed install. */
+export const GOVERNANCE_ENVELOPE_SCHEMA = 1
+
+/** Core refuses a payload addressed to anyone else, so Desktop must too:
+ *  waving one through only produces a launch that dies at startup. */
+const GOVERNANCE_PAYLOAD_AUDIENCE = 'comfyui-core'
+
+/** Custom-node governance posture, matching the signed payload exactly:
+ *  null when the form is inactive, else the authored mode. */
+export type CustomNodeMode = 'allowlist' | 'blocklist'
+
+export interface GovernanceMarker {
+  readonly governanceMarkerVersion: number
+  readonly governed: true
+  /** `GOVERNANCE_BUILD_IDENTITY` from the digest-verified archive. */
+  readonly expectedBuildIdentity: string
+  /** `GOVERNANCE_PUBLIC_KEY`: canonical unpadded base64url, 32 bytes. */
+  readonly publicKey: string
+  /** From the VERIFIED payload. Load-bearing: todo 22 forces
+   *  `--enable-asset-hashing` iff `"model"` is a member. */
+  readonly activeForms: readonly string[]
+  /** From the VERIFIED payload. Load-bearing: todo 22 omits
+   *  `--enable-manager` iff this is exactly `"allowlist"`. */
+  readonly customNodeMode: CustomNodeMode | null
+}
+
+/** Archive-relative location of the signed policy envelope. */
+export const GOVERNANCE_POLICY_RELATIVE = path.join('ComfyUI', 'governance', 'policy.signed.json')
+
+/** Archive-relative location of the compiled-in governance constants. */
+const GOVERNANCE_SOURCE_RELATIVE = path.join('ComfyUI', 'app', 'governance.py')
+
+/** Absolute path of a governed install's signed policy envelope. */
+export function governancePolicyPath(installPath: string): string {
+  return path.join(installPath, GOVERNANCE_POLICY_RELATIVE)
+}
+
+// ---- Envelope codec ---------------------------------------------------------
+//
+// Byte-for-byte the same rules ComfyUI's `app/governance.py` applies, because
+// the two verify the SAME envelope: canonical unpadded base64url, a 32-byte
+// key, a 64-byte signature, and the `comfyui-governance-v1\0` domain separator
+// prefixed to the exact transmitted payload bytes before verification. A
+// looser codec here would accept envelopes core rejects, so Desktop would wave
+// through a launch that then dies at startup - the opposite of this module's
+// purpose.
+
+const DOMAIN_SEPARATOR = Buffer.from('comfyui-governance-v1\0', 'utf-8')
+const MAX_ENVELOPE_BYTES = 1024 * 1024
+const MAX_PAYLOAD_BYTES = 512 * 1024
+const MAX_ENCODED_PAYLOAD_CHARS = Math.floor((MAX_PAYLOAD_BYTES * 4 + 2) / 3)
+const ENVELOPE_KEYS = ['payload', 'schema', 'signature'] as const
+const BASE64URL_CHARS = /^[A-Za-z0-9_-]*$/
+/** SPKI DER prefix for an Ed25519 public key; Node has no raw-key importer. */
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+
+/**
+ * Decode canonical unpadded base64url, or null. "Canonical" is enforced by
+ * re-encoding and comparing: without it, `AB` and `AA` both decode to one zero
+ * byte, so two different envelopes would carry the same signature bytes.
+ */
+export function decodeBase64UrlStrict(encoded: unknown): Buffer | null {
+  if (typeof encoded !== 'string' || !BASE64URL_CHARS.test(encoded)) return null
+  const decoded = Buffer.from(encoded, 'base64url')
+  return decoded.toString('base64url') === encoded ? decoded : null
+}
+
+/** The subset of the signed payload Desktop needs. Core owns full schema
+ *  validation; re-implementing it here would be a second, drifting copy. */
+export interface VerifiedGovernancePayload {
+  readonly buildIdentity: string
+  readonly activeForms: readonly string[]
+  readonly customNodeMode: CustomNodeMode | null
+  /**
+   * The effective signed model digest set (`payload.models`). Exposed so the
+   * ledger writer in todo 41 consults this verifier rather than
+   * re-implementing signature checking against a user-writable file.
+   */
+  readonly models: ReadonlySet<string>
+}
+
+export type GovernanceVerifyResult =
+  | { readonly ok: true; readonly payload: VerifiedGovernancePayload }
+  | { readonly ok: false; readonly reason: string }
+
+function isCustomNodeMode(raw: unknown): raw is CustomNodeMode {
+  return raw === 'allowlist' || raw === 'blocklist'
+}
+
+function ed25519KeyFrom(raw: Buffer): ReturnType<typeof createPublicKey> | null {
+  try {
+    return createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, raw]),
+      format: 'der',
+      type: 'spki'
+    })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Verify a signed governance envelope against the marker's recorded public key
+ * and build identity, returning the fields Desktop consumes.
+ *
+ * Structural + signature + build-identity verification only: core performs the
+ * full 13-key payload validation and is the actual boundary. Every failure is
+ * a plain reason string so callers can log which control tripped without the
+ * refusal message leaking envelope internals to the user.
+ */
+export function verifyGovernanceEnvelope(
+  envelopeBytes: Uint8Array,
+  expected: { readonly publicKey: string; readonly buildIdentity: string }
+): GovernanceVerifyResult {
+  if (envelopeBytes.length > MAX_ENVELOPE_BYTES) return { ok: false, reason: 'envelope too large' }
+
+  let envelope: unknown
+  try {
+    envelope = JSON.parse(Buffer.from(envelopeBytes).toString('utf-8'))
+  } catch {
+    return { ok: false, reason: 'envelope is not valid JSON' }
+  }
+  if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
+    return { ok: false, reason: 'envelope is not an object' }
+  }
+  const record = envelope as Record<string, unknown>
+  const keys = Object.keys(record).sort()
+  if (keys.length !== ENVELOPE_KEYS.length || keys.some((k, i) => k !== ENVELOPE_KEYS[i])) {
+    return { ok: false, reason: 'envelope must contain exactly schema, payload, and signature' }
+  }
+  if (record.schema !== GOVERNANCE_ENVELOPE_SCHEMA) {
+    return { ok: false, reason: 'unsupported envelope schema' }
+  }
+  if (typeof record.payload !== 'string' || typeof record.signature !== 'string') {
+    return { ok: false, reason: 'payload and signature must be strings' }
+  }
+  if (record.payload.length > MAX_ENCODED_PAYLOAD_CHARS) {
+    return { ok: false, reason: 'payload exceeds maximum size' }
+  }
+
+  const payloadBytes = decodeBase64UrlStrict(record.payload)
+  if (!payloadBytes) return { ok: false, reason: 'payload is not canonical unpadded base64url' }
+  if (payloadBytes.length > MAX_PAYLOAD_BYTES) {
+    return { ok: false, reason: 'payload exceeds maximum size' }
+  }
+  const signature = decodeBase64UrlStrict(record.signature)
+  if (!signature) return { ok: false, reason: 'signature is not canonical unpadded base64url' }
+  if (signature.length !== 64) return { ok: false, reason: 'signature must be 64 bytes' }
+  const publicKeyBytes = decodeBase64UrlStrict(expected.publicKey)
+  if (!publicKeyBytes)
+    return { ok: false, reason: 'public key is not canonical unpadded base64url' }
+  if (publicKeyBytes.length !== 32) return { ok: false, reason: 'public key must be 32 bytes' }
+
+  const key = ed25519KeyFrom(publicKeyBytes)
+  if (!key) return { ok: false, reason: 'public key is not a usable Ed25519 key' }
+  // Signed over the exact transmitted payload BYTES, never a re-serialization:
+  // a JSON round-trip would change the signed message.
+  const signed = Buffer.concat([DOMAIN_SEPARATOR, payloadBytes])
+  let signatureValid: boolean
+  try {
+    signatureValid = verifySignature(null, signed, key, signature)
+  } catch {
+    signatureValid = false
+  }
+  if (!signatureValid) return { ok: false, reason: 'signature verification failed' }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(payloadBytes.toString('utf-8'))
+  } catch {
+    return { ok: false, reason: 'payload is not valid JSON' }
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return { ok: false, reason: 'payload is not an object' }
+  }
+  const fields = payload as Record<string, unknown>
+
+  // Core owns full payload validation; these two are mirrored because they are
+  // fixed constants rather than a schema to keep in sync, and letting either
+  // through would hand the user a launch that dies at startup instead of the
+  // refusal this module exists to produce.
+  if (fields.schemaVersion !== GOVERNANCE_ENVELOPE_SCHEMA) {
+    return { ok: false, reason: 'unsupported payload schema' }
+  }
+  if (fields.audience !== GOVERNANCE_PAYLOAD_AUDIENCE) {
+    return { ok: false, reason: 'payload is addressed to a different audience' }
+  }
+  if (typeof fields.buildIdentity !== 'string') {
+    return { ok: false, reason: 'payload buildIdentity must be a string' }
+  }
+  if (fields.buildIdentity !== expected.buildIdentity) {
+    return { ok: false, reason: 'payload build identity does not match this installation' }
+  }
+
+  const activeForms = fields.activeForms
+  if (!Array.isArray(activeForms) || activeForms.some((f) => typeof f !== 'string')) {
+    return { ok: false, reason: 'payload activeForms must be a string list' }
+  }
+  const customNodeMode = fields.customNodeMode
+  if (customNodeMode !== null && !isCustomNodeMode(customNodeMode)) {
+    return { ok: false, reason: 'payload customNodeMode is invalid' }
+  }
+  const models = fields.models
+  if (!Array.isArray(models) || models.some((m) => typeof m !== 'string')) {
+    return { ok: false, reason: 'payload models must be a string list' }
+  }
+
+  return {
+    ok: true,
+    payload: {
+      buildIdentity: fields.buildIdentity,
+      activeForms: activeForms as string[],
+      customNodeMode: customNodeMode as CustomNodeMode | null,
+      models: new Set(models as string[])
+    }
+  }
+}
+
+/**
+ * Verify the signed policy envelope that ships inside `installPath`.
+ *
+ * The reusable entry point: todo 41's ledger writer calls this and reads
+ * `payload.models` rather than re-implementing verification against a file the
+ * user can edit.
+ */
+export async function verifyInstalledGovernancePolicy(
+  installPath: string,
+  expected: { readonly publicKey: string; readonly buildIdentity: string }
+): Promise<GovernanceVerifyResult> {
+  let envelopeBytes: Buffer
+  try {
+    // Bounded read, not `readFile`: this is the one file in the tree the user
+    // is expected to be able to replace, so its size is attacker-chosen. One
+    // byte past the limit is enough for the size check below to reject it.
+    const handle = await fs.promises.open(governancePolicyPath(installPath), 'r')
+    try {
+      const buffer = Buffer.alloc(MAX_ENVELOPE_BYTES + 1)
+      const { bytesRead } = await handle.read(buffer, 0, MAX_ENVELOPE_BYTES + 1, 0)
+      envelopeBytes = buffer.subarray(0, bytesRead)
+    } finally {
+      await handle.close()
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    return {
+      ok: false,
+      reason:
+        code === 'ENOENT' ? 'the signed policy file is missing' : `policy unreadable (${code})`
+    }
+  }
+  return verifyGovernanceEnvelope(envelopeBytes, expected)
+}
+
+// ---- Archive constants ------------------------------------------------------
+
+export interface ArchiveGovernanceConstants {
+  readonly required: boolean
+  readonly buildIdentity: string
+  readonly publicKey: string
+}
+
+/** Assignments the archive rewriter patches, each of which must appear exactly
+ *  once at column 0. A duplicate is a shadowing attempt, not an ambiguity to
+ *  resolve by "last wins". */
+const CONSTANT_NAMES = [
+  'GOVERNANCE_REQUIRED',
+  'GOVERNANCE_BUILD_IDENTITY',
+  'GOVERNANCE_PUBLIC_KEY'
+] as const
+
+/** Max bytes of `app/governance.py` to read; the real file is a few tens of KB
+ *  and an unbounded read of an attacker-supplied path is not worth allowing. */
+const MAX_GOVERNANCE_SOURCE_BYTES = 2 * 1024 * 1024
+
+/**
+ * Parse the three compiled-in constants out of `app/governance.py` source.
+ *
+ * Deliberately literal: the rewriter emits `NAME = <literal>` at column 0, so
+ * anything else (a missing constant, a second assignment shadowing the first,
+ * a non-literal value) is treated as an unrecognizable build and fails closed
+ * rather than being guessed at.
+ */
+export function parseGovernanceConstants(source: string): ArchiveGovernanceConstants | null {
+  const found = new Map<string, string>()
+  for (const rawLine of source.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line || line.startsWith(' ') || line.startsWith('\t')) continue
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const name = line.slice(0, eq).trim()
+    if (!(CONSTANT_NAMES as readonly string[]).includes(name)) continue
+    if (found.has(name)) return null // shadowed: fail closed
+    found.set(name, line.slice(eq + 1).trim())
+  }
+  if (found.size !== CONSTANT_NAMES.length) return null
+
+  const requiredRaw = found.get('GOVERNANCE_REQUIRED')!
+  if (requiredRaw !== 'True' && requiredRaw !== 'False') return null
+  const identity = parsePyString(found.get('GOVERNANCE_BUILD_IDENTITY')!)
+  const publicKey = parsePyString(found.get('GOVERNANCE_PUBLIC_KEY')!)
+  if (identity === null || publicKey === null) return null
+
+  return { required: requiredRaw === 'True', buildIdentity: identity, publicKey }
+}
+
+/** Parse the double-quoted literal the rewriter emits. Go's `strconv.Quote`
+ *  and JSON agree on every escape it can produce for these ASCII values. */
+function parsePyString(raw: string): string | null {
+  if (!raw.startsWith('"') || !raw.endsWith('"') || raw.length < 2) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return typeof parsed === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the constants out of an EXTRACTED, digest-verified archive tree.
+ *
+ * The caller must only invoke this after `archiveSha256` matched: that digest
+ * is the chain of custody, so values taken from the tree it produced inherit
+ * its trust. Reading the same file later, from a tree the user has been able
+ * to edit, would inherit none.
+ *
+ * Returns null for EXACTLY ONE case: the file is absent, which is a build
+ * predating governance. Every other outcome - unreadable, or present but
+ * unparseable - THROWS. Those two must not share the "not governed" return:
+ * an unreadable governed archive would then be recorded with no marker at
+ * all, which reads downstream as `absent` rather than `malformed` and hands
+ * the install every relaxation that governance exists to withhold.
+ */
+export async function readArchiveGovernanceConstants(
+  installPath: string
+): Promise<ArchiveGovernanceConstants | null> {
+  const sourcePath = path.join(installPath, GOVERNANCE_SOURCE_RELATIVE)
+  let source: string
+  try {
+    const handle = await fs.promises.open(sourcePath, 'r')
+    try {
+      const buffer = Buffer.alloc(MAX_GOVERNANCE_SOURCE_BYTES)
+      const { bytesRead } = await handle.read(buffer, 0, MAX_GOVERNANCE_SOURCE_BYTES, 0)
+      source = buffer.subarray(0, bytesRead).toString('utf-8')
+    } finally {
+      await handle.close()
+    }
+  } catch (err) {
+    // A build with no `app/governance.py` at all predates governance; it is
+    // simply not governed, which the null return expresses.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw new Error(
+      `This build's governance constants could not be read (${(err as NodeJS.ErrnoException).code ?? 'unknown error'}). The archive is not usable; contact your administrator.`,
+      { cause: err }
+    )
+  }
+  const constants = parseGovernanceConstants(source)
+  if (!constants) {
+    throw new Error(
+      'This build ships governance constants that could not be parsed. The archive is not usable; contact your administrator.'
+    )
+  }
+  return constants
+}
+
+/**
+ * Build the durable marker for a freshly extracted, digest-verified archive,
+ * or null when the build is not governed.
+ *
+ * `activeForms` / `customNodeMode` are taken from the VERIFIED payload, never
+ * from an unverified tree: they drive todo 22's launch-argument matrix, so a
+ * defaulted or attacker-chosen value would silently restore ungoverned
+ * behaviour. A governed archive whose own shipped policy does not verify is a
+ * broken build - throw rather than record a half-marker, so the install fails
+ * loudly instead of producing a record that reads as non-governed.
+ */
+export async function buildGovernanceMarker(installPath: string): Promise<GovernanceMarker | null> {
+  const constants = await readArchiveGovernanceConstants(installPath)
+  if (!constants || !constants.required) return null
+  if (!constants.buildIdentity || !constants.publicKey) {
+    throw new Error(
+      'This build is marked as governed but its build identity or public key is missing. The archive is not usable; contact your administrator.'
+    )
+  }
+
+  const verified = await verifyInstalledGovernancePolicy(installPath, {
+    publicKey: constants.publicKey,
+    buildIdentity: constants.buildIdentity
+  })
+  if (!verified.ok) {
+    throw new Error(
+      `This build is a managed installation but its signed governance policy could not be verified (${verified.reason}). The archive is not usable; contact your administrator.`
+    )
+  }
+
+  return {
+    governanceMarkerVersion: GOVERNANCE_MARKER_VERSION,
+    governed: true,
+    expectedBuildIdentity: constants.buildIdentity,
+    publicKey: constants.publicKey,
+    activeForms: [...verified.payload.activeForms],
+    customNodeMode: verified.payload.customNodeMode
+  }
+}
+
+// ---- Reading the marker back ------------------------------------------------
+
+export type GovernanceMarkerState =
+  /** No marker at all: an ordinary, ungoverned install. Never blocked. */
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'governed'; readonly marker: GovernanceMarker }
+  /** A marker exists but does not parse. Treated as governed-but-broken and
+   *  refused - NEVER silently as `governed: false`. */
+  | { readonly kind: 'malformed'; readonly reason: string }
+
+/**
+ * Read the marker off an installation record, failing closed.
+ *
+ * The asymmetry is the point: an ABSENT marker means ungoverned (and must not
+ * block anything), while a PRESENT-but-unparseable marker means a governed
+ * install whose record was truncated or edited, and must refuse. Collapsing
+ * the two into "not governed" would make truncating the record a bypass.
+ */
+export function readGovernanceMarker(record: {
+  readonly [key: string]: unknown
+}): GovernanceMarkerState {
+  const raw = record[GOVERNANCE_MARKER_FIELD]
+  if (raw === undefined || raw === null) return { kind: 'absent' }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return { kind: 'malformed', reason: 'the governance marker is not an object' }
+  }
+  const marker = raw as Record<string, unknown>
+
+  if (marker.governanceMarkerVersion !== GOVERNANCE_MARKER_VERSION) {
+    return { kind: 'malformed', reason: 'the governance marker version is unrecognized' }
+  }
+  if (marker.governed !== true) {
+    return { kind: 'malformed', reason: 'the governance marker is incomplete' }
+  }
+  if (typeof marker.expectedBuildIdentity !== 'string' || !marker.expectedBuildIdentity) {
+    return { kind: 'malformed', reason: 'the governance marker has no build identity' }
+  }
+  if (typeof marker.publicKey !== 'string' || !marker.publicKey) {
+    return { kind: 'malformed', reason: 'the governance marker has no public key' }
+  }
+  // `activeForms` and `customNodeMode` are load-bearing for todo 22's launch
+  // arguments, so a marker missing either is malformed rather than defaulted.
+  const activeForms = marker.activeForms
+  if (!Array.isArray(activeForms) || activeForms.some((f) => typeof f !== 'string')) {
+    return { kind: 'malformed', reason: 'the governance marker has no active policy forms' }
+  }
+  if (!('customNodeMode' in marker)) {
+    return { kind: 'malformed', reason: 'the governance marker has no custom-node mode' }
+  }
+  const customNodeMode = marker.customNodeMode
+  if (customNodeMode !== null && !isCustomNodeMode(customNodeMode)) {
+    return { kind: 'malformed', reason: 'the governance marker has an invalid custom-node mode' }
+  }
+
+  return {
+    kind: 'governed',
+    marker: {
+      governanceMarkerVersion: GOVERNANCE_MARKER_VERSION,
+      governed: true,
+      expectedBuildIdentity: marker.expectedBuildIdentity,
+      publicKey: marker.publicKey,
+      activeForms: activeForms as string[],
+      customNodeMode
+    }
+  }
+}
+
+// ---- The pre-launch check ---------------------------------------------------
+
+/**
+ * The refusal a user (or an agent acting for one) sees. `tdd.md` §5.5: every
+ * denial states the policy explicitly, because unexplained errors get routed
+ * around while stated policy gets respected. `{detail}` names which control
+ * tripped without implying the user can fix it themselves.
+ */
+export function governanceRefusalMessage(detail: string): string {
+  return (
+    'This is a managed ComfyUI installation. Its signed organization policy ' +
+    `could not be verified (${detail}), so ComfyUI was not started. ` +
+    "Removing or modifying the policy violates your organization's policy - " +
+    'contact your administrator.'
+  )
+}
+
+export type GovernanceLaunchCheck = { readonly ok: true } | { readonly ok: false; message: string }
+
+/**
+ * Pre-launch gate for a governed install: the signed policy must be present
+ * and verify against the marker's recorded key and build identity.
+ *
+ * A SECOND LAYER and a better error surface only. Core self-enforces from its
+ * compiled-in constant whatever this returns, so a PASS here enables exactly
+ * nothing - it merely declines to interrupt. A non-governed install is a
+ * no-op.
+ */
+export async function checkGovernedInstallPolicy(installation: {
+  readonly installPath: string
+  readonly [key: string]: unknown
+}): Promise<GovernanceLaunchCheck> {
+  const state = readGovernanceMarker(installation)
+  if (state.kind === 'absent') return { ok: true }
+  if (state.kind === 'malformed')
+    return { ok: false, message: governanceRefusalMessage(state.reason) }
+
+  const verified = await verifyInstalledGovernancePolicy(installation.installPath, {
+    publicKey: state.marker.publicKey,
+    buildIdentity: state.marker.expectedBuildIdentity
+  })
+  if (!verified.ok) return { ok: false, message: governanceRefusalMessage(verified.reason) }
+  return { ok: true }
+}
+
+/**
+ * The effective signed model digest set for a governed install, or null when
+ * the install is not governed or its policy does not verify.
+ *
+ * Todo 41's ledger writer consults this instead of re-implementing
+ * verification: a ledger built from an unverified policy would let one edited
+ * file authorize arbitrary model bytes.
+ */
+export async function governedModelDigests(installation: {
+  readonly installPath: string
+  readonly [key: string]: unknown
+}): Promise<ReadonlySet<string> | null> {
+  const state = readGovernanceMarker(installation)
+  if (state.kind !== 'governed') return null
+  const verified = await verifyInstalledGovernancePolicy(installation.installPath, {
+    publicKey: state.marker.publicKey,
+    buildIdentity: state.marker.expectedBuildIdentity
+  })
+  return verified.ok ? verified.payload.models : null
+}

--- a/src/main/comfybuilder/index.ts
+++ b/src/main/comfybuilder/index.ts
@@ -21,7 +21,35 @@ export { ComfyBuilderClient, ComfyBuilderApiError, DEFAULT_BASE_URL } from './cl
 export type { ComfyBuilderClientOptions, ComfyBuilderErrorKind } from './client'
 export { hostOs, selectArtifactForHost } from './targets'
 export { installArtifact, ComfyBuilderInstallError, sha256File } from './install'
-export type { InstallArtifactOptions, ComfyBuilderInstallErrorKind } from './install'
+export type {
+  InstallArtifactOptions,
+  InstallArtifactResult,
+  ComfyBuilderInstallErrorKind
+} from './install'
+export {
+  GOVERNANCE_MARKER_FIELD,
+  GOVERNANCE_MARKER_VERSION,
+  GOVERNANCE_POLICY_RELATIVE,
+  buildGovernanceMarker,
+  checkGovernedInstallPolicy,
+  governancePolicyPath,
+  governanceRefusalMessage,
+  governedModelDigests,
+  parseGovernanceConstants,
+  readArchiveGovernanceConstants,
+  readGovernanceMarker,
+  verifyGovernanceEnvelope,
+  verifyInstalledGovernancePolicy
+} from './governance'
+export type {
+  ArchiveGovernanceConstants,
+  CustomNodeMode,
+  GovernanceLaunchCheck,
+  GovernanceMarker,
+  GovernanceMarkerState,
+  GovernanceVerifyResult,
+  VerifiedGovernancePayload
+} from './governance'
 export { normalizeSha256 } from './integrity'
 export { stageModels, installModelsRoot, StageModelsError } from './models'
 export type { StageModelsOptions, StageModelsErrorKind, ModelJobSurface } from './models'

--- a/src/main/comfybuilder/install.ts
+++ b/src/main/comfybuilder/install.ts
@@ -24,6 +24,8 @@ import type { ExtractProgress } from '../lib/extract'
 import { sha256File } from '../lib/modelDownloadStaging'
 import { formatDownloadDetail } from '../lib/util'
 import type { ComfyBuilderClient } from './client'
+import { buildGovernanceMarker } from './governance'
+import type { GovernanceMarker } from './governance'
 import { isSecureDownloadUrl, normalizeSha256 } from './integrity'
 import type { Artifact, InstallProgress } from './types'
 
@@ -54,6 +56,15 @@ export interface InstallArtifactOptions {
   cacheDir: string
   onProgress?: (p: InstallProgress) => void
   signal?: AbortSignal
+}
+
+export interface InstallArtifactResult {
+  /**
+   * The durable governance marker for this archive, or null when the build is
+   * not governed. The caller persists it onto the installation record; launch
+   * reads governed status from THAT, never from the policy file's presence.
+   */
+  governance: GovernanceMarker | null
 }
 
 /** A real directory (not a symlink). Rejecting a symlinked layout dir guards
@@ -107,7 +118,9 @@ async function cleanupCreated(
  * {@link ComfyBuilderInstallError} on a bad artifact, a checksum mismatch, or a
  * bad extracted layout, or a missing integrity value.
  */
-export async function installArtifact(opts: InstallArtifactOptions): Promise<void> {
+export async function installArtifact(
+  opts: InstallArtifactOptions
+): Promise<InstallArtifactResult> {
   const { artifact, client, installPath, cacheDir, onProgress, signal } = opts
   if (!artifact?.id)
     throw new ComfyBuilderInstallError('invalid-artifact', 'No artifact id was provided.')
@@ -167,6 +180,14 @@ export async function installArtifact(opts: InstallArtifactOptions): Promise<voi
         signal ? { signal } : {}
       )
       assertLayout(installPath)
+      // Capture governance BEFORE the install is considered complete, so the
+      // marker's values come from a tree the verified `archiveSha256` above
+      // vouches for. Reading them later, from a tree the user can edit, would
+      // let a deleted policy file reclassify the install as ungoverned - the
+      // exact bypass the marker exists to close. A governed archive whose own
+      // policy fails to verify throws here and is cleaned up below: no
+      // half-written marker ever reaches the record.
+      return { governance: await buildGovernanceMarker(installPath) }
     } catch (err) {
       await cleanupCreated(installPath, preexisting)
       throw err

--- a/src/main/comfybuilder/integrity.test.ts
+++ b/src/main/comfybuilder/integrity.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+
+import {
+  coerceDigest,
+  digestKey,
+  digestsEqual,
+  isValidDigest,
+  isValidSha256,
+  makeDigest,
+  normalizeDigestHex,
+  normalizeSha256,
+  parseDigestKey,
+  selectModelDigest
+} from './integrity'
+
+const HEX_A = 'a'.repeat(64)
+const HEX_B = 'b'.repeat(64)
+
+describe('algorithm-tagged digests', () => {
+  it('tags a bare hex value with the algorithm it was given', () => {
+    expect(makeDigest(HEX_A, 'blake3')).toEqual({ algo: 'blake3', value: HEX_A })
+    expect(makeDigest(HEX_A, 'sha256')).toEqual({ algo: 'sha256', value: HEX_A })
+  })
+
+  it('strips the matching prefix and normalizes case and whitespace', () => {
+    expect(normalizeDigestHex(`  BLAKE3:${HEX_A.toUpperCase()} `, 'blake3')).toBe(HEX_A)
+    expect(normalizeDigestHex(`sha256:${HEX_A}`, 'sha256')).toBe(HEX_A)
+  })
+
+  it('refuses a value labelled with a DIFFERENT algorithm instead of re-tagging it', () => {
+    expect(normalizeDigestHex(`blake3:${HEX_A}`, 'sha256')).toBe('')
+    expect(makeDigest(`sha256:${HEX_A}`, 'blake3')).toBeNull()
+  })
+
+  it.each([undefined, '', 'not-a-digest', 'a'.repeat(63), 'g'.repeat(64)])(
+    'rejects %s as a digest value',
+    (raw) => {
+      expect(makeDigest(raw, 'blake3')).toBeNull()
+      expect(makeDigest(raw, 'sha256')).toBeNull()
+    }
+  )
+
+  it('rejects a structurally invalid tagged value', () => {
+    expect(isValidDigest(undefined)).toBe(false)
+    expect(isValidDigest({ algo: 'md5' as never, value: HEX_A })).toBe(false)
+    expect(isValidDigest({ algo: 'blake3', value: 'short' })).toBe(false)
+    expect(isValidDigest({ algo: 'blake3', value: HEX_A })).toBe(true)
+  })
+})
+
+describe('digestKey - the algorithm is part of the identity', () => {
+  it('keys a digest as <algo>:<hex>', () => {
+    expect(digestKey({ algo: 'blake3', value: HEX_A })).toBe(`blake3:${HEX_A}`)
+    expect(digestKey({ algo: 'sha256', value: HEX_A })).toBe(`sha256:${HEX_A}`)
+  })
+
+  it('gives IDENTICAL hex under different algorithms DIFFERENT keys', () => {
+    const asBlake3 = { algo: 'blake3', value: HEX_A } as const
+    const asSha256 = { algo: 'sha256', value: HEX_A } as const
+    expect(asBlake3.value).toBe(asSha256.value)
+    expect(digestKey(asBlake3)).not.toBe(digestKey(asSha256))
+    expect(digestsEqual(asBlake3, asSha256)).toBe(false)
+  })
+
+  it('never reports two absent or invalid digests as equal', () => {
+    expect(digestsEqual(undefined, undefined)).toBe(false)
+    expect(digestsEqual(null, { algo: 'blake3', value: HEX_A })).toBe(false)
+    expect(digestKey(undefined)).toBeUndefined()
+  })
+
+  it('round-trips through parseDigestKey', () => {
+    expect(parseDigestKey(`blake3:${HEX_A}`)).toEqual({ algo: 'blake3', value: HEX_A })
+    expect(parseDigestKey(`sha256:${HEX_B}`)).toEqual({ algo: 'sha256', value: HEX_B })
+    expect(parseDigestKey(HEX_A)).toBeNull()
+    expect(parseDigestKey(`md5:${HEX_A}`)).toBeNull()
+  })
+
+  it('coerces only a well-formed persisted object', () => {
+    expect(coerceDigest({ algo: 'blake3', value: HEX_A })).toEqual({ algo: 'blake3', value: HEX_A })
+    expect(coerceDigest({ algo: 'md5', value: HEX_A })).toBeNull()
+    expect(coerceDigest({ value: HEX_A })).toBeNull()
+    expect(coerceDigest(HEX_A)).toBeNull()
+    expect(coerceDigest(null)).toBeNull()
+  })
+})
+
+describe('selectModelDigest', () => {
+  it('prefers blake3 when the manifest carries one', () => {
+    expect(selectModelDigest({ blake3: HEX_A, sha256: HEX_B })).toEqual({
+      algo: 'blake3',
+      value: HEX_A
+    })
+  })
+
+  it('falls back to sha256 for a manifest sealed before blake3 sealing', () => {
+    expect(selectModelDigest({ sha256: HEX_B })).toEqual({ algo: 'sha256', value: HEX_B })
+  })
+
+  it('falls back to sha256 when the blake3 field is present but unusable', () => {
+    expect(selectModelDigest({ blake3: '', sha256: HEX_B })).toEqual({
+      algo: 'sha256',
+      value: HEX_B
+    })
+    expect(selectModelDigest({ blake3: 'nonsense', sha256: HEX_B })).toEqual({
+      algo: 'sha256',
+      value: HEX_B
+    })
+  })
+
+  it('returns null when neither field is usable', () => {
+    expect(selectModelDigest({})).toBeNull()
+    expect(selectModelDigest(undefined)).toBeNull()
+    expect(selectModelDigest({ sha256: 'nope' })).toBeNull()
+  })
+})
+
+describe('archive-install sha256 helpers stay intact', () => {
+  it('keeps normalizeSha256 and isValidSha256 behaving exactly as before', () => {
+    expect(normalizeSha256(`SHA256:${HEX_A.toUpperCase()}`)).toBe(HEX_A)
+    expect(normalizeSha256(undefined)).toBe('')
+    expect(isValidSha256(HEX_A)).toBe(true)
+    expect(isValidSha256('nope')).toBe(false)
+  })
+})

--- a/src/main/comfybuilder/integrity.ts
+++ b/src/main/comfybuilder/integrity.ts
@@ -1,5 +1,8 @@
 /** Normalize a manifest hash for comparison: strip an optional `sha256:` prefix,
- * trim, and lowercase. Returns an empty string when there is no usable hash. */
+ * trim, and lowercase. Returns an empty string when there is no usable hash.
+ *
+ * Archive-install only (`archiveSha256`). The MODEL path is algorithm-tagged -
+ * use {@link selectModelDigest} / {@link makeDigest} there. */
 export function normalizeSha256(raw: string | undefined): string {
   return (
     raw
@@ -10,7 +13,134 @@ export function normalizeSha256(raw: string | undefined): string {
 }
 
 export function isValidSha256(raw: string | undefined): boolean {
-  return /^[a-f0-9]{64}$/.test(normalizeSha256(raw))
+  return HEX_32_BYTES.test(normalizeSha256(raw))
+}
+
+// ---- Algorithm-tagged digests (the model path) ------------------------------
+//
+// Both algorithms below emit 32 bytes, so a BARE hex string cannot say which
+// one produced it. That ambiguity is not academic on the model path: staged
+// bytes carry their expected digest in a durable sidecar, and a bare-hex
+// identity would let a partially downloaded file verified under one algorithm
+// be resumed against the other whenever the two hex strings coincide. Every
+// integrity value on the model path is therefore a tagged `{algo, value}`,
+// and `digestKey` - which ALWAYS includes the algorithm - is the only
+// identity two digests may be compared by.
+
+/** Digest algorithms Desktop can verify a model with. BLAKE3 is preferred when
+ *  the distribution was sealed with one; SHA-256 stays fully supported because
+ *  manifests sealed before BLAKE3 sealing carry only `Sha256`, are never
+ *  re-cut, and are never backfilled. */
+export type DigestAlgorithm = 'blake3' | 'sha256'
+
+/** An integrity value tagged with the algorithm that produced it. */
+export interface Digest {
+  readonly algo: DigestAlgorithm
+  readonly value: string
+}
+
+/** Preference order: a manifest carrying both is verified with BLAKE3. */
+export const DIGEST_ALGORITHMS: readonly DigestAlgorithm[] = ['blake3', 'sha256']
+
+const HEX_32_BYTES = /^[a-f0-9]{64}$/
+
+export function isDigestAlgorithm(raw: unknown): raw is DigestAlgorithm {
+  return typeof raw === 'string' && (DIGEST_ALGORITHMS as readonly string[]).includes(raw)
+}
+
+/**
+ * Normalize a hash for `algo`: trim, lowercase, and strip an optional
+ * `<algo>:` prefix. A value labelled with a DIFFERENT known algorithm yields
+ * an empty string rather than being silently re-tagged - a mislabelled
+ * manifest must fail closed, not become the wrong algorithm's expectation.
+ */
+export function normalizeDigestHex(raw: string | undefined, algo: DigestAlgorithm): string {
+  const trimmed = raw?.trim().toLowerCase() ?? ''
+  if (!trimmed) return ''
+  const prefix = `${algo}:`
+  if (trimmed.startsWith(prefix)) return trimmed.slice(prefix.length).trim()
+  if (DIGEST_ALGORITHMS.some((a) => trimmed.startsWith(`${a}:`))) return ''
+  return trimmed
+}
+
+/** Tag a raw manifest hash with its algorithm, or null when it is not a valid
+ *  32-byte lowercase-hex value for that algorithm. */
+export function makeDigest(raw: string | undefined, algo: DigestAlgorithm): Digest | null {
+  const value = normalizeDigestHex(raw, algo)
+  return HEX_32_BYTES.test(value) ? { algo, value } : null
+}
+
+export function isValidDigest(digest: Digest | null | undefined): digest is Digest {
+  return !!digest && isDigestAlgorithm(digest.algo) && HEX_32_BYTES.test(digest.value)
+}
+
+/**
+ * The identity key for a digest, `<algo>:<hex>`. **The algorithm is part of
+ * the key.** A BLAKE3 value and a SHA-256 value with identical hex are
+ * different content expectations and must never compare equal - the resume
+ * identity, the join guard, and final verification all key off this.
+ * Returns undefined for anything not a valid digest, so an invalid value can
+ * never accidentally equal another.
+ */
+export function digestKey(digest: Digest | null | undefined): string | undefined {
+  return isValidDigest(digest) ? `${digest.algo}:${digest.value}` : undefined
+}
+
+/** True only when both sides are valid digests of the SAME algorithm with the
+ *  same value. Two invalid/absent digests are never "equal". */
+export function digestsEqual(a: Digest | null | undefined, b: Digest | null | undefined): boolean {
+  const keyA = digestKey(a)
+  return keyA !== undefined && keyA === digestKey(b)
+}
+
+/** Parse a persisted `<algo>:<hex>` reference back into a tagged digest. */
+export function parseDigestKey(raw: string | undefined): Digest | null {
+  const trimmed = raw?.trim().toLowerCase() ?? ''
+  const sep = trimmed.indexOf(':')
+  if (sep < 0) return null
+  const algo = trimmed.slice(0, sep)
+  return isDigestAlgorithm(algo) ? makeDigest(trimmed.slice(sep + 1), algo) : null
+}
+
+/** Re-tag an untrusted persisted/serialized value as a digest, or null. Used
+ *  when reading a sidecar written by another process. */
+export function coerceDigest(raw: unknown): Digest | null {
+  if (!raw || typeof raw !== 'object') return null
+  const { algo, value } = raw as { algo?: unknown; value?: unknown }
+  if (!isDigestAlgorithm(algo) || typeof value !== 'string') return null
+  return makeDigest(value, algo)
+}
+
+/**
+ * The digest a manifest model is verified with: BLAKE3 when the build was
+ * sealed with one, otherwise the SHA-256 that older sealed manifests carry.
+ * Returns null when neither is a usable 32-byte hex value.
+ *
+ * A null is NOT on its own a licence to stage unverified: pair it with
+ * {@link declaresModelIntegrity} to tell "sealed without a hash" apart from
+ * "declared a hash that is not usable".
+ */
+export function selectModelDigest(
+  source: { blake3?: string; sha256?: string } | null | undefined
+): Digest | null {
+  if (!source) return null
+  return makeDigest(source.blake3, 'blake3') ?? makeDigest(source.sha256, 'sha256')
+}
+
+/**
+ * Whether the manifest declared ANY integrity value, regardless of whether it
+ * parses.
+ *
+ * This is the difference between two failures that must not be conflated. A
+ * model sealed with no hash at all is something the build API knowingly emits
+ * for public model sources; a model whose declared hash is malformed is a
+ * broken or tampered manifest. Only the first is ever a candidate for being
+ * staged unverified, and then only on a non-governed install.
+ */
+export function declaresModelIntegrity(
+  source: { blake3?: string; sha256?: string } | null | undefined
+): boolean {
+  return Boolean(source?.blake3?.trim() || source?.sha256?.trim())
 }
 
 export function isSecureDownloadUrl(raw: string): boolean {

--- a/src/main/comfybuilder/launch.test.ts
+++ b/src/main/comfybuilder/launch.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildLaunchSpec, venvPython } from './launch'
+import type { GovernanceMarkerState } from './governance'
 
 const isWin = process.platform === 'win32'
 
@@ -64,5 +65,113 @@ describe('launch', () => {
     const p = path.join(dir, 'install')
     layout(p, opts)
     expect(buildLaunchSpec(p)).toBeNull()
+  })
+
+  describe('governance launch arguments', () => {
+    const baseArgs = '--cpu --port 9001'
+    const expectedBase = ['-s', path.join('ComfyUI', 'main.py'), '--cpu', '--port', '9001']
+
+    function marker(
+      customNodeMode: 'allowlist' | 'blocklist' | null,
+      activeForms: string[]
+    ): GovernanceMarkerState {
+      return {
+        kind: 'governed',
+        marker: {
+          governanceMarkerVersion: 1,
+          governed: true,
+          expectedBuildIdentity: 'test',
+          publicKey: 'test',
+          activeForms,
+          customNodeMode
+        }
+      }
+    }
+
+    it.each([
+      ['(a) custom allowlist (no model)', marker('allowlist', ['custom_node']), [...expectedBase]],
+      [
+        '(a) custom allowlist (with model)',
+        marker('allowlist', ['custom_node', 'model']),
+        [...expectedBase, '--enable-asset-hashing']
+      ],
+      [
+        '(b) custom non-empty blocklist',
+        marker('blocklist', ['custom_node']),
+        [...expectedBase, '--enable-manager']
+      ],
+      [
+        '(c) model-only governed',
+        marker(null, ['model']),
+        [...expectedBase, '--enable-manager', '--enable-asset-hashing']
+      ],
+      [
+        '(d) node-id-only governed',
+        marker(null, ['node_id']),
+        [...expectedBase, '--enable-manager']
+      ],
+      [
+        '(e) partner-only governed',
+        marker(null, ['partner']),
+        [...expectedBase, '--enable-manager']
+      ],
+      [
+        '(f) all four active',
+        marker('allowlist', ['custom_node', 'model', 'node_id', 'partner']),
+        [...expectedBase, '--enable-asset-hashing']
+      ],
+      [
+        '(g) non-governed (absent marker)',
+        { kind: 'absent' } as GovernanceMarkerState,
+        [...expectedBase, '--enable-manager']
+      ],
+      [
+        '(g) non-governed (malformed marker)',
+        { kind: 'malformed', reason: 'test' } as GovernanceMarkerState,
+        [...expectedBase, '--enable-manager']
+      ],
+      [
+        '(g) empty-blocklist-only build (inactive custom node mode)',
+        marker(null, []),
+        [...expectedBase, '--enable-manager']
+      ]
+    ])('adjusts args for %s', (_name, governance, expectedArgs) => {
+      const p = path.join(dir, 'install')
+      layout(p)
+      // Include --enable-manager in the user args to prove it gets stripped when it should be,
+      // and preserved when it should be.
+      const spec = buildLaunchSpec(p, { launchArgs: `${baseArgs} --enable-manager`, governance })
+      expect(spec?.args).toEqual(expectedArgs)
+    })
+
+    // Core's `cli_args.py` sets `enable_manager = True` for the legacy-ui flag
+    // too, so stripping only `--enable-manager` would leave the Manager on and
+    // make core refuse the launch outright.
+    it.each(['--enable-manager-legacy-ui', '--enable-manager --enable-manager-legacy-ui'])(
+      'strips %s on an allowlist install',
+      (managerArgs) => {
+        const p = path.join(dir, 'install')
+        layout(p)
+
+        const spec = buildLaunchSpec(p, {
+          launchArgs: `${baseArgs} ${managerArgs}`,
+          governance: marker('allowlist', ['custom_node'])
+        })
+
+        expect(spec?.args).toEqual([...expectedBase])
+      }
+    )
+
+    it('keeps the legacy-ui flag when the custom-node form is not an allowlist', () => {
+      const p = path.join(dir, 'install')
+      layout(p)
+
+      const spec = buildLaunchSpec(p, {
+        launchArgs: `${baseArgs} --enable-manager-legacy-ui`,
+        governance: marker('blocklist', ['custom_node'])
+      })
+
+      expect(spec?.args).toEqual([...expectedBase, '--enable-manager-legacy-ui'])
+    })
   })
 })

--- a/src/main/comfybuilder/launch.ts
+++ b/src/main/comfybuilder/launch.ts
@@ -11,8 +11,21 @@ import path from 'path'
 
 import { extractPort, parseArgs } from '../lib/util'
 import type { LaunchSpec } from './types'
+import type { GovernanceMarkerState } from './governance'
 
 const DEFAULT_LAUNCH_ARGS = '--enable-manager'
+
+/**
+ * Every flag that turns the Manager on in core. `--enable-manager-legacy-ui`
+ * is NOT a separate feature: `comfy/cli_args.py` sets `enable_manager = True`
+ * whenever it is present.
+ *
+ * Filtering only the obvious one would let a user re-enable the Manager on an
+ * allowlist install by naming the other. Core then refuses to start at all,
+ * with the generic "could not apply your organization's policy" - the exact
+ * cryptic failure this module exists to replace with a stated refusal.
+ */
+const MANAGER_ENABLING_ARGS = new Set(['--enable-manager', '--enable-manager-legacy-ui'])
 
 /**
  * The archive's bundled interpreter.
@@ -35,6 +48,8 @@ export function venvPython(installPath: string): string {
 export interface LaunchOptions {
   /** Extra ComfyUI args, e.g. `--cpu --port 8188`. Defaults to `--enable-manager`. */
   launchArgs?: string
+  /** The durable governance marker from the installation record. */
+  governance?: GovernanceMarkerState
 }
 
 /**
@@ -48,7 +63,18 @@ export function buildLaunchSpec(installPath: string, opts: LaunchOptions = {}): 
   if (!fs.existsSync(mainPy)) return null
 
   const raw = (opts.launchArgs ?? DEFAULT_LAUNCH_ARGS).trim()
-  const parsed = raw.length > 0 ? parseArgs(raw) : []
+  let parsed = raw.length > 0 ? parseArgs(raw) : []
+
+  if (opts.governance?.kind === 'governed') {
+    const marker = opts.governance.marker
+    if (marker.customNodeMode === 'allowlist') {
+      parsed = parsed.filter((arg) => !MANAGER_ENABLING_ARGS.has(arg))
+    }
+    if (marker.activeForms.includes('model') && !parsed.includes('--enable-asset-hashing')) {
+      parsed.push('--enable-asset-hashing')
+    }
+  }
+
   return {
     cmd: python,
     args: ['-s', path.join('ComfyUI', 'main.py'), ...parsed],

--- a/src/main/comfybuilder/modelDownloadStaging.test.ts
+++ b/src/main/comfybuilder/modelDownloadStaging.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+import { createHash } from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { digestKey } from './integrity'
+import {
+  digestFile,
+  ensureStagedPlaceholder,
+  hashFile,
+  readStagedMeta,
+  stagedMetaDigest,
+  stagedMetaDigestFields,
+  stagingMetaPathFor,
+  stagingPathFor,
+  writeStagedMeta,
+  type StagedDownloadMeta
+} from '../lib/modelDownloadStaging'
+
+const HEX_A = 'a'.repeat(64)
+const HEX_B = 'b'.repeat(64)
+
+let tmpDir: string
+let finalPath: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-staging-digest-'))
+  finalPath = path.join(tmpDir, 'checkpoints', 'model.safetensors')
+  fs.mkdirSync(path.dirname(finalPath), { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function meta(overrides: Partial<StagedDownloadMeta> = {}): StagedDownloadMeta {
+  return {
+    version: 2,
+    url: 'https://example.com/model.safetensors',
+    expectedSize: 10,
+    directory: 'checkpoints',
+    filename: 'model.safetensors',
+    ...overrides
+  }
+}
+
+describe('STAGING METADATA carries an algorithm-tagged digest', () => {
+  it('persists {algo, value} in the sidecar and reads it back tagged', () => {
+    const digest = { algo: 'blake3', value: HEX_A } as const
+    writeStagedMeta(stagingMetaPathFor(finalPath), meta(stagedMetaDigestFields(digest)))
+    const roundTripped = readStagedMeta(stagingMetaPathFor(finalPath))
+    expect(roundTripped?.digest).toEqual(digest)
+    expect(stagedMetaDigest(roundTripped)).toEqual(digest)
+  })
+
+  it('mirrors sha256 alongside the tagged field, but never mirrors blake3 as sha256', () => {
+    expect(stagedMetaDigestFields({ algo: 'sha256', value: HEX_A })).toEqual({
+      digest: { algo: 'sha256', value: HEX_A },
+      sha256: HEX_A
+    })
+    expect(stagedMetaDigestFields({ algo: 'blake3', value: HEX_A })).toEqual({
+      digest: { algo: 'blake3', value: HEX_A }
+    })
+    expect(stagedMetaDigestFields(null)).toEqual({})
+  })
+
+  it('reads a LEGACY sha256-only sidecar as a sha256-tagged digest (backward compat)', () => {
+    writeStagedMeta(stagingMetaPathFor(finalPath), meta({ sha256: HEX_B }))
+    const legacy = readStagedMeta(stagingMetaPathFor(finalPath))
+    expect(legacy?.digest).toBeUndefined()
+    expect(stagedMetaDigest(legacy)).toEqual({ algo: 'sha256', value: HEX_B })
+  })
+
+  it('never re-tags a legacy sha256-only sidecar as blake3', () => {
+    const legacy = stagedMetaDigest(meta({ sha256: HEX_A }))
+    expect(digestKey(legacy)).toBe(`sha256:${HEX_A}`)
+    expect(digestKey(legacy)).not.toBe(`blake3:${HEX_A}`)
+  })
+
+  it('upgrades a persisted sha256 expectation to blake3 with the SAME hex', () => {
+    fs.writeFileSync(stagingPathFor(finalPath), 'staged-bytes')
+    writeStagedMeta(stagingMetaPathFor(finalPath), meta({ sha256: HEX_A }))
+
+    const upgraded = { algo: 'blake3', value: HEX_A } as const
+    expect(ensureStagedPlaceholder(finalPath, meta(stagedMetaDigestFields(upgraded)))).toBe(true)
+    expect(stagedMetaDigest(readStagedMeta(stagingMetaPathFor(finalPath)))).toEqual(upgraded)
+  })
+
+  it('keeps a persisted digest when the new caller declares none', () => {
+    fs.writeFileSync(stagingPathFor(finalPath), 'staged-bytes')
+    const existing = meta(stagedMetaDigestFields({ algo: 'blake3', value: HEX_A }))
+    writeStagedMeta(stagingMetaPathFor(finalPath), existing)
+    expect(ensureStagedPlaceholder(finalPath, meta())).toBe(true)
+    expect(stagedMetaDigest(readStagedMeta(stagingMetaPathFor(finalPath)))).toEqual({
+      algo: 'blake3',
+      value: HEX_A
+    })
+  })
+})
+
+describe('file hashing under both algorithms', () => {
+  it('computes the published BLAKE3 vectors', async () => {
+    const empty = path.join(tmpDir, 'empty.bin')
+    fs.writeFileSync(empty, '')
+    expect(await hashFile(empty, 'blake3')).toBe(
+      'af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262'
+    )
+    const abc = path.join(tmpDir, 'abc.bin')
+    fs.writeFileSync(abc, 'abc')
+    expect(await hashFile(abc, 'blake3')).toBe(
+      '6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85'
+    )
+  })
+
+  it('streams a multi-chunk file to the same digest as a one-shot hash', async () => {
+    const big = path.join(tmpDir, 'big.bin')
+    const bytes = Buffer.alloc(3 * 64 * 1024 + 17, 7)
+    fs.writeFileSync(big, bytes)
+    expect(await hashFile(big, 'sha256')).toBe(createHash('sha256').update(bytes).digest('hex'))
+    expect((await hashFile(big, 'blake3')).length).toBe(64)
+  })
+
+  it('returns the actual content already tagged with the algorithm used', async () => {
+    const file = path.join(tmpDir, 'weights.bin')
+    fs.writeFileSync(file, 'weights')
+    await expect(digestFile(file, 'blake3')).resolves.toMatchObject({ algo: 'blake3' })
+    await expect(digestFile(file, 'sha256')).resolves.toEqual({
+      algo: 'sha256',
+      value: createHash('sha256').update('weights').digest('hex')
+    })
+  })
+
+  it('gives the same bytes DIFFERENT digests under the two algorithms', async () => {
+    const file = path.join(tmpDir, 'weights.bin')
+    fs.writeFileSync(file, 'weights')
+    const [asBlake3, asSha256] = await Promise.all([
+      digestFile(file, 'blake3'),
+      digestFile(file, 'sha256')
+    ])
+    expect(asBlake3.value).not.toBe(asSha256.value)
+  })
+})

--- a/src/main/comfybuilder/modelLedger.ts
+++ b/src/main/comfybuilder/modelLedger.ts
@@ -1,0 +1,111 @@
+import fs from 'fs'
+import path from 'path'
+
+import { writeFileSafeAsync } from '../lib/safe-file'
+
+export const MODEL_LEDGER_VERSION = 1
+export const MODEL_LEDGER_RELATIVE = path.join('ComfyUI', 'governance', 'model_ledger.json')
+
+const MODEL_DIGEST = /^blake3:[0-9a-f]{64}$/
+const DECIMAL_INTEGER = /^(0|[1-9][0-9]*)$/
+const LEDGER_KEYS = ['ledgerVersion', 'entries'] as const
+const ENTRY_KEYS = ['path', 'size', 'mtimeNs', 'inode', 'dev', 'digest'] as const
+
+export interface ModelLedgerEntry {
+  readonly path: string
+  readonly size: number
+  readonly mtimeNs: string
+  readonly inode: string
+  readonly dev: string
+  readonly digest: string
+}
+
+export interface ModelLedger {
+  readonly ledgerVersion: 1
+  readonly entries: readonly ModelLedgerEntry[]
+}
+
+export function modelLedgerPath(installPath: string): string {
+  return path.join(installPath, MODEL_LEDGER_RELATIVE)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const keys = Object.keys(value)
+  return keys.length === expected.length && expected.every((key) => key in value)
+}
+
+function isModelLedgerEntry(value: unknown): value is ModelLedgerEntry {
+  if (!isRecord(value) || !hasExactKeys(value, ENTRY_KEYS)) return false
+  return (
+    typeof value.path === 'string' &&
+    path.isAbsolute(value.path) &&
+    !value.path.includes('\\') &&
+    typeof value.size === 'number' &&
+    Number.isInteger(value.size) &&
+    value.size >= 0 &&
+    typeof value.mtimeNs === 'string' &&
+    DECIMAL_INTEGER.test(value.mtimeNs) &&
+    typeof value.inode === 'string' &&
+    DECIMAL_INTEGER.test(value.inode) &&
+    typeof value.dev === 'string' &&
+    DECIMAL_INTEGER.test(value.dev) &&
+    typeof value.digest === 'string' &&
+    MODEL_DIGEST.test(value.digest)
+  )
+}
+
+function isModelLedger(value: unknown): value is ModelLedger {
+  if (!isRecord(value) || !hasExactKeys(value, LEDGER_KEYS)) return false
+  return (
+    value.ledgerVersion === MODEL_LEDGER_VERSION &&
+    Array.isArray(value.entries) &&
+    value.entries.every(isModelLedgerEntry)
+  )
+}
+
+export async function readModelLedger(installPath: string): Promise<ModelLedger | null> {
+  try {
+    const parsed: unknown = JSON.parse(
+      await fs.promises.readFile(modelLedgerPath(installPath), 'utf-8')
+    )
+    return isModelLedger(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export async function createModelLedgerEntry(
+  filePath: string,
+  digest: string
+): Promise<ModelLedgerEntry> {
+  if (!MODEL_DIGEST.test(digest)) throw new Error(`Invalid model ledger digest: ${digest}`)
+
+  const realPath = await fs.promises.realpath(filePath)
+  const stat = await fs.promises.stat(realPath, { bigint: true })
+  if (!stat.isFile()) throw new Error(`Model ledger path is not a file: ${realPath}`)
+  if (stat.size > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Model is too large for the model ledger: ${realPath}`)
+  }
+
+  return {
+    path: realPath.replace(/\\/g, '/'),
+    size: Number(stat.size),
+    mtimeNs: stat.mtimeNs.toString(),
+    inode: stat.ino.toString(),
+    dev: stat.dev.toString(),
+    digest
+  }
+}
+
+export async function writeModelLedger(
+  installPath: string,
+  entries: readonly ModelLedgerEntry[]
+): Promise<void> {
+  const ledger: ModelLedger = { ledgerVersion: MODEL_LEDGER_VERSION, entries: [...entries] }
+  if (!isModelLedger(ledger)) throw new Error('Refusing to write an invalid model ledger')
+  await writeFileSafeAsync(modelLedgerPath(installPath), JSON.stringify(ledger))
+}

--- a/src/main/comfybuilder/models.test.ts
+++ b/src/main/comfybuilder/models.test.ts
@@ -614,6 +614,30 @@ describe('model governance ledger', () => {
     }
   })
 
+  it('records the managed job save path when its normalized filename differs', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('approved-model')
+    const digest = `blake3:${blake(bytes)}`
+    const governance = configureGovernedInstall(install, [digest])
+    const actualPath = path.join(installModelsRoot(install), 'checkpoints', 'model.safetensors')
+    const jobs = fakeJobs((_opts, _dest) => {
+      fs.mkdirSync(path.dirname(actualPath), { recursive: true })
+      fs.writeFileSync(actualPath, bytes)
+      return { status: 'completed', savePath: actualPath }
+    })
+
+    await stageModels({
+      models: [model({ filename: 'model.safetensors?download=1', blake3: digest })],
+      installPath: install,
+      governance,
+      jobs
+    })
+
+    expect((await readModelLedger(install))?.entries[0]?.path).toBe(
+      fs.realpathSync(actualPath).replace(/\\/g, '/')
+    )
+  })
+
   it('writes no entry when downloaded bytes fail their declared digest', async () => {
     const install = freshInstall()
     const declaredBytes = Buffer.from('declared-model-bytes')
@@ -650,8 +674,35 @@ describe('model governance ledger', () => {
     expect(
       fs.readFileSync(path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors'))
     ).toEqual(bytes)
-    expect(await readModelLedger(install)).toBeNull()
-    expect(fs.existsSync(modelLedgerPath(install))).toBe(false)
+    // An EMPTY ledger, not an absent one: the run must state that it vouches
+    // for nothing rather than stay silent (see the supersede case below).
+    expect(await readModelLedger(install)).toEqual({ ledgerVersion: 1, entries: [] })
+  })
+
+  it('supersedes a ledger from an earlier policy when the run approves nothing', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('valid-but-unapproved-model')
+    const digest = `blake3:${blake(bytes)}`
+    const governance = configureGovernedInstall(install, [])
+
+    // A ledger left behind by a staging run under a previous, wider policy.
+    const stalePath = path.join(installModelsRoot(install), 'checkpoints', 'stale.safetensors')
+    fs.mkdirSync(path.dirname(stalePath), { recursive: true })
+    fs.writeFileSync(stalePath, Buffer.from('previously-approved'))
+    await writeModelLedger(install, [
+      await createModelLedgerEntry(stalePath, `blake3:${'7'.repeat(64)}`)
+    ])
+    expect((await readModelLedger(install))?.entries).toHaveLength(1)
+
+    await stageModels({
+      models: [model({ blake3: digest })],
+      installPath: install,
+      governance,
+      jobs: verifiedJobs({ 'm.safetensors': bytes })
+    })
+
+    // The superseded entry must not survive as evidence under the new policy.
+    expect(await readModelLedger(install)).toEqual({ ledgerVersion: 1, entries: [] })
   })
 
   it('does not consult policy or write a ledger when the model form is inactive', async () => {

--- a/src/main/comfybuilder/models.test.ts
+++ b/src/main/comfybuilder/models.test.ts
@@ -1,15 +1,28 @@
 // @vitest-environment node
-import { createHash, randomUUID } from 'crypto'
+import { blake3 } from '@noble/hashes/blake3.js'
+import { createHash, generateKeyPairSync, randomUUID, sign as signBytes } from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { stageModels, installModelsRoot, type ModelJobSurface } from './models'
 import type { ModelJobOptions, ModelJobOutcome } from '../lib/comfyDownloadManager'
+import sharedModelLedgerFixture from './fixtures/model-ledger-v1.json'
+import { governancePolicyPath } from './governance'
+import type { GovernanceMarker } from './governance'
+import {
+  createModelLedgerEntry,
+  modelLedgerPath,
+  readModelLedger,
+  writeModelLedger
+} from './modelLedger'
+import { stageModels, installModelsRoot, type ModelJobSurface } from './models'
 import type { ModelDescriptor, StageProgress } from './types'
 
 const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
+const blake = (buf: Buffer): string => Buffer.from(blake3(buf)).toString('hex')
+const DOMAIN_SEPARATOR = Buffer.from('comfyui-governance-v1\0', 'utf-8')
+const BUILD_IDENTITY = 'build-7|release-3|artifact-9|linux/nvidia/cu124|sha256:abcd'
 
 const tmpRoots: string[] = []
 function freshInstall(): string {
@@ -48,6 +61,69 @@ function fakeJobs(
   return { start, cancel } satisfies ModelJobSurface
 }
 
+function verifiedJobs(bytesByFilename: Readonly<Record<string, Buffer>>) {
+  return fakeJobs((opts, dest) => {
+    const bytes = bytesByFilename[opts.filename]
+    if (!bytes) return { status: 'error', error: 'missing test bytes' }
+    if (!opts.digest) return { status: 'error', error: 'missing test digest' }
+    const actual = opts.digest.algo === 'blake3' ? blake(bytes) : sha(bytes)
+    if (actual !== opts.digest.value) {
+      return { status: 'error', error: 'checksum mismatch', code: 'checksum-mismatch' }
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, bytes)
+    return { status: 'completed', savePath: dest }
+  })
+}
+
+function configureGovernedInstall(
+  installPath: string,
+  models: readonly string[],
+  activeForms: readonly string[] = ['model']
+): GovernanceMarker {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const rawPublicKey = publicKey.export({ format: 'der', type: 'spki' }).subarray(12)
+  const encodedPublicKey = Buffer.from(rawPublicKey).toString('base64url')
+  const customNodeMode = activeForms.includes('customNode') ? 'blocklist' : null
+  const payload = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      audience: 'comfyui-core',
+      versionId: 'version-42',
+      buildIdentity: BUILD_IDENTITY,
+      sourcesDigest: `sha256:${'a'.repeat(64)}`,
+      policyGeneration: 3,
+      activeForms,
+      customNodeMode,
+      packs: [],
+      deniedPacks: [],
+      disabledNodes: [],
+      disabledPartnerNodes: [],
+      models
+    }),
+    'utf-8'
+  )
+  const signature = signBytes(
+    null,
+    Buffer.concat([DOMAIN_SEPARATOR, payload]),
+    privateKey
+  ).toString('base64url')
+  const policyPath = governancePolicyPath(installPath)
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true })
+  fs.writeFileSync(
+    policyPath,
+    JSON.stringify({ schema: 1, payload: payload.toString('base64url'), signature })
+  )
+  return {
+    governanceMarkerVersion: 1,
+    governed: true,
+    expectedBuildIdentity: BUILD_IDENTITY,
+    publicKey: encodedPublicKey,
+    activeForms,
+    customNodeMode
+  }
+}
+
 const model = (o: Partial<ModelDescriptor> = {}): ModelDescriptor => ({
   type: 'checkpoints',
   filename: 'm.safetensors',
@@ -82,7 +158,7 @@ describe('stageModels', () => {
       filename: 'v.pt',
       directory: 'vae',
       installationId: 'inst-1',
-      sha256: sha(bytes),
+      digest: { algo: 'sha256', value: sha(bytes) },
       destinationBaseDir: installModelsRoot(install),
       bypassRootLockFor: installModelsRoot(install)
     })
@@ -97,7 +173,7 @@ describe('stageModels', () => {
       installPath: install,
       jobs
     })
-    expect(jobs.start.mock.calls[0]![0].sha256).toBe(sha(bytes))
+    expect(jobs.start.mock.calls[0]![0].digest).toEqual({ algo: 'sha256', value: sha(bytes) })
   })
 
   it('maps a checksum-mismatch outcome to model-checksum-mismatch without retrying', async () => {
@@ -158,13 +234,45 @@ describe('stageModels', () => {
     expect(jobs.start).toHaveBeenCalledTimes(1)
   })
 
-  it.each([undefined, '', '   '])('downloads a model without SHA-256 integrity', async (sha256) => {
+  it.each([undefined, '', '   '])(
+    'downloads a model without integrity on an ungoverned install',
+    async (blank) => {
+      const install = freshInstall()
+      const jobs = fakeJobs()
+      const untrusted: ModelDescriptor = { ...model(), sha256: blank, blake3: blank }
+      await stageModels({ models: [untrusted], installPath: install, jobs })
+      expect(jobs.start).toHaveBeenCalledTimes(1)
+      expect(jobs.start.mock.calls[0]![0].digest).toBeUndefined()
+    }
+  )
+
+  it.each([undefined, '', '   '])(
+    'refuses a model without integrity on a governed install',
+    async (blank) => {
+      const install = freshInstall()
+      const governance = configureGovernedInstall(install, [])
+      const jobs = fakeJobs()
+      const untrusted: ModelDescriptor = { ...model(), sha256: blank, blake3: blank }
+      await expect(
+        stageModels({ models: [untrusted], installPath: install, governance, jobs })
+      ).rejects.toMatchObject({ kind: 'invalid-model' })
+      expect(jobs.start).not.toHaveBeenCalled()
+    }
+  )
+
+  it('refuses a model without integrity when the governance marker is unreadable', async () => {
     const install = freshInstall()
     const jobs = fakeJobs()
-    const untrusted = { ...model(), sha256 } as unknown as ModelDescriptor
-    await stageModels({ models: [untrusted], installPath: install, jobs })
-    expect(jobs.start).toHaveBeenCalledTimes(1)
-    expect(jobs.start.mock.calls[0]![0].sha256).toBeUndefined()
+    const untrusted: ModelDescriptor = { ...model(), sha256: undefined }
+    await expect(
+      stageModels({
+        models: [untrusted],
+        installPath: install,
+        governance: { governed: true } as unknown as GovernanceMarker,
+        jobs
+      })
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    expect(jobs.start).not.toHaveBeenCalled()
   })
 
   it.each(['not-a-sha256', 'sha256:'])(
@@ -179,16 +287,114 @@ describe('stageModels', () => {
     }
   )
 
+  it.each(['not-a-blake3', 'blake3:', `sha256:${'a'.repeat(64)}`])(
+    'rejects a model with malformed BLAKE3 before any download',
+    async (blake3) => {
+      const install = freshInstall()
+      const jobs = fakeJobs()
+      await expect(
+        stageModels({
+          models: [model({ blake3, sha256: undefined })],
+          installPath: install,
+          jobs
+        })
+      ).rejects.toMatchObject({ kind: 'invalid-model' })
+      expect(jobs.start).not.toHaveBeenCalled()
+    }
+  )
+
+  it('stages a nested model type at its nested path', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('gemma-weights')
+    const jobs = fakeJobs((_opts, dest) => {
+      fs.mkdirSync(path.dirname(dest), { recursive: true })
+      fs.writeFileSync(dest, bytes)
+      return { status: 'completed', savePath: dest }
+    })
+    await stageModels({
+      models: [
+        model({
+          type: 'text_encoders/gemma_3_12b_it_hf',
+          filename: 'gemma.safetensors',
+          sha256: sha(bytes)
+        })
+      ],
+      installPath: install,
+      jobs
+    })
+    const dest = path.join(
+      installModelsRoot(install),
+      'text_encoders',
+      'gemma_3_12b_it_hf',
+      'gemma.safetensors'
+    )
+    expect(fs.readFileSync(dest)).toEqual(bytes)
+    expect(jobs.start.mock.calls[0]![0].directory).toBe('text_encoders/gemma_3_12b_it_hf')
+  })
+
+  // Every accepted value here is one Cloud can seal (`common.ValidModelDir`),
+  // so a distribution Cloud built cannot be unstageable on Desktop.
   it.each([
-    ['type', { type: '../evil' }],
-    ['type sep', { type: 'a/b' }],
-    ['filename', { filename: '../../etc/passwd' }],
-    ['filename sep', { filename: 'a/b.pt' }]
-  ])('rejects an unsafe %s before any download', async (_name, bad) => {
+    'checkpoints',
+    'text_encoders/gemma_3_12b_it_hf',
+    'diffusers/governance-fixture/text_encoder',
+    'insightface/models/antelopev2',
+    'LLM/Qwen-VL/Qwen3-VL-2B-Instruct',
+    'My-Type_1.2'
+  ])('accepts %s as a model type', async (type) => {
+    const install = freshInstall()
+    const jobs = fakeJobs()
+    await stageModels({ models: [model({ type })], installPath: install, jobs })
+    expect(jobs.start.mock.calls[0]![0].directory).toBe(type)
+    expect(fs.existsSync(path.join(installModelsRoot(install), type, 'm.safetensors'))).toBe(true)
+  })
+
+  it.each([
+    ['a leading traversal segment', '../evil'],
+    ['an interior traversal segment', 'text_encoders/../../evil'],
+    ['a bare traversal', '..'],
+    ['a posix absolute path', '/checkpoints'],
+    ['a windows drive path', 'C:/models'],
+    ['a backslash separator', 'checkpoints\\evil'],
+    ['a doubled separator', 'text_encoders//gemma'],
+    ['a trailing separator', 'text_encoders/'],
+    ['an empty type', ''],
+    ['a dot segment', 'text_encoders/./gemma'],
+    ['a hidden segment', 'text_encoders/.hidden'],
+    ['a reserved code root', 'custom_nodes/evil'],
+    ['a reserved config root', 'configs/evil'],
+    ['a dos device segment', 'nul/weights'],
+    ['a trailing-dot segment', 'text_encoders/gemma.'],
+    ['a whitespace segment', 'text encoders/gemma'],
+    ['a NUL byte', 'text_encoders/gem\0ma'],
+    ['an over-long path', `${'a/'.repeat(128)}b`]
+  ])('rejects %s as a model type before any download', async (_name, type) => {
     const install = freshInstall()
     const jobs = fakeJobs()
     await expect(
-      stageModels({ models: [model(bad)], installPath: install, jobs })
+      stageModels({ models: [model({ type })], installPath: install, jobs })
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    expect(jobs.start).not.toHaveBeenCalled()
+  })
+
+  // A filename is ALWAYS a single segment: accepting nested TYPES must not have
+  // relaxed the filename half of `models/<type>/<filename>`.
+  it.each([
+    ['a traversal', '../../etc/passwd'],
+    ['a bare traversal', '..'],
+    ['a posix separator', 'a/b.pt'],
+    ['a windows separator', 'a\\b.pt'],
+    ['a nested fixture path', 'unet/diffusion_pytorch_model.safetensors'],
+    ['a dot', '.'],
+    ['an absolute path', '/etc/passwd'],
+    ['a drive prefix', 'C:evil.pt'],
+    ['a NUL byte', 'ev\0il.pt'],
+    ['nothing at all', '']
+  ])('still rejects a filename containing %s before any download', async (_name, filename) => {
+    const install = freshInstall()
+    const jobs = fakeJobs()
+    await expect(
+      stageModels({ models: [model({ filename })], installPath: install, jobs })
     ).rejects.toMatchObject({ kind: 'invalid-model' })
     expect(jobs.start).not.toHaveBeenCalled()
   })
@@ -230,6 +436,32 @@ describe('stageModels', () => {
     ).rejects.toMatchObject({ kind: 'invalid-model' })
     expect(jobs.start).not.toHaveBeenCalled()
     expect(fs.existsSync(path.join(outside, 'x.pth'))).toBe(false)
+  })
+
+  it('refuses a nested type whose parent segment symlinks outside the install', async () => {
+    const install = freshInstall()
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-escape-nested-'))
+    tmpRoots.push(outside)
+    const modelsRoot = installModelsRoot(install)
+    fs.mkdirSync(modelsRoot, { recursive: true })
+    // The grammar cannot see this: every segment of `diffusers/governance-fixture`
+    // is valid, and only the realpath check catches the redirected parent.
+    fs.symlinkSync(
+      outside,
+      path.join(modelsRoot, 'diffusers'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const jobs = fakeJobs()
+    await expect(
+      stageModels({
+        models: [model({ type: 'diffusers/governance-fixture', filename: 'model_index.json' })],
+        installPath: install,
+        jobs
+      })
+    ).rejects.toMatchObject({ kind: 'invalid-model' })
+    expect(jobs.start).not.toHaveBeenCalled()
+    expect(fs.existsSync(path.join(outside, 'governance-fixture'))).toBe(true)
+    expect(fs.existsSync(path.join(outside, 'governance-fixture', 'model_index.json'))).toBe(false)
   })
 
   it('removes a legacy .partial leftover before starting the job', async () => {
@@ -333,5 +565,187 @@ describe('stageModels', () => {
     controller.abort()
     await expect(staging).rejects.toThrow(/cancel/i)
     expect(cancel).toHaveBeenCalledWith('job-1')
+  })
+})
+
+describe('model governance ledger', () => {
+  it('records exactly two successfully staged approved BLAKE3 models', async () => {
+    const install = freshInstall()
+    const firstBytes = Buffer.from('approved-model-one')
+    const secondBytes = Buffer.from('approved-model-two')
+    const firstDigest = `blake3:${blake(firstBytes)}`
+    const secondDigest = `blake3:${blake(secondBytes)}`
+    const governance = configureGovernedInstall(install, [firstDigest, secondDigest])
+
+    await stageModels({
+      models: [
+        model({ type: 'checkpoints', filename: 'one.safetensors', blake3: firstDigest }),
+        model({ type: 'vae', filename: 'two.safetensors', blake3: secondDigest })
+      ],
+      installPath: install,
+      governance,
+      jobs: verifiedJobs({
+        'one.safetensors': firstBytes,
+        'two.safetensors': secondBytes
+      })
+    })
+
+    const ledger = await readModelLedger(install)
+    expect(ledger?.entries).toHaveLength(2)
+    const firstPath = fs.realpathSync(
+      path.join(installModelsRoot(install), 'checkpoints', 'one.safetensors')
+    )
+    const secondPath = fs.realpathSync(
+      path.join(installModelsRoot(install), 'vae', 'two.safetensors')
+    )
+    expect(
+      ledger?.entries.map(({ path: entryPath, digest }) => ({ path: entryPath, digest }))
+    ).toEqual([
+      { path: firstPath.replace(/\\/g, '/'), digest: firstDigest },
+      { path: secondPath.replace(/\\/g, '/'), digest: secondDigest }
+    ])
+
+    for (const entry of ledger!.entries) {
+      const stat = fs.statSync(entry.path, { bigint: true })
+      expect(entry.size).toBe(Number(stat.size))
+      expect(entry.mtimeNs).toBe(stat.mtimeNs.toString())
+      expect(entry.inode).toBe(stat.ino.toString())
+      expect(entry.dev).toBe(stat.dev.toString())
+    }
+  })
+
+  it('writes no entry when downloaded bytes fail their declared digest', async () => {
+    const install = freshInstall()
+    const declaredBytes = Buffer.from('declared-model-bytes')
+    const downloadedBytes = Buffer.from('different-downloaded-bytes')
+    const digest = `blake3:${blake(declaredBytes)}`
+    const governance = configureGovernedInstall(install, [digest])
+
+    await expect(
+      stageModels({
+        models: [model({ blake3: digest })],
+        installPath: install,
+        governance,
+        jobs: verifiedJobs({ 'm.safetensors': downloadedBytes })
+      })
+    ).rejects.toMatchObject({ kind: 'model-checksum-mismatch' })
+
+    expect(await readModelLedger(install)).toBeNull()
+    expect(fs.existsSync(modelLedgerPath(install))).toBe(false)
+  })
+
+  it('writes no entry when valid bytes are outside the verified approved set', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('valid-but-unapproved-model')
+    const digest = `blake3:${blake(bytes)}`
+    const governance = configureGovernedInstall(install, [])
+
+    await stageModels({
+      models: [model({ blake3: digest })],
+      installPath: install,
+      governance,
+      jobs: verifiedJobs({ 'm.safetensors': bytes })
+    })
+
+    expect(
+      fs.readFileSync(path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors'))
+    ).toEqual(bytes)
+    expect(await readModelLedger(install)).toBeNull()
+    expect(fs.existsSync(modelLedgerPath(install))).toBe(false)
+  })
+
+  it('does not consult policy or write a ledger when the model form is inactive', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('ordinary-staged-model')
+    const digest = `blake3:${blake(bytes)}`
+    const governance = configureGovernedInstall(install, [], ['customNode'])
+    fs.rmSync(governancePolicyPath(install))
+    const readFileSpy = vi.spyOn(fs.promises, 'readFile')
+
+    try {
+      await stageModels({
+        models: [model({ blake3: digest })],
+        installPath: install,
+        governance,
+        jobs: verifiedJobs({ 'm.safetensors': bytes })
+      })
+      expect(readFileSpy).not.toHaveBeenCalled()
+    } finally {
+      readFileSpy.mockRestore()
+    }
+
+    expect(
+      fs.readFileSync(path.join(installModelsRoot(install), 'checkpoints', 'm.safetensors'))
+    ).toEqual(bytes)
+    expect(fs.existsSync(modelLedgerPath(install))).toBe(false)
+  })
+
+  it('leaves a complete old or new ledger when publication crashes', async () => {
+    const realRename = fs.promises.rename.bind(fs.promises)
+
+    for (const publishBeforeCrash of [false, true]) {
+      const install = freshInstall()
+      const oldFile = path.join(installModelsRoot(install), 'checkpoints', 'old.safetensors')
+      const newFile = path.join(installModelsRoot(install), 'checkpoints', 'new.safetensors')
+      fs.mkdirSync(path.dirname(oldFile), { recursive: true })
+      fs.writeFileSync(oldFile, 'old')
+      fs.writeFileSync(newFile, 'new')
+      const oldEntry = await createModelLedgerEntry(oldFile, `blake3:${'1'.repeat(64)}`)
+      const newEntry = await createModelLedgerEntry(newFile, `blake3:${'2'.repeat(64)}`)
+      await writeModelLedger(install, [oldEntry])
+
+      const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementationOnce(async (from, to) => {
+        if (publishBeforeCrash) await realRename(from, to)
+        throw new Error('simulated crash during ledger publication')
+      })
+      try {
+        await expect(writeModelLedger(install, [newEntry])).rejects.toThrow(/simulated crash/)
+      } finally {
+        renameSpy.mockRestore()
+      }
+
+      expect(await readModelLedger(install)).toEqual({
+        ledgerVersion: 1,
+        entries: publishBeforeCrash ? [newEntry] : [oldEntry]
+      })
+    }
+  })
+
+  it('matches the shared Python ModelLedgerKey tuple field order, units, and wire types', async () => {
+    const install = freshInstall()
+    const ledgerPath = modelLedgerPath(install)
+    fs.mkdirSync(path.dirname(ledgerPath), { recursive: true })
+    fs.writeFileSync(ledgerPath, JSON.stringify(sharedModelLedgerFixture.ledger))
+
+    const ledger = await readModelLedger(install)
+    expect(ledger).not.toBeNull()
+    const entry = ledger!.entries[0]!
+    expect([entry.path, entry.size, entry.mtimeNs, entry.inode, entry.dev]).toEqual(
+      sharedModelLedgerFixture.modelLedgerKey
+    )
+    expect(Object.keys(ledger!)).toEqual(['ledgerVersion', 'entries'])
+    expect(Object.keys(entry)).toEqual(['path', 'size', 'mtimeNs', 'inode', 'dev', 'digest'])
+    expect(typeof entry.size).toBe('number')
+    expect([typeof entry.mtimeNs, typeof entry.inode, typeof entry.dev]).toEqual([
+      'string',
+      'string',
+      'string'
+    ])
+  })
+
+  it('starts a freshly installed Builder archive without a ledger and creates it only after staging', async () => {
+    const install = freshInstall()
+    const bytes = Buffer.from('fresh-archive-model')
+    const digest = `blake3:${blake(bytes)}`
+    const governance = configureGovernedInstall(install, [digest])
+
+    expect(fs.existsSync(modelLedgerPath(install))).toBe(false)
+    await stageModels({
+      models: [model({ blake3: digest })],
+      installPath: install,
+      governance,
+      jobs: verifiedJobs({ 'm.safetensors': bytes })
+    })
+    expect(fs.existsSync(modelLedgerPath(install))).toBe(true)
   })
 })

--- a/src/main/comfybuilder/models.ts
+++ b/src/main/comfybuilder/models.ts
@@ -10,6 +10,8 @@
  * Placement is `<installPath>/ComfyUI/models/<type>/<filename>`, the install's
  * built-in model root. That root is always on ComfyUI's model search path, so a
  * staged model is found whether or not the user shares a global model library.
+ * `<type>` may be NESTED (`diffusers/<model>/unet`) - a Diffusers tree is many
+ * models under one parent, and Cloud seals such types.
  *
  * Every model transfer is a REAL managed job in `comfyDownloadManager` - the
  * same job type as in-Comfy and starter-template model downloads. Jobs appear
@@ -20,16 +22,35 @@
  * source registry, which includes the ComfyBuilder plugin, so importing it
  * here at runtime would be a cycle.
  *
- * When a model declares a sha256, the managed transport verifies it before the
- * file appears under its final name. A file already at the destination must
- * match a declared hash to be kept; a mismatch is a conflict, never silently
- * overwritten. Public model sources may omit the hash.
+ * Integrity is expressed as an ALGORITHM-TAGGED digest - BLAKE3 when the build
+ * was sealed with one, else the SHA-256 older sealed manifests carry - which
+ * the managed transport verifies byte-for-byte before the file appears under
+ * its final name. A file already at the destination must match that digest to
+ * be kept; a mismatch is a conflict, never silently overwritten.
+ *
+ * Whether a digest is REQUIRED depends on the install:
+ *   - A declared-but-unusable value is always refused. A malformed hash is a
+ *     broken or tampered manifest, never a licence to skip verification.
+ *   - A manifest that declares no hash at all is staged unverified on an
+ *     ordinary install, because public model sources may legitimately omit it
+ *     (the API accepts such manifests, so staging must too).
+ *   - The same hashless model is REFUSED on a governed install. A managed
+ *     installation exists to guarantee that what runs is what its organization
+ *     signed off, which it cannot do for bytes it has no way to verify.
  */
 import fs from 'fs'
 import path from 'path'
 
 import type { ModelJobHandle, ModelJobOptions, ModelJobOutcome } from '../lib/comfyDownloadManager'
-import { isSecureDownloadUrl, isValidSha256, normalizeSha256 } from './integrity'
+import { governedModelDigests, readGovernanceMarker } from './governance'
+import {
+  declaresModelIntegrity,
+  digestKey,
+  isSecureDownloadUrl,
+  selectModelDigest
+} from './integrity'
+import { createModelLedgerEntry, writeModelLedger } from './modelLedger'
+import type { ModelLedgerEntry } from './modelLedger'
 import type { ModelDescriptor, StageProgress } from './types'
 
 export type StageModelsErrorKind = 'invalid-model' | 'model-checksum-mismatch' | 'model-conflict'
@@ -58,6 +79,7 @@ export interface StageModelsOptions {
   installPath: string
   /** Install record id, so jobs are attributed to this install. */
   installationId?: string | null
+  governance?: GovernanceMarker | null
   jobs: ModelJobSurface
   onProgress?: (p: StageProgress) => void
   signal?: AbortSignal
@@ -73,12 +95,86 @@ const MODEL_DOWNLOAD_RETRIES = 2
 const PROGRESS_REPORT_MS = 500
 
 /** A single path segment that cannot escape its parent: no separators, no `..`,
- *  no drive/absolute markers. Guards `models/<type>/<filename>` against a
- *  manifest that tries to traverse out of the model tree. */
+ *  no drive/absolute markers. Guards the `<filename>` half of
+ *  `models/<type>/<filename>` against a manifest that tries to traverse out of
+ *  the model tree. A filename is ALWAYS exactly one segment - a manifest that
+ *  smuggles a separator into it is refused, not split. */
 function isSafeSegment(seg: string): boolean {
   if (!seg || seg === '.' || seg === '..') return false
   if (seg.includes('/') || seg.includes('\\') || seg.includes('\0')) return false
   if (path.isAbsolute(seg) || /^[a-zA-Z]:/.test(seg)) return false
+  return true
+}
+
+/** One safe directory segment, mirroring Cloud's `modelDirSegmentPattern`
+ *  (`cloud/common/model_directories.go`). Alphanumeric-led is what rules out
+ *  traversal, leading dots, drive prefixes, separators and whitespace in a
+ *  single expression. */
+const MODEL_DIR_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/
+
+/** Bounds the path, and so its depth. Cloud's `maxModelDirLen`. */
+const MAX_MODEL_DIR_LEN = 255
+
+/** Roots ComfyUI reads as config or code rather than weights, so a "model"
+ *  placed under either would be imported instead of loaded. Cloud's
+ *  `reservedModelDirRoots`. */
+const RESERVED_MODEL_DIR_ROOTS = new Set(['configs', 'custom_nodes'])
+
+/** DOS device names, which the install cannot create a directory for on
+ *  Windows. Cloud's `windowsReservedNames`. */
+const WINDOWS_RESERVED_NAMES = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9'
+])
+
+/**
+ * `type` is a RELATIVE, possibly MULTI-SEGMENT directory under `models/`. Cloud
+ * deliberately seals nested types (`text_encoders/gemma_3_12b_it_hf`,
+ * `diffusers/Kolors/unet`), so validating the whole type as ONE segment rejected
+ * every distribution carrying one - a Diffusers distribution could never install.
+ *
+ * The rule is Cloud's `common.ValidModelDir` segment grammar, so neither side can
+ * accept what the other rejects. A leading, trailing or doubled `/`, a `..`, and
+ * an absolute or drive-prefixed path all fail as an unmatched segment.
+ *
+ * Deliberately NOT mirrored: Cloud's vetted-directory allow-list and its
+ * rejection of case variants of it, which exist so Cloud's model mirror cannot
+ * presign a URL that 404s. Desktop is handed a ready-to-GET `downloadUrl` and has
+ * no way to keep a copy of that list in sync; Cloud's own
+ * `TestVettedDirectoriesSatisfyTheSegmentRule` pins every vetted entry as
+ * grammar-valid, so this rule still accepts everything Cloud can seal.
+ *
+ * Containment stays enforced separately by {@link isContained} once the directory
+ * exists - no grammar can see a symlinked segment.
+ */
+function isSafeModelDir(dir: string): boolean {
+  if (!dir || dir.length > MAX_MODEL_DIR_LEN) return false
+  const segments = dir.split('/')
+  if (RESERVED_MODEL_DIR_ROOTS.has(segments[0]!.toLowerCase())) return false
+  for (const segment of segments) {
+    if (!MODEL_DIR_SEGMENT.test(segment) || segment.endsWith('.')) return false
+    if (WINDOWS_RESERVED_NAMES.has(segment.split('.')[0]!.toUpperCase())) return false
+  }
   return true
 }
 
@@ -144,16 +240,30 @@ async function runModelJob(
  * repeated install does not re-download what is already staged.
  */
 export async function stageModels(opts: StageModelsOptions): Promise<void> {
-  const { models, installPath, installationId, jobs, onProgress, signal } = opts
+  const { models, installPath, installationId, governance, jobs, onProgress, signal } = opts
   const total = models.length
   const modelsRoot = installModelsRoot(installPath)
+  const installation = { installPath, governance }
+  const governanceState = readGovernanceMarker(installation)
+  // Only an ABSENT marker means "ordinary install". A marker that exists but
+  // does not parse is a managed install whose record was truncated or edited,
+  // so it must keep the stricter rule - otherwise corrupting one field of the
+  // installation record would be a way to buy the right to stage unverifiable
+  // models.
+  const integrityRequired = governanceState.kind !== 'absent'
+  const modelGovernanceActive =
+    governanceState.kind === 'governed' && governanceState.marker.activeForms.includes('model')
+  const approvedModelDigests = modelGovernanceActive
+    ? await governedModelDigests(installation)
+    : null
+  const ledgerEntries: ModelLedgerEntry[] = []
 
   for (let i = 0; i < total; i++) {
     if (signal?.aborted) throw new Error('Cancelled')
     const model = models[i]!
     const index = i + 1
 
-    if (!isSafeSegment(model.type) || !isSafeSegment(model.filename)) {
+    if (!isSafeModelDir(model.type) || !isSafeSegment(model.filename)) {
       throw new StageModelsError(
         'invalid-model',
         `Model ${model.type}/${model.filename} has an unsafe path.`
@@ -165,14 +275,25 @@ export async function stageModels(opts: StageModelsOptions): Promise<void> {
         `Model ${model.type}/${model.filename} download URL must be https.`
       )
     }
-    const rawSha256 = model.sha256?.trim()
-    if (rawSha256 && !isValidSha256(rawSha256)) {
-      throw new StageModelsError(
-        'invalid-model',
-        `Model ${model.type}/${model.filename} has an invalid SHA-256 integrity value.`
-      )
+    // Prefer BLAKE3, fall back to the SHA-256 older sealed manifests carry.
+    // A DECLARED value that does not parse is always fatal; a manifest that
+    // declares nothing is fatal only under governance (see the file header).
+    const digest = selectModelDigest(model)
+    if (!digest) {
+      if (declaresModelIntegrity(model)) {
+        throw new StageModelsError(
+          'invalid-model',
+          `Model ${model.type}/${model.filename} has an invalid BLAKE3 or SHA-256 integrity value.`
+        )
+      }
+      if (integrityRequired) {
+        throw new StageModelsError(
+          'invalid-model',
+          `Model ${model.type}/${model.filename} carries no BLAKE3 or SHA-256 integrity value, ` +
+            'and a managed installation cannot stage a model it is unable to verify.'
+        )
+      }
     }
-    const sha256 = normalizeSha256(rawSha256)
 
     const destDir = path.join(modelsRoot, model.type)
     // Create the target dir first, then confirm it really resolves inside the
@@ -199,7 +320,7 @@ export async function stageModels(opts: StageModelsOptions): Promise<void> {
       filename: model.filename,
       directory: model.type,
       installationId,
-      ...(sha256 ? { sha256 } : {}),
+      ...(digest ? { digest } : {}),
       // Always the install's own model tree, even when the install's model
       // settings would route interactive downloads to a shared root - and the
       // caller holds this root's download lock for the whole transaction.
@@ -242,6 +363,12 @@ export async function stageModels(opts: StageModelsOptions): Promise<void> {
       // runModelJob; whatever reaches here is a transport/filesystem failure.
       throw new Error(`Model ${model.type}/${model.filename} download failed: ${outcome.error}`)
     }
+    const ledgerDigest = digest?.algo === 'blake3' ? digestKey(digest) : undefined
+    if (ledgerDigest && approvedModelDigests?.has(ledgerDigest)) {
+      ledgerEntries.push(await createModelLedgerEntry(dest, ledgerDigest))
+    }
     onProgress?.({ index, total, filename: model.filename, percent: 100 })
   }
+
+  if (ledgerEntries.length > 0) await writeModelLedger(installPath, ledgerEntries)
 }

--- a/src/main/comfybuilder/models.ts
+++ b/src/main/comfybuilder/models.ts
@@ -29,14 +29,20 @@
  * be kept; a mismatch is a conflict, never silently overwritten.
  *
  * Whether a digest is REQUIRED depends on the install:
- *   - A declared-but-unusable value is always refused. A malformed hash is a
- *     broken or tampered manifest, never a licence to skip verification.
+ *   - A model with NO usable hash in either field is refused when the manifest
+ *     declared one anyway - a malformed hash is a broken or tampered manifest,
+ *     never a licence to skip verification.
  *   - A manifest that declares no hash at all is staged unverified on an
  *     ordinary install, because public model sources may legitimately omit it
  *     (the API accepts such manifests, so staging must too).
  *   - The same hashless model is REFUSED on a governed install. A managed
  *     installation exists to guarantee that what runs is what its organization
  *     signed off, which it cannot do for bytes it has no way to verify.
+ *
+ * The two fields are tried in order, so a malformed `blake3` alongside a valid
+ * `sha256` verifies under SHA-256 rather than failing: verification still
+ * happens byte-for-byte, and anyone able to corrupt one manifest field can
+ * corrupt the other, so refusing would cost availability and buy nothing.
  */
 import fs from 'fs'
 import path from 'path'
@@ -370,10 +376,16 @@ export async function stageModels(opts: StageModelsOptions): Promise<void> {
     }
     const ledgerDigest = digest?.algo === 'blake3' ? digestKey(digest) : undefined
     if (ledgerDigest && approvedModelDigests?.has(ledgerDigest)) {
-      ledgerEntries.push(await createModelLedgerEntry(dest, ledgerDigest))
+      // The job's own `savePath`, never a recomputed one: the download manager
+      // strips query params from the filename, so a recomputed path can name a
+      // file that was never written and fail the ledger's realpath outright.
+      ledgerEntries.push(await createModelLedgerEntry(outcome.savePath ?? dest, ledgerDigest))
     }
     onProgress?.({ index, total, filename: model.filename, percent: 100 })
   }
 
-  if (ledgerEntries.length > 0) await writeModelLedger(installPath, ledgerEntries)
+  // Written whenever the model form is active, INCLUDING with no entries: a
+  // run that approves nothing must supersede a ledger left by an earlier
+  // policy, not leave it standing as though it still described this install.
+  if (modelGovernanceActive) await writeModelLedger(installPath, ledgerEntries)
 }

--- a/src/main/comfybuilder/models.ts
+++ b/src/main/comfybuilder/models.ts
@@ -79,7 +79,12 @@ export interface StageModelsOptions {
   installPath: string
   /** Install record id, so jobs are attributed to this install. */
   installationId?: string | null
-  governance?: GovernanceMarker | null
+  /** The install record's governance marker, AS STORED. Deliberately untyped:
+   *  it is validated here by {@link readGovernanceMarker}, and a caller that
+   *  narrowed it first would have to collapse "present but unparseable" into
+   *  "absent", which is precisely the distinction the integrity rule below
+   *  depends on. */
+  governance?: unknown
   jobs: ModelJobSurface
   onProgress?: (p: StageProgress) => void
   signal?: AbortSignal

--- a/src/main/comfybuilder/types.ts
+++ b/src/main/comfybuilder/types.ts
@@ -99,8 +99,14 @@ export interface InstallProgress {
 export interface ModelDescriptor {
   type: string
   filename: string
-  /** Hex sha256 of the content. Verified during installation when provided. */
+  /** Hex sha256 of the content. Verified during installation when provided.
+   *  Manifests sealed before BLAKE3 sealing carry ONLY this, are never re-cut
+   *  and are never backfilled, so it stays a fully supported verification
+   *  input. */
   sha256?: string
+  /** Hex BLAKE3 of the content when the distribution was sealed with one.
+   *  Preferred over `sha256` when both are present. */
+  blake3?: string
   downloadUrl: string
   /** When `downloadUrl` expires (presigned URLs only). Advisory. */
   expiresAt?: string

--- a/src/main/lib/comfyDownloadManager.ts
+++ b/src/main/lib/comfyDownloadManager.ts
@@ -17,13 +17,16 @@ import {
   regularFileExists,
   resolveDownloadContextById
 } from './modelDownloadPaths'
+import { coerceDigest, digestsEqual, makeDigest, type Digest } from '../comfybuilder/integrity'
 import {
+  digestFile,
   ensureStagedPlaceholder,
   migrateLegacyModelDownloadArtifacts,
   removeStagedArtifacts,
   revalidateStagedPair,
   scanForStagedDownloads,
-  sha256File,
+  stagedMetaDigest,
+  stagedMetaDigestFields,
   type DiscoveredStagedDownload
 } from './modelDownloadStaging'
 import { startModelTransfer, type ModelTransferHandle } from './modelDownloadTransport'
@@ -165,9 +168,9 @@ interface PendingDownload {
   leases?: Set<string>
   installationId?: string | null
   expectedSize?: number
-  /** Expected lowercase-hex sha256 of the complete file; the transport
+  /** Expected algorithm-tagged digest of the complete file; the transport
    *  verifies staged bytes against it before finalizing. */
-  sha256?: string
+  digest?: Digest
   /** Explicit session for headless callers (template task). Falls back to
    *  senderContents.session, then the install's partition, then default. */
   explicitSession?: Electron.Session
@@ -234,9 +237,9 @@ function findActiveByRef(ref: string): PendingDownload | undefined {
 
 /** Machine-readable cause for callers that must distinguish integrity
  *  failures from transport failures (e.g. ComfyBuilder model staging):
- *  `checksum-mismatch` means the downloaded bytes failed sha256 verification;
+ *  `checksum-mismatch` means the downloaded bytes failed digest verification;
  *  `existing-file-mismatch` means a file already at the destination does not
- *  match the expected sha256. */
+ *  match the expected digest. */
 export type ModelJobErrorCode = 'checksum-mismatch' | 'existing-file-mismatch'
 
 /** Terminal outcome of a managed model job. `paused` is deliberately absent:
@@ -339,7 +342,7 @@ export function acquireModelDownloadRootLock(modelsRoot: string): (() => void) |
  * rows hydrated from a previous run or left parked by a released caller.
  * Their rows leave the Downloads surfaces and their completion settles as
  * cancelled, but the staged bytes + sidecar STAY on disk, so a new job for
- * the same content (matched by persisted sha256 or URL) resumes them.
+ * the same content (matched by persisted digest or URL) resumes them.
  *
  * For ComfyBuilder installs/updates: a parked row inside the install's model
  * root would otherwise permanently block `acquireModelDownloadRootLock`, and
@@ -423,8 +426,9 @@ interface RetryParams {
    *  Retry dedupe compares canonical destinations, never URL + directory -
    *  two installs can share both while writing different files. */
   savePath?: string
-  /** Model jobs: expected sha256, so a retry keeps verifying integrity. */
-  sha256?: string
+  /** Model jobs: the expected algorithm-tagged digest, so a retry keeps
+   *  verifying integrity under the SAME algorithm the original attempt used. */
+  digest?: Digest
   /** Model jobs: explicit destination root of the original attempt, so a
    *  retry resolves the same final path. */
   destinationBaseDir?: string
@@ -823,10 +827,14 @@ export interface ModelJobOptions {
   session?: Electron.Session
   /** Caller-known expected byte count, validated against the server. */
   expectedSize?: number
-  /** Expected lowercase-hex sha256 of the complete file. When set, the staged
-   *  bytes are verified before finalization (mismatch -> error with code
-   *  'checksum-mismatch'), and a file already at the destination must match
-   *  it to count as already present (mismatch -> 'existing-file-mismatch'). */
+  /** Expected ALGORITHM-TAGGED digest of the complete file. When set, the
+   *  staged bytes are verified before finalization (mismatch -> error with
+   *  code 'checksum-mismatch'), and a file already at the destination must
+   *  match it to count as already present (-> 'existing-file-mismatch'). */
+  digest?: Digest
+  /** Legacy bare sha256 for callers that predate algorithm tagging (the
+   *  in-Comfy bridge). Tagged as `sha256` on entry; `digest` wins when both
+   *  are supplied. */
   sha256?: string
   /** Explicit models root the file must land under, bypassing the install's
    *  model-settings resolution (ComfyBuilder staging always targets the
@@ -1044,7 +1052,7 @@ async function runModelTransport(pending: PendingDownload): Promise<void> {
     installationId: pending.installationId,
     session: sess,
     expectedSize: pending.expectedSize,
-    sha256: pending.sha256,
+    digest: pending.digest,
     onProgress: ({ receivedBytes, totalBytes }) => {
       if (gen !== pending.attemptGen) return
       if (pending.progressSubscribers) {
@@ -1147,7 +1155,15 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
   const url = opts.url
   const filename = stripQueryParams(opts.filename)
   const directory = opts.directory
-  const sha256 = opts.sha256?.trim().toLowerCase()
+  // A caller supplying only the legacy bare hex is tagged `sha256` here, so
+  // everything downstream compares algorithm-tagged identities exclusively.
+  const digest = coerceDigest(opts.digest) ?? makeDigest(opts.sha256, 'sha256')
+  // A caller that DECLARED an expectation which does not parse is refused
+  // rather than downgraded to "no expectation": silently dropping it would
+  // skip both the already-present check and final verification, finalizing
+  // unverified bytes under a final model name.
+  const declaredIntegrity = opts.digest !== undefined || opts.sha256 !== undefined
+  const integrityUnusable = declaredIntegrity && digest === null
   // Resolve the initiating install so destination + existence check follow its
   // model settings. An explicit `installationId` (from retries / templates)
   // wins over the live sender so a retry still targets the right install
@@ -1163,18 +1179,20 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
 
   // Capture before the validation early-returns so even a synchronous
   // error (bad path / extension) lands a retryable terminal entry.
-  retryParamsById.set(id, {
-    kind: 'model',
-    url,
-    filename,
-    directory,
-    window: opts.window,
-    senderContents: opts.senderContents,
-    installationId: resolvedInstallId,
-    savePath,
-    sha256,
-    destinationBaseDir: opts.destinationBaseDir
-  })
+  if (!integrityUnusable) {
+    retryParamsById.set(id, {
+      kind: 'model',
+      url,
+      filename,
+      directory,
+      window: opts.window,
+      senderContents: opts.senderContents,
+      installationId: resolvedInstallId,
+      savePath,
+      digest: digest ?? undefined,
+      destinationBaseDir: opts.destinationBaseDir
+    })
+  }
 
   const makeProgress = (
     overrides: Partial<DownloadProgress>
@@ -1206,6 +1224,12 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
 
   if (!hasValidExtension(filename)) {
     const error = `Invalid file type. Allowed: ${ALLOWED_EXTENSIONS.join(', ')}`
+    reportProgress(makeProgress({ status: 'error', error }))
+    return settledJobHandle(id, url, savePath, { status: 'error', error })
+  }
+
+  if (integrityUnusable) {
+    const error = 'Invalid integrity value: expected a 32-byte hex digest'
     reportProgress(makeProgress({ status: 'error', error }))
     return settledJobHandle(id, url, savePath, { status: 'error', error })
   }
@@ -1257,19 +1281,19 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
     if (await regularFileExists(candidate)) {
       const lockedBeforeExistingResult = rejectLockedRoot(candidate)
       if (lockedBeforeExistingResult) return lockedBeforeExistingResult
-      if (sha256) {
+      if (digest) {
         // An integrity-checked caller can only accept an existing file that
         // IS the expected content; anything else at the destination is a
         // conflict the caller must resolve, not a completed download.
-        let actual: string
+        let actual: Digest
         try {
-          actual = await sha256File(candidate)
+          actual = await digestFile(candidate, digest.algo)
         } catch (err) {
           const error = `Cannot verify existing file: ${(err as Error).message}`
           reportProgress(makeProgress({ status: 'error', error }))
           return settledJobHandle(id, url, savePath, { status: 'error', error })
         }
-        if (actual !== sha256) {
+        if (!digestsEqual(actual, digest)) {
           const error = `Existing file ${filename} does not match the expected checksum`
           reportProgress(makeProgress({ status: 'error', error }))
           return settledJobHandle(id, url, savePath, {
@@ -1317,17 +1341,18 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
     if (active) {
       // Joining is only safe when the caller wants the same bytes: the same
       // source URL and (when both sides declare one) the same expected size
-      // and hash. A caller that REQUIRES integrity verification can also
-      // never join a job that does not verify - the guarantee would silently
-      // vanish. A different source aimed at the same final file is a
-      // conflict, not a join - silently attaching would hand the caller
-      // another URL's file.
+      // and digest. Digests are compared by `digestKey`, so the same hex
+      // under a different algorithm is a conflict, not a join. A caller that
+      // REQUIRES integrity verification can also never join a job that does
+      // not verify - the guarantee would silently vanish. A different source
+      // aimed at the same final file is a conflict, not a join - silently
+      // attaching would hand the caller another URL's file.
       if (
         active.url !== url ||
         (opts.expectedSize !== undefined &&
           active.expectedSize !== undefined &&
           opts.expectedSize !== active.expectedSize) ||
-        (sha256 !== undefined && active.sha256 !== sha256)
+        (digest !== null && !digestsEqual(active.digest, digest))
       ) {
         const error = `Another download is already writing ${filename} from a different source`
         reportProgress(makeProgress({ status: 'error', error }))
@@ -1362,7 +1387,7 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
     suspended: false,
     installationId: resolvedInstallId,
     expectedSize: opts.expectedSize,
-    sha256,
+    digest: digest ?? undefined,
     explicitSession: opts.session,
     progressSubscribers: opts.onProgress ? new Set([opts.onProgress]) : undefined,
     settleJob,
@@ -1427,7 +1452,7 @@ export async function startManagedModelJob(opts: ModelJobOptions): Promise<Model
       directory,
       filename,
       installationId: resolvedInstallId ?? undefined,
-      sha256
+      ...stagedMetaDigestFields(digest)
     })
     pending.starting = false
     if (!staged) {
@@ -2111,7 +2136,7 @@ export function retryDownload(ref: string): boolean {
       window: win ?? undefined,
       senderContents: sender,
       installationId: params.installationId,
-      sha256: params.sha256,
+      digest: params.digest,
       destinationBaseDir: params.destinationBaseDir
     })
   }
@@ -2559,7 +2584,7 @@ async function doInitializeModelDownloads(): Promise<ModelDownloadStartupSafety>
       suspended: true,
       installationId: meta.installationId ?? null,
       expectedSize: meta.expectedSize > 0 ? meta.expectedSize : undefined,
-      sha256: meta.sha256,
+      digest: stagedMetaDigest(meta) ?? undefined,
       settleJob,
       completion,
       lastProgress: progress,
@@ -2575,7 +2600,7 @@ async function doInitializeModelDownloads(): Promise<ModelDownloadStartupSafety>
       directory: meta.directory,
       installationId: meta.installationId ?? null,
       savePath: finalPath,
-      sha256: meta.sha256,
+      digest: stagedMetaDigest(meta) ?? undefined,
       // Pin the retry to the root this pair was staged under; resolving the
       // current install/shared settings could pick a different root.
       destinationBaseDir: deriveDestinationBaseDir(finalPath, meta.directory)

--- a/src/main/lib/comfyDownloadManagerModelJobs.test.ts
+++ b/src/main/lib/comfyDownloadManagerModelJobs.test.ts
@@ -41,7 +41,7 @@ interface FakeTransfer {
     directory: string
     filename: string
     session?: unknown
-    sha256?: string
+    digest?: Digest
     onProgress?: (p: { receivedBytes: number; totalBytes: number }) => void
   }
   resolve: (outcome: Record<string, unknown>) => void
@@ -108,14 +108,18 @@ const revalidateStagedPair = vi.fn((finalPath: string) => {
   }
   return null
 })
-vi.mock('./modelDownloadStaging', () => ({
-  removeStagedArtifacts: (p: string) => removeStagedArtifacts(p),
-  ensureStagedPlaceholder: (p: string, meta: unknown) => ensureStagedPlaceholder(p, meta),
-  scanForStagedDownloads: (roots: string[]) => scanForStagedDownloads(roots),
-  migrateLegacyModelDownloadArtifacts: (roots: string[]) =>
-    migrateLegacyModelDownloadArtifacts(roots),
-  revalidateStagedPair: (finalPath: string) => revalidateStagedPair(finalPath)
-}))
+vi.mock('./modelDownloadStaging', async (importOriginal) => {
+  const actual = await importOriginal<typeof ModelDownloadStagingModule>()
+  return {
+    ...actual,
+    removeStagedArtifacts: (p: string) => removeStagedArtifacts(p),
+    ensureStagedPlaceholder: (p: string, meta: unknown) => ensureStagedPlaceholder(p, meta),
+    scanForStagedDownloads: (roots: string[]) => scanForStagedDownloads(roots),
+    migrateLegacyModelDownloadArtifacts: (roots: string[]) =>
+      migrateLegacyModelDownloadArtifacts(roots),
+    revalidateStagedPair: (finalPath: string) => revalidateStagedPair(finalPath)
+  }
+})
 
 // Targeted overrides for otherwise-real modules: a test flips one on, runs,
 // and restores null so every other test keeps the real behavior.
@@ -150,6 +154,8 @@ vi.mock('./modelDownloadPaths', async (importOriginal) => {
 import type * as ComfyDownloadManager from './comfyDownloadManager'
 import type * as InstallationsModule from '../installations'
 import type * as ModelDownloadPathsModule from './modelDownloadPaths'
+import type * as ModelDownloadStagingModule from './modelDownloadStaging'
+import type { Digest } from '../comfybuilder/integrity'
 import { getModelsBaseDir } from './modelDownloadPaths'
 import { _registerExtraBroadcastTarget, _unregisterExtraBroadcastTarget } from './ipc/broadcast'
 
@@ -1993,6 +1999,20 @@ describe('sha-256 expectations and install-local roots', () => {
     return { installRoot, modelsRoot: path.join(installRoot, 'ComfyUI', 'models') }
   }
 
+  it('does not let retry drop a malformed integrity expectation', async () => {
+    const before = transfers.length
+    const h = await mod.startManagedModelJob({
+      url: `https://host.example/${uniqueName()}`,
+      filename: uniqueName(),
+      directory: 'checkpoints',
+      digest: { algo: 'blake3', value: 'not-a-digest' } as unknown as Digest
+    })
+
+    await expect(h.completion).resolves.toMatchObject({ status: 'error' })
+    expect(mod.retryDownload(h.id)).toBe(false)
+    expect(transfers).toHaveLength(before)
+  })
+
   it('passes the expected hash to the transport and keeps it across a retry', async () => {
     const name = uniqueName()
     const url = `https://host.example/${name}`
@@ -2004,7 +2024,7 @@ describe('sha-256 expectations and install-local roots', () => {
       sha256: SHA_A
     })
     await waitForTransfers(before + 1)
-    expect(transfers[before]!.opts.sha256).toBe(SHA_A)
+    expect(transfers[before]!.opts.digest).toEqual({ algo: 'sha256', value: SHA_A })
     transfers[before]!.resolve({ outcome: 'error', error: 'network gone' })
     await expect(h.completion).resolves.toMatchObject({ status: 'error' })
     await flush()
@@ -2012,7 +2032,7 @@ describe('sha-256 expectations and install-local roots', () => {
     expect(mod.retryDownload(h.id)).toBe(true)
     await waitForTransfers(before + 2)
     // The retry is a fresh job, but the integrity expectation must survive it.
-    expect(transfers[before + 1]!.opts.sha256).toBe(SHA_A)
+    expect(transfers[before + 1]!.opts.digest).toEqual({ algo: 'sha256', value: SHA_A })
     expect(mod.cancelModelDownload(transfers[before + 1]!.opts.jobId as string)).toBe(true)
     await flush()
   })
@@ -2218,7 +2238,7 @@ describe('sha-256 expectations and install-local roots', () => {
       expect(mod.resumeModelDownload(row.id!)).toBe(true)
       await waitForTransfers(before + 1)
       expect(transfers[before]!.opts.finalPath).toBe(dest)
-      expect(transfers[before]!.opts.sha256).toBe(SHA_A)
+      expect(transfers[before]!.opts.digest).toEqual({ algo: 'sha256', value: SHA_A })
       transfers[before]!.resolve({ outcome: 'error', error: 'presigned url expired' })
       await flush()
 
@@ -2228,7 +2248,7 @@ describe('sha-256 expectations and install-local roots', () => {
       expect(mod.retryDownload(row.id!)).toBe(true)
       await waitForTransfers(before + 1)
       expect(transfers[before]!.opts.finalPath).toBe(dest)
-      expect(transfers[before]!.opts.sha256).toBe(SHA_A)
+      expect(transfers[before]!.opts.digest).toEqual({ algo: 'sha256', value: SHA_A })
 
       expect(mod.cancelModelDownload(transfers[before]!.opts.jobId as string)).toBe(true)
       await flush()

--- a/src/main/lib/ipc/sessionActions/launch.governance.test.ts
+++ b/src/main/lib/ipc/sessionActions/launch.governance.test.ts
@@ -1,0 +1,268 @@
+// @vitest-environment node
+import { EventEmitter } from 'node:events'
+import { generateKeyPairSync, sign as signBytes } from 'node:crypto'
+import type { KeyObject } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { root, priorXdgDataHome } = await vi.hoisted(async () => {
+  const { mkdtempSync } = await import('node:fs')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  const root = mkdtempSync(join(tmpdir(), 'launch-governance-'))
+  const priorXdgDataHome = process.env.XDG_DATA_HOME
+  process.env.XDG_DATA_HOME = join(root, 'xdg-data')
+  return { root, priorXdgDataHome }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => path.join(root, 'userData'),
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en'
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+  dialog: {},
+  shell: {},
+  WebContentsView: class {},
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeTheme: { on: vi.fn(), shouldUseDarkColors: false }
+}))
+
+// Only the spawn is replaced; the rest of the launch pipeline stays real so
+// "did not launch" is observed at the actual process boundary rather than at a
+// stub standing in for it.
+const spawned = vi.hoisted(() => ({ spawnProcess: vi.fn() }))
+vi.mock('../../process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ProcessModule>()
+  return { ...actual, spawnProcess: spawned.spawnProcess }
+})
+
+import { handleLaunch } from './launch'
+import type * as ProcessModule from '../../process'
+import type { ActionContext } from './types'
+import { sourceMap, _removeSession, _runningSessions } from '../shared'
+import type { ChildProcess, InstallationRecord } from '../shared'
+import type { LaunchCommand, SourcePlugin } from '../../../types/sources'
+import { GOVERNANCE_MARKER_FIELD, governancePolicyPath } from '../../../comfybuilder/governance'
+
+const DOMAIN_SEPARATOR = Buffer.from('comfyui-governance-v1\0', 'utf-8')
+const BUILD_IDENTITY = 'build-1|release-1|artifact-1|linux/nvidia/cu124|sha256:feed'
+const SOURCE_ID = 'governance-test-source'
+
+interface Signer {
+  readonly publicKey: string
+  readonly privateKey: KeyObject
+}
+
+function makeSigner(): Signer {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const raw = Buffer.from(publicKey.export({ format: 'der', type: 'spki' }).subarray(12))
+  return { publicKey: raw.toString('base64url'), privateKey }
+}
+
+function makeEnvelope(signer: Signer): string {
+  const payloadBytes = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      audience: 'comfyui-core',
+      versionId: 'v1',
+      buildIdentity: BUILD_IDENTITY,
+      sourcesDigest: `sha256:${'a'.repeat(64)}`,
+      policyGeneration: 1,
+      activeForms: ['customNode'],
+      customNodeMode: 'allowlist',
+      packs: [],
+      deniedPacks: [],
+      disabledNodes: [],
+      disabledPartnerNodes: [],
+      models: []
+    }),
+    'utf-8'
+  )
+  const signature = signBytes(
+    null,
+    Buffer.concat([DOMAIN_SEPARATOR, payloadBytes]),
+    signer.privateKey
+  )
+  return JSON.stringify({
+    schema: 1,
+    payload: payloadBytes.toString('base64url'),
+    signature: signature.toString('base64url')
+  })
+}
+
+function fakeChildProcess(): ChildProcess {
+  const proc = new EventEmitter() as unknown as Record<string, unknown>
+  proc.stdout = new EventEmitter()
+  proc.stderr = new EventEmitter()
+  proc.pid = 4242
+  return proc as unknown as ChildProcess
+}
+
+let counter = 0
+const launched: string[] = []
+
+/** A minimal launchable install: a real directory, an executable that exists,
+ *  and `skipPortWait` so the happy path reaches an actual spawn. */
+function makeInstall(overrides: Record<string, unknown> = {}): InstallationRecord {
+  const id = `gov-inst-${++counter}`
+  const installPath = path.join(root, id)
+  fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+  launched.push(id)
+  return {
+    id,
+    name: `Governed ${id}`,
+    installPath,
+    sourceId: SOURCE_ID,
+    status: 'installed',
+    ...overrides
+  } as InstallationRecord
+}
+
+function governedRecord(
+  signer: Signer,
+  overrides: Record<string, unknown> = {}
+): InstallationRecord {
+  return makeInstall({
+    [GOVERNANCE_MARKER_FIELD]: {
+      governanceMarkerVersion: 1,
+      governed: true,
+      expectedBuildIdentity: BUILD_IDENTITY,
+      publicKey: signer.publicKey,
+      activeForms: ['customNode'],
+      customNodeMode: 'allowlist',
+      ...(overrides[GOVERNANCE_MARKER_FIELD] as object | undefined)
+    },
+    ...overrides
+  })
+}
+
+function writePolicy(inst: InstallationRecord, envelope: string): void {
+  const policy = governancePolicyPath(inst.installPath)
+  fs.mkdirSync(path.dirname(policy), { recursive: true })
+  fs.writeFileSync(policy, envelope)
+}
+
+function ctxFor(inst: InstallationRecord): ActionContext {
+  return {
+    event: {
+      sender: { send: vi.fn(), isDestroyed: () => false }
+    } as unknown as Electron.IpcMainInvokeEvent,
+    installationId: inst.id,
+    inst,
+    actionData: {}
+  }
+}
+
+beforeEach(() => {
+  spawned.spawnProcess.mockImplementation(() => fakeChildProcess())
+  sourceMap[SOURCE_ID] = {
+    id: SOURCE_ID,
+    category: 'local',
+    getLaunchCommand: (inst: InstallationRecord): LaunchCommand =>
+      ({
+        // `process.execPath` always exists, so the executable-existence gate
+        // after this check cannot mask a governance pass as a refusal.
+        cmd: process.execPath,
+        args: ['--version'],
+        cwd: inst.installPath,
+        skipPortWait: true
+      }) as unknown as LaunchCommand
+  } as unknown as SourcePlugin
+})
+
+afterEach(() => {
+  for (const id of launched) {
+    if (_runningSessions.has(id)) _removeSession(id)
+  }
+  launched.length = 0
+  delete sourceMap[SOURCE_ID]
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  if (priorXdgDataHome === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = priorXdgDataHome
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('governed pre-launch policy check', () => {
+  it('lets a governed install with a valid envelope launch', async () => {
+    const signer = makeSigner()
+    const inst = governedRecord(signer)
+    writePolicy(inst, makeEnvelope(signer))
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    expect(result.ok).toBe(true)
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses and never spawns when the envelope was deleted', async () => {
+    const signer = makeSigner()
+    const inst = governedRecord(signer)
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    // "Did not launch" is the invariant; assert it FIRST so the test cannot
+    // pass on message text alone if the refusal ever stops short-circuiting.
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(0)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('managed ComfyUI installation')
+    expect(result.message).toContain('contact your administrator')
+  })
+
+  it('refuses and never spawns when one signature byte is flipped', async () => {
+    const signer = makeSigner()
+    const inst = governedRecord(signer)
+    const parsed = JSON.parse(makeEnvelope(signer)) as Record<string, string>
+    const signature = Buffer.from(parsed.signature!, 'base64url')
+    signature[3] = signature[3]! ^ 0x01
+    writePolicy(inst, JSON.stringify({ ...parsed, signature: signature.toString('base64url') }))
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(0)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('managed ComfyUI installation')
+  })
+
+  it('refuses and never spawns when the marker itself is truncated', async () => {
+    const signer = makeSigner()
+    const inst = makeInstall({
+      [GOVERNANCE_MARKER_FIELD]: { governanceMarkerVersion: 1, governed: true }
+    })
+    writePolicy(inst, makeEnvelope(signer))
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(0)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('managed ComfyUI installation')
+  })
+
+  it('is a no-op for a non-governed install, which launches normally', async () => {
+    const inst = makeInstall()
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    expect(result.ok).toBe(true)
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not block a non-governed install whose tree happens to hold a policy file', async () => {
+    // Presence must select nothing: only the durable marker decides.
+    const signer = makeSigner()
+    const inst = makeInstall()
+    writePolicy(inst, 'not even valid json')
+
+    const result = await handleLaunch(ctxFor(inst))
+
+    expect(result.ok).toBe(true)
+    expect(spawned.spawnProcess).toHaveBeenCalledTimes(1)
+    expect(signer.publicKey).toBeTruthy()
+  })
+})

--- a/src/main/lib/ipc/sessionActions/launch.ts
+++ b/src/main/lib/ipc/sessionActions/launch.ts
@@ -89,6 +89,7 @@ import {
 } from '../../bootPhaseBuffer'
 import { appendLog } from '../../logsBroadcast'
 import { reconcileManagerConfigForLaunch } from '../../managerConfigLaunch'
+import { checkGovernedInstallPolicy } from '../../../comfybuilder/governance'
 import { recoverInterruptedComfyOp } from '../../opMarker'
 import { waitLaunchSpawnHold } from '../../e2eOverrides'
 import { migrateEnvLayout } from '../../../sources/standalone/install'
@@ -390,6 +391,23 @@ async function runLaunch(
     console.warn('Model download startup pass failed; launching anyway:', err)
   }
   if (abort.signal.aborted) return { ok: false, cancelled: true }
+
+  // Governed installs: refuse rather than spawn when the signed organization
+  // policy is missing or fails verification. A SECOND LAYER only - ComfyUI
+  // self-enforces from its compiled-in constant whatever happens here, so a
+  // pass enables nothing and merely declines to interrupt. Non-governed
+  // installs are a no-op.
+  //
+  // Deliberately the FIRST thing after the abort check and ahead of ALL of:
+  // background model re-staging (which resolves a manifest and can start
+  // multi-gigabyte downloads), arg-schema and feature-flag discovery (which
+  // each execute the install's own Python), and Manager config reconciliation
+  // (which writes to disk). A refusal has to mean nothing in the install ran.
+  const governance = await checkGovernedInstallPolicy(inst)
+  if (!governance.ok) {
+    return { ok: false, message: governance.message }
+  }
+
   const source = sourceMap[inst.sourceId]
   if (!source) return { ok: false, message: i18n.t('errors.unknownSource') }
   if (!source.skipInstall) {

--- a/src/main/lib/modelDownloadStaging.test.ts
+++ b/src/main/lib/modelDownloadStaging.test.ts
@@ -593,7 +593,11 @@ describe('ensureStagedPlaceholder', () => {
 
     const sha256 = 'a'.repeat(64)
     expect(ensureStagedPlaceholder(finalPath, validMeta({ expectedSize: 0, sha256 }))).toBe(true)
-    expect(readStagedMeta(stagingMetaPathFor(finalPath))).toEqual({ ...existing, sha256 })
+    expect(readStagedMeta(stagingMetaPathFor(finalPath))).toEqual({
+      ...existing,
+      sha256,
+      digest: { algo: 'sha256', value: sha256 }
+    })
     expect(fs.readFileSync(stagingPathFor(finalPath), 'utf-8')).toBe('staged-bytes')
   })
 
@@ -605,7 +609,11 @@ describe('ensureStagedPlaceholder', () => {
 
     const sha256 = 'a'.repeat(64)
     expect(ensureStagedPlaceholder(finalPath, validMeta({ sha256 }))).toBe(true)
-    expect(readStagedMeta(stagingMetaPathFor(finalPath))).toEqual({ ...existing, sha256 })
+    expect(readStagedMeta(stagingMetaPathFor(finalPath))).toEqual({
+      ...existing,
+      sha256,
+      digest: { algo: 'sha256', value: sha256 }
+    })
   })
 
   it('keeps a persisted hash when the new caller has none', () => {

--- a/src/main/lib/modelDownloadStaging.ts
+++ b/src/main/lib/modelDownloadStaging.ts
@@ -1,6 +1,14 @@
+import { blake3 } from '@noble/hashes/blake3.js'
 import { createHash } from 'crypto'
 import fs from 'fs'
 import path from 'path'
+import {
+  coerceDigest,
+  digestsEqual,
+  makeDigest,
+  type Digest,
+  type DigestAlgorithm
+} from '../comfybuilder/integrity'
 import { ALLOWED_EXTENSIONS } from './downloadFilename'
 
 /**
@@ -49,10 +57,67 @@ export interface StagedDownloadMeta {
   filename: string
   /** Install that initiated the download, when known. */
   installationId?: string | null
-  /** Expected lowercase-hex sha256 of the complete file. When present, the
-   *  transport verifies the staged bytes against it before finalizing, and a
-   *  restart-hydrated job keeps verifying without the original caller. */
+  /** LEGACY expected lowercase-hex sha256, written by builds that predate
+   *  algorithm tagging. Still READ (a sidecar staged by an older build must
+   *  stay resumable) and still WRITTEN alongside `digest` whenever the
+   *  expectation is sha256, so downgrading to such a build keeps verifying. */
   sha256?: string
+  /** Expected ALGORITHM-TAGGED digest of the complete file. When present the
+   *  transport verifies the staged bytes against it before finalizing, and a
+   *  restart-hydrated job keeps verifying without the original caller. The
+   *  algorithm is persisted, not inferred: staged bytes expected to hash to a
+   *  given hex under BLAKE3 must never be resumed for a job expecting the
+   *  same hex under SHA-256. */
+  digest?: Digest
+}
+
+/**
+ * What a staged pair's sidecar says about the content it expects.
+ *
+ * `invalid` is deliberately NOT collapsed into `none`. A sidecar that carries
+ * an integrity field which does not parse describes bytes nothing can vouch
+ * for; reading that as "no expectation" would finalize an unverified file
+ * under its final model name. `none` - no integrity field at all - is the only
+ * state that legitimately finalizes without a hash.
+ */
+export type StagedMetaDigestState =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'valid'; readonly digest: Digest }
+  | { readonly kind: 'invalid' }
+
+export function stagedMetaDigestState(
+  meta: Pick<StagedDownloadMeta, 'digest' | 'sha256'> | null | undefined
+): StagedMetaDigestState {
+  if (!meta) return { kind: 'none' }
+  const digest = coerceDigest(meta.digest) ?? makeDigest(meta.sha256, 'sha256')
+  if (digest) return { kind: 'valid', digest }
+  const declared = meta.digest !== undefined || meta.sha256 !== undefined
+  return declared ? { kind: 'invalid' } : { kind: 'none' }
+}
+
+/** The digest a staged pair is verified against: the tagged field when the
+ *  sidecar has one, else the legacy bare `sha256` an older build persisted.
+ *  Returns null for BOTH "no expectation" and "unparseable expectation", so a
+ *  caller that must fail closed on the latter uses
+ *  {@link stagedMetaDigestState} instead. */
+export function stagedMetaDigest(
+  meta: Pick<StagedDownloadMeta, 'digest' | 'sha256'> | null | undefined
+): Digest | null {
+  const state = stagedMetaDigestState(meta)
+  return state.kind === 'valid' ? state.digest : null
+}
+
+/** The sidecar fields carrying `digest`. `sha256` is mirrored only for a
+ *  sha256 expectation, so an older build reading this sidecar still verifies
+ *  rather than finalizing unverified bytes; a blake3 expectation deliberately
+ *  leaves it unset, because an older build must not verify a BLAKE3 hex as
+ *  though it were sha256. */
+export function stagedMetaDigestFields(
+  digest: Digest | null | undefined
+): Pick<StagedDownloadMeta, 'digest' | 'sha256'> {
+  const tagged = coerceDigest(digest)
+  if (!tagged) return {}
+  return { digest: tagged, ...(tagged.algo === 'sha256' ? { sha256: tagged.value } : {}) }
 }
 
 export function stagingPathFor(finalPath: string): string {
@@ -257,29 +322,59 @@ export function quarantineOrphanStagedBytes(finalPath: string): boolean {
   )
 }
 
-/** Streaming lowercase-hex sha256 of a file. Resolves on 'close' (not 'end')
- *  so the fd is released before any following rm/rename, avoiding EBUSY on
- *  Windows - but only when 'end' fired first, so an early destroy can never
- *  yield a digest of a partial read. Shared by the model transport and
- *  ComfyBuilder archive install. */
-export function sha256File(filePath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
+/** Incremental hasher shared by every supported algorithm. `sha256` uses
+ *  Node's OpenSSL binding; `blake3` uses `@noble/hashes`, a dependency-free
+ *  pure-TypeScript implementation, so no native addon has to be rebuilt for
+ *  Electron or unpacked from the asar on any shipped platform. */
+function createDigestHasher(algo: DigestAlgorithm): {
+  update: (chunk: Buffer) => void
+  hex: () => string
+} {
+  if (algo === 'sha256') {
     const hash = createHash('sha256')
+    return { update: (chunk) => void hash.update(chunk), hex: () => hash.digest('hex') }
+  }
+  const hash = blake3.create()
+  return {
+    update: (chunk) => void hash.update(chunk),
+    hex: () => Array.from(hash.digest(), (b) => b.toString(16).padStart(2, '0')).join('')
+  }
+}
+
+/** Streaming lowercase-hex digest of a file under `algo`. Resolves on 'close'
+ *  (not 'end') so the fd is released before any following rm/rename, avoiding
+ *  EBUSY on Windows - but only when 'end' fired first, so an early destroy can
+ *  never yield a digest of a partial read. */
+export function hashFile(filePath: string, algo: DigestAlgorithm): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createDigestHasher(algo)
     const stream = fs.createReadStream(filePath)
     let ended = false
     stream.on('error', reject)
     stream.on('end', () => {
       ended = true
     })
-    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('data', (chunk) => hash.update(chunk as Buffer))
     stream.on('close', () => {
       if (!ended) {
-        reject(new Error(`sha256 read stream closed before end of file: ${filePath}`))
+        reject(new Error(`${algo} read stream closed before end of file: ${filePath}`))
         return
       }
-      resolve(hash.digest('hex'))
+      resolve(hash.hex())
     })
   })
+}
+
+/** The file's actual content as an algorithm-tagged digest, ready to compare
+ *  by `digestKey` against an expectation. */
+export async function digestFile(filePath: string, algo: DigestAlgorithm): Promise<Digest> {
+  return { algo, value: await hashFile(filePath, algo) }
+}
+
+/** Streaming lowercase-hex sha256. Kept for the ComfyBuilder ARCHIVE install,
+ *  whose `archiveSha256` is not algorithm-tagged. */
+export function sha256File(filePath: string): Promise<string> {
+  return hashFile(filePath, 'sha256')
 }
 
 /** Byte-for-byte comparison in 1 MiB chunks, async so a multi-gigabyte model
@@ -368,7 +463,7 @@ export async function installStagedAtFinal(
  *  starts, so a quit/crash in that window cannot lose the job. An existing
  *  sidecar is a previous attempt's resume identity (validators, expected
  *  size) and keeps that identity - only its missing `.part` is restored and,
- *  when the new caller supplies a content hash, the persisted `sha256` is
+ *  when the new caller supplies a content digest, the persisted one is
  *  upgraded to it. The transport rewrites the sidecar only at response time,
  *  so without that upgrade a crash before the first response would hydrate
  *  the pair with the old (possibly absent) hash and let an unverified file
@@ -383,9 +478,14 @@ export function ensureStagedPlaceholder(finalPath: string, meta: StagedDownloadM
   const existing = readStagedMeta(metaPath)
   if (existing !== null) {
     // Persist the caller's content expectation before the job is admitted;
-    // a caller without one never weakens a persisted hash.
-    if (meta.sha256 && existing.sha256 !== meta.sha256) {
-      if (!writeStagedMeta(metaPath, { ...existing, sha256: meta.sha256 })) return false
+    // a caller without one never weakens a persisted digest. Compared by
+    // `digestKey`, so the same hex under a different algorithm still counts
+    // as a change and is written through.
+    const incoming = stagedMetaDigest(meta)
+    if (incoming && !digestsEqual(stagedMetaDigest(existing), incoming)) {
+      if (!writeStagedMeta(metaPath, { ...existing, ...stagedMetaDigestFields(incoming) })) {
+        return false
+      }
     }
     if (fs.existsSync(stagingPath)) return true
     // The pair is only hydratable when both files exist: restore a missing

--- a/src/main/lib/modelDownloadTransport.test.ts
+++ b/src/main/lib/modelDownloadTransport.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Digest } from '../comfybuilder/integrity'
 import { R2_BASE_URL, R2_MIRROR_BASE_URL } from './r2Mirror'
 import {
   readStagedMeta,
@@ -456,6 +457,35 @@ describe('resume', () => {
     expect(fs.readFileSync(finalPath, 'utf-8')).toBe('0123456789')
   })
 
+  // Present-but-garbage integrity must never degrade into "no expectation":
+  // a hydrated job has no caller digest, so the sidecar is the only thing
+  // standing between these bytes and the final model name.
+  it.each([
+    ['a legacy sha256', { sha256: 'not-a-sha256' }],
+    ['a tagged digest', { digest: { algo: 'blake3', value: 'nope' } as unknown as Digest }],
+    [
+      'an unknown algorithm',
+      { digest: { algo: 'md5', value: 'a'.repeat(32) } as unknown as Digest }
+    ]
+  ])('discards staged bytes whose sidecar carries %s that does not parse', async (_name, bad) => {
+    preStage('0123456789', stagedMeta({ expectedSize: 10, ...bad }))
+
+    const handle = startModelTransfer(baseOpts())
+    const outcome = await handle.done
+
+    expect(outcome).toMatchObject({ outcome: 'error', code: 'checksum-mismatch' })
+    expect(fs.existsSync(finalPath)).toBe(false)
+    expect(fs.existsSync(stagingPathFor(finalPath))).toBe(false)
+  })
+
+  it('still finalizes staged bytes whose sidecar declares no integrity at all', async () => {
+    preStage('0123456789', stagedMeta({ expectedSize: 10 }))
+
+    const outcome = await startModelTransfer(baseOpts()).done
+
+    expect(outcome).toEqual({ outcome: 'completed', savePath: finalPath, finalBytes: 10 })
+  })
+
   it('never treats staged bytes EXCEEDING the expected size as complete', async () => {
     preStage('0123456789X', stagedMeta({ expectedSize: 10 }))
     const handle = startModelTransfer(baseOpts())
@@ -650,6 +680,7 @@ describe('resume', () => {
 })
 
 describe('sha-256 integrity', () => {
+  const sha256Digest = (value: string): Digest => ({ algo: 'sha256', value })
   const SHA_0123456789 = '84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882'
   const SHA_AAAAABBBBB = '59158e9f11434e40f5af83230f07877ecf9acd90b9fbeb6002a5e836b6edecee'
 
@@ -660,7 +691,7 @@ describe('sha-256 integrity', () => {
   }
 
   it('persists the expected hash in the sidecar and finalizes when the bytes match', async () => {
-    const handle = startModelTransfer(baseOpts({ sha256: SHA_0123456789 }))
+    const handle = startModelTransfer(baseOpts({ digest: sha256Digest(SHA_0123456789) }))
     const req = requests[0]!
     const res = makeResponse(200, { 'content-length': '10' })
     req.emit('response', res)
@@ -677,7 +708,7 @@ describe('sha-256 integrity', () => {
   })
 
   it('discards staged bytes and reports checksum-mismatch when the download is corrupt', async () => {
-    const handle = startModelTransfer(baseOpts({ sha256: SHA_AAAAABBBBB }))
+    const handle = startModelTransfer(baseOpts({ digest: sha256Digest(SHA_AAAAABBBBB) }))
     const req = requests[0]!
     const res = makeResponse(200, { 'content-length': '10' })
     req.emit('response', res)
@@ -702,7 +733,7 @@ describe('sha-256 integrity', () => {
         etag: '"v1"'
       })
     )
-    const handle = startModelTransfer(baseOpts({ sha256: SHA_AAAAABBBBB }))
+    const handle = startModelTransfer(baseOpts({ digest: sha256Digest(SHA_AAAAABBBBB) }))
     const req = requests[0]!
     const headers = headerCalls(req)
     expect(headers['Range']).toBe('bytes=5-')
@@ -719,7 +750,7 @@ describe('sha-256 integrity', () => {
 
   it('restarts clean when the staged pair was written for different expected content', async () => {
     preStage('AAAAA', stagedMeta({ sha256: SHA_0123456789, expectedSize: 10, etag: '"v1"' }))
-    const handle = startModelTransfer(baseOpts({ sha256: SHA_AAAAABBBBB }))
+    const handle = startModelTransfer(baseOpts({ digest: sha256Digest(SHA_AAAAABBBBB) }))
     const headers = headerCalls(requests[0]!)
     // Splicing onto bytes for other content could only fail verification.
     expect(headers['Range']).toBeUndefined()

--- a/src/main/lib/modelDownloadTransport.ts
+++ b/src/main/lib/modelDownloadTransport.ts
@@ -3,12 +3,16 @@ import fs from 'fs'
 import path from 'path'
 import * as settings from '../settings'
 import { r2MirrorUrl } from './r2Mirror'
+import { digestKey, digestsEqual, type Digest } from '../comfybuilder/integrity'
 import {
+  digestFile,
   installStagedAtFinal,
   quarantineOrphanStagedBytes,
   readStagedMeta,
   removeStagedArtifacts,
-  sha256File,
+  stagedMetaDigest,
+  stagedMetaDigestFields,
+  stagedMetaDigestState,
   stagingMetaPathFor,
   stagingPathFor,
   writeStagedMeta,
@@ -69,10 +73,11 @@ export interface ModelTransferOptions {
   session?: Electron.Session
   /** Caller-known total size; conflicts with the server's length fail fast. */
   expectedSize?: number
-  /** Expected lowercase-hex sha256 of the complete file. When present, the
+  /** Expected ALGORITHM-TAGGED digest of the complete file. When present, the
    *  staged bytes are verified against it before finalization; a mismatch
-   *  discards the staged state and fails with code 'checksum-mismatch'. */
-  sha256?: string
+   *  discards the staged state and fails with code 'checksum-mismatch'. It is
+   *  also half of the resume identity - see `issueAttempt`. */
+  digest?: Digest
   /** Abort when no bytes arrive for this long (ms). */
   idleTimeoutMs?: number
   onProgress?: (p: ModelTransferProgress) => void
@@ -135,7 +140,7 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
     installationId,
     session,
     expectedSize,
-    sha256,
+    digest,
     idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
     onProgress
   } = opts
@@ -253,21 +258,50 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
     let resumeFrom = 0
     let existingMeta: StagedDownloadMeta | null = readStagedMeta(metaPath)
     let resumeValidator: { kind: 'etag' | 'last-modified'; value: string } | null = null
-    if (existingMeta && sha256 && existingMeta.sha256 && existingMeta.sha256 !== sha256) {
+    // RESUME IDENTITY. Both halves below compare `digestKey(...)`, which is
+    // `<algo>:<hex>` - the ALGORITHM IS PART OF THE KEY. Comparing bare hex
+    // here would let a partial file staged under a BLAKE3 expectation be
+    // adopted by a job expecting the very same hex under SHA-256 (and vice
+    // versa): the etag/last-modified validators only prove the SOURCE has not
+    // changed, not that the two callers wanted the same content, so the
+    // splice would produce bytes neither expectation describes.
+    const stagedState = stagedMetaDigestState(existingMeta)
+    const stagedDigest = stagedState.kind === 'valid' ? stagedState.digest : null
+    if (stagedState.kind === 'invalid' && !digest) {
+      // The sidecar DECLARED an expectation that no longer parses, and this
+      // transfer carries none of its own - which is exactly the restart-
+      // hydrated case, where the original caller is gone and the sidecar is
+      // the only surviving expectation. Re-fetching would not help: the fresh
+      // bytes would be just as unverifiable, and would finalize under the
+      // final model name. Fail closed and let the caller re-issue the job
+      // with a real expectation.
+      removeStagedArtifacts(finalPath)
+      settle({
+        outcome: 'error',
+        error: 'Download failed: the staged download has an unreadable integrity record',
+        code: 'checksum-mismatch'
+      })
+      return
+    }
+    const stagedMismatch = Boolean(digest && stagedDigest && !digestsEqual(stagedDigest, digest))
+    if (existingMeta && (stagedMismatch || stagedState.kind === 'invalid')) {
       // The staged pair was written for DIFFERENT expected content (e.g. a
-      // superseded Build version re-using the destination). Splicing
-      // onto those bytes could only ever fail verification - restart clean.
+      // superseded Build version re-using the destination, or the same hex
+      // under another algorithm), or its recorded expectation no longer parses
+      // while this transfer carries one of its own. Splicing onto those bytes
+      // could only ever fail verification - restart clean.
       removeStagedArtifacts(finalPath)
       existingMeta = null
     }
     // Staged bytes are resumable when they are provably for the same content:
-    // the same source URL, or a matching persisted sha256 (presigned URLs
+    // the same source URL, or a matching persisted digest (presigned URLs
     // rotate between attempts while addressing the same object; the recorded
     // etag/last-modified validators still guard the actual splice, and the
-    // final hash verification catches anything they miss).
+    // final digest verification catches anything they miss).
     const stagedContentMatches =
       existingMeta !== null &&
-      (existingMeta.url === url || (sha256 !== undefined && existingMeta.sha256 === sha256))
+      (existingMeta.url === url ||
+        (digestKey(digest) !== undefined && digestsEqual(stagedDigest, digest)))
     if (existingMeta && stagedContentMatches && fs.existsSync(stagingPath)) {
       resumeValidator = resumeValidatorFor(existingMeta)
       if (resumeValidator) {
@@ -341,7 +375,7 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
         directory,
         filename,
         installationId: installationId ?? undefined,
-        sha256: sha256 ?? undefined
+        ...stagedMetaDigestFields(digest)
       })
       if (!durable) {
         failRetaining('Download failed: cannot write staging metadata')
@@ -574,8 +608,8 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
           filename,
           installationId: installationId ?? undefined,
           // Keep a persisted expectation alive across attempts even when a
-          // hydrated resume no longer knows the caller's hash.
-          sha256: sha256 ?? existingMeta?.sha256
+          // hydrated resume no longer knows the caller's digest.
+          ...stagedMetaDigestFields(digest ?? stagedMetaDigest(existingMeta))
         }
         if (!writeStagedMeta(metaPath, meta)) {
           // Accepting body bytes without a durable resume identity would
@@ -694,11 +728,26 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
       // whose caller is gone, from the persisted sidecar. A mismatch is not
       // resumable - the bytes are wrong, not short - so discard the staged
       // state; a retry re-fetches from scratch.
-      const expectedSha256 = sha256 ?? readStagedMeta(metaPath)?.sha256
-      if (expectedSha256) {
-        let actualSha256: string
+      const staged = stagedMetaDigestState(readStagedMeta(metaPath))
+      if (!digest && staged.kind === 'invalid') {
+        // The sidecar DECLARED an expectation that does not parse. There is
+        // nothing left to check these bytes against, and "unverifiable" must
+        // never degrade into "unverified" - discard rather than finalize.
+        removeStagedArtifacts(finalPath)
+        settle({
+          outcome: 'error',
+          error: 'Download corrupt: the staged download has an unreadable integrity record',
+          code: 'checksum-mismatch'
+        })
+        return
+      }
+      const expected = digest ?? (staged.kind === 'valid' ? staged.digest : null)
+      if (expected) {
+        // Hashed under the EXPECTATION's algorithm, so a blake3 manifest is
+        // verified with blake3 and a sha256-only one with sha256.
+        let actual: Digest
         try {
-          actualSha256 = await sha256File(stagingPath)
+          actual = await digestFile(stagingPath, expected.algo)
         } catch (err) {
           settle({
             outcome: 'error',
@@ -706,11 +755,11 @@ export function startModelTransfer(opts: ModelTransferOptions): ModelTransferHan
           })
           return
         }
-        if (actualSha256 !== expectedSha256) {
+        if (!digestsEqual(actual, expected)) {
           removeStagedArtifacts(finalPath)
           settle({
             outcome: 'error',
-            error: `Download corrupt: checksum mismatch: expected ${expectedSha256}, got ${actualSha256}`,
+            error: `Download corrupt: checksum mismatch: expected ${digestKey(expected)}, got ${digestKey(actual)}`,
             code: 'checksum-mismatch'
           })
           return

--- a/src/main/sources/comfybuilder/constants.ts
+++ b/src/main/sources/comfybuilder/constants.ts
@@ -1,5 +1,7 @@
-/** Shared by the plugin and its detail sections; separate module so the two
- *  don't import each other in a cycle. */
+/**
+ * Shared by the plugin and its detail sections; separate module so the two
+ * don't import each other in a cycle.
+ */
 export const DEFAULT_LAUNCH_ARGS = '--enable-manager'
 
 /** Launch settings stamped on every new ComfyBuilder install record. */

--- a/src/main/sources/comfybuilder/governanceMarker.test.ts
+++ b/src/main/sources/comfybuilder/governanceMarker.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment node
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const root = await vi.hoisted(async () => {
+  const { mkdtempSync } = await import('node:fs')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  return mkdtempSync(join(tmpdir(), 'cb-marker-'))
+})
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => path.join(root, 'userData'),
+    getVersion: () => '0.0.0-test',
+    getLocale: () => 'en'
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), off: vi.fn() },
+  dialog: {},
+  shell: {},
+  WebContentsView: class {},
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeTheme: { on: vi.fn(), shouldUseDarkColors: false }
+}))
+
+const lib = vi.hoisted(() => ({
+  installArtifact: vi.fn(),
+  stageModels: vi.fn(async () => {}),
+  resolveModelManifest: vi.fn(async () => ({ models: [] }))
+}))
+vi.mock('../../comfybuilder', async (importOriginal) => {
+  const actual = await importOriginal<typeof ComfyBuilderModule>()
+  return { ...actual, ...lib }
+})
+
+const store = vi.hoisted(() => ({
+  update: vi.fn<(id: string, data: Record<string, unknown>) => Promise<null>>(async () => null)
+}))
+vi.mock('../../installations', () => ({ update: store.update }))
+
+vi.mock('../../devplatform/session', () => ({ getBuilderClient: () => ({}) }))
+
+vi.mock('../../lib/comfyDownloadManager', () => ({
+  releaseParkedModelJobsUnder: vi.fn(),
+  acquireModelDownloadRootLock: vi.fn(() => () => {}),
+  startManagedModelJob: vi.fn(),
+  cancelModelDownload: vi.fn()
+}))
+
+import { comfybuilder } from './index'
+import type * as ComfyBuilderModule from '../../comfybuilder'
+import { GOVERNANCE_MARKER_FIELD } from '../../comfybuilder'
+import type { GovernanceMarker } from '../../comfybuilder'
+import type { InstallationRecord } from '../../installations'
+
+const MARKER: GovernanceMarker = {
+  governanceMarkerVersion: 1,
+  governed: true,
+  expectedBuildIdentity: 'build-1|release-1|artifact-1|linux/cpu/cpu|sha256:beef',
+  publicKey: Buffer.alloc(32, 9).toString('base64url'),
+  activeForms: ['customNode', 'model'],
+  customNodeMode: 'allowlist'
+}
+
+let counter = 0
+
+function makeRecord(): InstallationRecord {
+  const id = `marker-inst-${++counter}`
+  const installPath = path.join(root, id)
+  fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+  return {
+    id,
+    name: id,
+    createdAt: new Date().toISOString(),
+    installPath,
+    sourceId: 'comfybuilder',
+    distributionId: 'dist-1',
+    version: '1',
+    artifactId: 'a1',
+    artifactOs: 'linux',
+    artifactGpu: 'cpu',
+    artifactAccelVariant: 'cpu',
+    artifactSha256: 'a'.repeat(64)
+  } as InstallationRecord
+}
+
+const tools = { sendProgress: vi.fn(), signal: undefined }
+
+/** Stand in for a real extraction: `makeRecord` leaves an existing `ComfyUI/`
+ *  behind, so the install takes the entry-swap path and the swap needs a
+ *  populated staging tree to move into place. */
+function extractInto(installPath: string): void {
+  fs.mkdirSync(path.join(installPath, 'venv'), { recursive: true })
+  fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
+  fs.writeFileSync(path.join(installPath, 'venv', 'pyvenv.cfg'), 'home = /usr')
+  fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), 'code')
+}
+
+beforeEach(() => {
+  lib.installArtifact.mockImplementation(async ({ installPath }: { installPath: string }) => {
+    extractInto(installPath)
+    return { governance: MARKER }
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('comfybuilder install persists the governance marker', () => {
+  it('writes the marker returned by installArtifact in a single record update', async () => {
+    const record = makeRecord()
+
+    await comfybuilder.install!(record, tools as never)
+
+    const markerWrites = store.update.mock.calls.filter(
+      (call) => (call[1] as Record<string, unknown>)[GOVERNANCE_MARKER_FIELD] !== undefined
+    )
+    expect(markerWrites).toHaveLength(1)
+    expect(markerWrites[0]![0]).toBe(record.id)
+    expect(markerWrites[0]![1]).toEqual({ [GOVERNANCE_MARKER_FIELD]: MARKER })
+  })
+
+  it('clears any stale marker when the newly installed archive is not governed', async () => {
+    lib.installArtifact.mockImplementation(async ({ installPath }: { installPath: string }) => {
+      extractInto(installPath)
+      return { governance: null }
+    })
+    const record = makeRecord()
+
+    await comfybuilder.install!(record, tools as never)
+
+    expect(store.update).toHaveBeenCalledWith(record.id, {
+      [GOVERNANCE_MARKER_FIELD]: undefined
+    })
+  })
+
+  it('never writes a marker when the archive install itself fails', async () => {
+    lib.installArtifact.mockRejectedValue(new Error('Artifact checksum mismatch'))
+    const record = makeRecord()
+
+    await expect(comfybuilder.install!(record, tools as never)).rejects.toThrow(/checksum mismatch/)
+
+    expect(store.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('environmentPaths policy location', () => {
+  it('resolves the signed policy under the install ComfyUI tree', async () => {
+    const { GOVERNANCE_POLICY_RELATIVE, governancePolicyPath } = await import('../../comfybuilder')
+    expect(governancePolicyPath(os.tmpdir())).toBe(
+      path.join(os.tmpdir(), GOVERNANCE_POLICY_RELATIVE)
+    )
+    expect(GOVERNANCE_POLICY_RELATIVE).toBe(
+      path.join('ComfyUI', 'governance', 'policy.signed.json')
+    )
+  })
+})

--- a/src/main/sources/comfybuilder/index.test.ts
+++ b/src/main/sources/comfybuilder/index.test.ts
@@ -22,7 +22,7 @@ vi.mock('electron', () => ({
 
 // Stub the library so install() wiring can be asserted without real downloads.
 vi.mock('../../comfybuilder', () => ({
-  installArtifact: vi.fn(async () => {}),
+  installArtifact: vi.fn(async () => ({ governance: null })),
   buildLaunchSpec: vi.fn(() => null),
   venvPython: vi.fn((installPath: string) =>
     process.platform === 'win32'
@@ -36,8 +36,11 @@ vi.mock('../../comfybuilder', () => ({
     models: [],
     modelPolicy: null,
     partnerNodePolicy: null
-  }))
+  })),
+  GOVERNANCE_MARKER_FIELD: 'governance',
+  GOVERNANCE_POLICY_RELATIVE: 'ComfyUI/governance/policy.signed.json'
 }))
+vi.mock('../../installations', () => ({ update: vi.fn(async () => null) }))
 vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
 vi.mock('../../lib/comfyDownloadManager', () => ({
   acquireModelDownloadRootLock,
@@ -198,6 +201,7 @@ describe('comfybuilder.install wiring', () => {
         await fsp.writeFile(path.join(installPath, 'ComfyUI', 'main.py'), 'new code')
         await fsp.writeFile(path.join(installPath, 'ComfyUI', 'models', 'build.bin'), 'debris')
         await fsp.writeFile(path.join(installPath, 'ComfyUI', 'user', 'build.json'), 'debris')
+        return { governance: null }
       })
 
       await comfybuilder.install!(record({ installPath: root }), fakeTools())
@@ -270,9 +274,13 @@ describe('comfybuilder.install wiring', () => {
     expect(resolveModelManifest).toHaveBeenCalledWith(expect.anything(), 'd1', '1')
     // The declared models are handed to the background staging task; install
     // itself never blocks on model bytes.
-    expect(startModelStaging).toHaveBeenCalledWith(installation, [
-      { type: 'checkpoints', filename: 'm.safetensors', downloadUrl: 'https://x/m' }
-    ])
+    // The third argument is the governance marker the archive install
+    // reported, so staging never has to re-read a record it would find stale.
+    expect(startModelStaging).toHaveBeenCalledWith(
+      installation,
+      [{ type: 'checkpoints', filename: 'm.safetensors', downloadUrl: 'https://x/m' }],
+      null
+    )
     expect(stageModels).not.toHaveBeenCalled()
   })
 
@@ -769,7 +777,8 @@ describe('comfybuilder update-comfyui', () => {
     expect(abortModelStaging).toHaveBeenCalledWith('i1')
     expect(startModelStaging).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'i1', version: '9' }),
-      []
+      [],
+      null
     )
     // The environment is laid down for the NEW artifact, not the old one.
     const passed = vi.mocked(installArtifact).mock.calls[0]![0] as { artifact: { id: string } }
@@ -844,6 +853,7 @@ describe('comfybuilder update-comfyui', () => {
       fs.mkdirSync(path.join(installPath, 'ComfyUI'), { recursive: true })
       fs.writeFileSync(path.join(installPath, 'venv', 'new.txt'), 'new venv')
       fs.writeFileSync(path.join(installPath, 'ComfyUI', 'main.py'), 'new code')
+      return { governance: null }
     })
     vi.mocked(resolveModelManifest).mockRejectedValueOnce(new Error('disk full'))
     const previousVenv = path.join(root, 'venv.previous')

--- a/src/main/sources/comfybuilder/index.ts
+++ b/src/main/sources/comfybuilder/index.ts
@@ -23,12 +23,15 @@ import {
   buildLaunchSpec,
   venvPython,
   resolveModelManifest,
-  normalizeSha256
+  normalizeSha256,
+  GOVERNANCE_MARKER_FIELD,
+  readGovernanceMarker
 } from '../../comfybuilder'
 import type {
   Artifact,
   ArtifactGpu,
   ArtifactOs,
+  GovernanceMarker,
   InstallProgress,
   ModelDescriptor
 } from '../../comfybuilder'
@@ -48,6 +51,7 @@ import { renameWithLockRetry } from '../../lib/fsRetry'
 import { defaultDownloadCacheDir } from '../../lib/paths'
 import { releaseInstallTerminalForFsOp } from '../../lib/popoutWindows'
 import { t } from '../../lib/i18n'
+import { update as updateInstallation } from '../../installations'
 import type { InstallationRecord } from '../../installations'
 import type {
   SourcePlugin,
@@ -77,6 +81,7 @@ interface EnvironmentRollback {
   artifactAccelVariant?: string
   artifactSha256?: string
   status?: string
+  [GOVERNANCE_MARKER_FIELD]?: unknown
 }
 
 export type ComfyBuilderRecovery =
@@ -393,6 +398,11 @@ export function withAccelArgs(installation: InstallationRecord, launchArgs: stri
  * transaction, so a build whose model list cannot be fetched fails (and rolls
  * back) rather than landing without its models.
  *
+ * The governance marker is returned alongside, because the caller's copy of
+ * the installation record predates the write below and would still read as
+ * ungoverned - and background staging must know it is staging into a managed
+ * install.
+ *
  * Takes only what both callers have: progress + an abort signal.
  */
 async function installEnvironment(
@@ -404,7 +414,10 @@ async function installEnvironment(
     signal?: AbortSignal
   },
   onTransactionStarted?: () => Promise<void>
-): Promise<readonly ModelDescriptor[]> {
+): Promise<{
+  readonly models: readonly ModelDescriptor[]
+  readonly governance: GovernanceMarker | null
+}> {
   releaseInstallTerminalForFsOp(installation.id)
   const artifact = artifactFromRecord(installation)
   const client = getBuilderClient()
@@ -420,7 +433,7 @@ async function installEnvironment(
     const artifactInstallPath = hasExistingEnvironment
       ? paths.nextEnvironment
       : installation.installPath
-    await installArtifact({
+    const installed = await installArtifact({
       artifact,
       client,
       installPath: artifactInstallPath,
@@ -460,6 +473,16 @@ async function installEnvironment(
       await onTransactionStarted?.()
     }
 
+    // Persist governed status durably, in ONE record write (temp file +
+    // rename), so a crash mid-install can never leave a partially written
+    // marker that reads as ungoverned. Written only once the swap has landed,
+    // so the record describes the tree actually on disk. Cleared explicitly
+    // when the new archive is not governed, so a version change out of a
+    // governed build does not leave the old build's marker behind.
+    await updateInstallation(installation.id, {
+      [GOVERNANCE_MARKER_FIELD]: installed.governance ?? undefined
+    })
+
     // Resolve the build's declared models while a failure can still roll the
     // environment back cleanly; the actual downloads run in the background
     // task the caller starts, so launch is not gated on model bytes.
@@ -472,7 +495,7 @@ async function installEnvironment(
 
     await fs.rm(paths.previousVenv, { recursive: true, force: true }).catch(() => {})
     await fs.rm(paths.previousComfy, { recursive: true, force: true }).catch(() => {})
-    return manifest.models
+    return { models: manifest.models, governance: installed.governance }
   } catch (err) {
     // Put the complete working environment back before surfacing the failure.
     if (hasExistingEnvironment) {
@@ -539,7 +562,8 @@ export const comfybuilder: SourcePlugin = {
       launchArgs: withAccelArgs(
         installation,
         (installation.launchArgs as string | undefined) ?? DEFAULT_LAUNCH_ARGS
-      )
+      ),
+      governance: readGovernanceMarker(installation)
     })
     if (!spec) return null
     return { cmd: spec.cmd, args: spec.args, cwd: spec.cwd, port: spec.port }
@@ -575,11 +599,11 @@ export const comfybuilder: SourcePlugin = {
   },
 
   async install(installation: InstallationRecord, tools: InstallTools): Promise<void> {
-    const models = await installEnvironment(installation, tools)
+    const { models, governance } = await installEnvironment(installation, tools)
     // Models download in the background; the install is launchable as soon as
     // the environment is on disk. Completion is recorded as `modelsStaged`,
     // and an unfinished staging re-runs at the next launch.
-    startModelStaging(installation, models)
+    startModelStaging(installation, models, governance)
   },
 
   // Launch / rename / open-folder / remove / delete never reach here — the
@@ -655,7 +679,8 @@ async function updateBuildVersion(
     artifactOs: installation.artifactOs as string | undefined,
     artifactGpu: installation.artifactGpu as string | undefined,
     artifactAccelVariant: installation.artifactAccelVariant as string | undefined,
-    artifactSha256: installation.artifactSha256 as string | undefined
+    artifactSha256: installation.artifactSha256 as string | undefined,
+    [GOVERNANCE_MARKER_FIELD]: installation[GOVERNANCE_MARKER_FIELD]
   }
   let environmentReady = false
 
@@ -684,7 +709,7 @@ async function updateBuildVersion(
     }
 
     const updated = { ...installation, ...next } as InstallationRecord
-    const models = await installEnvironment(updated, tools, () =>
+    const { models, governance } = await installEnvironment(updated, tools, () =>
       tools.update({ ...next, status: 'updating', [ROLLBACK_FIELD]: previous })
     )
     environmentReady = true
@@ -693,7 +718,7 @@ async function updateBuildVersion(
     // before the background task finishes knows to re-stage.
     await tools.update({ status: 'installed', modelsStaged: false, [ROLLBACK_FIELD]: undefined })
     await finalizeEnvironmentTransaction(installation.installPath).catch(() => {})
-    startModelStaging(updated, models)
+    startModelStaging(updated, models, governance)
     return { ok: true, navigate: 'detail' }
   } catch (err) {
     // Put the record back where it was. Leaving it pointed at a version whose

--- a/src/main/sources/comfybuilder/modelStagingTask.test.ts
+++ b/src/main/sources/comfybuilder/modelStagingTask.test.ts
@@ -22,7 +22,8 @@ vi.mock('../../lib/comfyDownloadManager', () => ({
 vi.mock('../../comfybuilder', () => ({
   stageModels,
   installModelsRoot: vi.fn((installPath: string) => `${installPath}/ComfyUI/models`),
-  resolveModelManifest
+  resolveModelManifest,
+  GOVERNANCE_MARKER_FIELD: 'governance'
 }))
 vi.mock('../../devplatform/session', () => ({ getBuilderClient: vi.fn(() => ({})) }))
 vi.mock('../../installations', () => ({ update: updateInstallation }))

--- a/src/main/sources/comfybuilder/modelStagingTask.ts
+++ b/src/main/sources/comfybuilder/modelStagingTask.ts
@@ -1,4 +1,9 @@
-import { installModelsRoot, resolveModelManifest, stageModels } from '../../comfybuilder'
+import {
+  GOVERNANCE_MARKER_FIELD,
+  installModelsRoot,
+  resolveModelManifest,
+  stageModels
+} from '../../comfybuilder'
 import type { ModelDescriptor } from '../../comfybuilder'
 import { getBuilderClient } from '../../devplatform/session'
 import * as installations from '../../installations'
@@ -42,17 +47,22 @@ export function abortModelStaging(installationId: string): void {
  * Synchronous + fire-and-forget; no-op if a task is already running for this
  * install. Failures are logged, never thrown: the launch-time re-stage is the
  * retry path.
+ *
+ * `governance` is passed explicitly by a caller that has just installed, whose
+ * copy of the record predates the marker write; every other caller leaves it
+ * out and the durable marker on the record is used.
  */
 export function startModelStaging(
   installation: InstallationRecord,
-  models: readonly ModelDescriptor[]
+  models: readonly ModelDescriptor[],
+  governance?: unknown
 ): void {
   const installationId = installation.id
   if (_stagingAborts.has(installationId)) return
   const abort = new AbortController()
   _stagingAborts.set(installationId, abort)
 
-  void runTask(installation, models, abort.signal)
+  void runTask(installation, models, abort.signal, governance)
     .catch((err) => {
       console.warn(
         `[buildModels:${installationId}] staging failed: ${err instanceof Error ? err.message : String(err)}`
@@ -69,9 +79,19 @@ export function startModelStaging(
 async function runTask(
   installation: InstallationRecord,
   models: readonly ModelDescriptor[],
-  signal: AbortSignal
+  signal: AbortSignal,
+  governance?: unknown
 ): Promise<void> {
   const installationId = installation.id
+  // Deliberately the RAW value, not a pre-narrowed marker: `stageModels`
+  // validates it, and a marker that fails to parse must stay distinguishable
+  // from an absent one so a corrupted record keeps the stricter rules.
+  //
+  // `undefined` (argument omitted) falls back to the record; an explicit
+  // `null` does NOT. A caller that just installed an ungoverned archive passes
+  // null deliberately, and `??` would swap that for the superseded marker
+  // still sitting on its stale copy of the record.
+  const marker = governance === undefined ? installation[GOVERNANCE_MARKER_FIELD] : governance
   if (models.length === 0) {
     await installations.update(installationId, { modelsStaged: true }).catch(() => {})
     return
@@ -98,6 +118,7 @@ async function runTask(
       models,
       installPath: installation.installPath,
       installationId,
+      governance: marker,
       jobs: {
         start: downloadManager.startManagedModelJob,
         cancel: downloadManager.cancelModelDownload


### PR DESCRIPTION
## Summary

ComfyBuilder archives can carry signed organization governance policy, but Desktop previously lacked a durable way to recognize those installs across restarts, refuse launch when policy verification failed, and preserve verified model identity through staging.

This PR adds four interleaved pieces:

- migrates model integrity to algorithm-tagged BLAKE3/SHA-256 digests and keeps verification ahead of final-name placement;
- persists a durable governance marker and verifies the signed policy before any governed install work or process launch;
- writes a model ledger from verified staged files, replacing stale policy evidence even when the new ledger is empty;
- applies per-form launch arguments, including disabling every Manager-enabling flag for custom-node allowlist installs and enabling asset hashing for governed model installs.

## Hashless public models

Existing non-governed installs continue to accept manifests that declare no model hash, matching current public-model behavior. Governed installs reject hashless models because their bytes cannot be matched to an organization-approved digest. A declared but unusable integrity value is rejected rather than silently downgraded to an unverified download.

The former `74e38157` change was dropped during rebase because `origin/main` already contains its complete behavior and stronger coverage for undefined, empty, and whitespace-only SHA-256 values.

## Change breakdown

Total: **30 files, 3,483 additions, 158 deletions, 3,641 changed lines**.

### Product code

**15 files, 1,400 additions, 117 deletions, 1,517 changed lines (41.66%)**

- `src/main/comfybuilder/governance.ts`
- `src/main/comfybuilder/index.ts`
- `src/main/comfybuilder/install.ts`
- `src/main/comfybuilder/integrity.ts`
- `src/main/comfybuilder/launch.ts`
- `src/main/comfybuilder/modelLedger.ts`
- `src/main/comfybuilder/models.ts`
- `src/main/comfybuilder/types.ts`
- `src/main/lib/comfyDownloadManager.ts`
- `src/main/lib/ipc/sessionActions/launch.ts`
- `src/main/lib/modelDownloadStaging.ts`
- `src/main/lib/modelDownloadTransport.ts`
- `src/main/sources/comfybuilder/constants.ts`
- `src/main/sources/comfybuilder/index.ts`
- `src/main/sources/comfybuilder/modelStagingTask.ts`

### Test code

**12 files, 2,051 additions, 41 deletions, 2,092 changed lines (57.46%)**

- `src/main/comfybuilder/governance.test.ts`
- `src/main/comfybuilder/integrity.test.ts`
- `src/main/comfybuilder/launch.test.ts`
- `src/main/comfybuilder/modelDownloadStaging.test.ts`
- `src/main/comfybuilder/models.test.ts`
- `src/main/lib/comfyDownloadManagerModelJobs.test.ts`
- `src/main/lib/ipc/sessionActions/launch.governance.test.ts`
- `src/main/lib/modelDownloadStaging.test.ts`
- `src/main/lib/modelDownloadTransport.test.ts`
- `src/main/sources/comfybuilder/governanceMarker.test.ts`
- `src/main/sources/comfybuilder/index.test.ts`
- `src/main/sources/comfybuilder/modelStagingTask.test.ts`

### Data fixture

**1 file, 22 additions, 0 deletions, 22 changed lines (0.60%)**

- `src/main/comfybuilder/fixtures/model-ledger-v1.json`

### Configuration

**1 file, 1 addition, 0 deletions, 1 changed line (0.03%)**

- `package.json`

### Lockfile

**1 file, 9 additions, 0 deletions, 9 changed lines (0.25%)**

- `pnpm-lock.yaml`

## Verification

- `pnpm run typecheck` — passed all node, web, E2E, and integration TypeScript checks.
- `pnpm run lint` — passed.
- `pnpm run format:check` — passed.
- Focused governance, launch, model, and download-manager Vitest suites — **239 passed, 1 skipped**.
- Full `pnpm run test` — **4,855 passed, 2 skipped, 1 failed**. The sole failed lock-detection test reproduces unchanged on an extracted `origin/main` tree in this environment; the run also reported an unrelated delayed renderer-test callback from untouched code.
- Two independent blind reviews found the three required invariants satisfied. One suggested treating `governance: null` as malformed; this was declined because install results deliberately use `null` for ordinary archives and persist it as field absence, while an attacker able to edit the record could remove the field just as easily. ComfyUI remains the independent enforcement layer.

## Dependencies

None. This is the root PR in the Desktop governance stack.
