### PR TITLE
fix(dashboard): open instances in new windows

### DIFF
--- a/e2e/nav-matrix-dashboard.test.ts
+++ b/e2e/nav-matrix-dashboard.test.ts
@@ -1,11 +1,11 @@
 /**
  * E2E: instance/window navigation matrix — Dashboard → X (issue #926).
  *
- * Drives the real picker bridge (`window.__comfyTitlePopup`) from a dashboard
- * (chooser) host and asserts the navigation outcome via recorded IPC
- * invocations + BrowserWindow counts. Mirrors `picker-cluster.test.ts`.
+ * Drives dashboard tiles and the picker bridge from a dashboard (chooser)
+ * host, then asserts navigation via recorded IPC invocations + BrowserWindow
+ * counts. Mirrors `picker-cluster.test.ts`.
  *
- * Covers: stopped instance → same-window launch; running instance → focus;
+ * Covers: stopped instance → new window; running instance → focus;
  * cloud → new-window via the caret. The decision itself is exhaustively unit
  * tested (`navDecision.test.ts`); this pins the bridge → main → window wiring.
  */
@@ -15,9 +15,9 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { test, expect } from '@playwright/test'
 import { launchApp, type AppContext } from './launchApp'
 import { expectChooserVisible } from './support/chooserHelpers'
+import { byTestId, TID } from './support/testIds'
 import {
   closeTitlePopupIfOpen,
-  isPopupVisible,
   titlePopupPage,
 } from './support/cdpPages'
 import {
@@ -78,28 +78,20 @@ test.beforeEach(async () => {
   await clearRunningSessions(ctx.app)
 })
 
-test('Dashboard → stopped instance: same-window launch, no new window @windows @macos @linux', async () => {
+test('Dashboard → stopped instance: opens a new window and preserves the dashboard @windows @macos @linux', async () => {
   const before = await liveWindowCount(ctx.app)
-  await openPicker(ctx.app, ctx.panel, 'pickInstall')
+  expect(await ctx.panel.click(byTestId(TID.dashboardTile(INSTALL_A_ID)))).toBe(true)
 
-  const popup = titlePopupPage(ctx.app)
-  await popup.evaluate<void>(`window.__comfyTitlePopup.pickInstall(${JSON.stringify(INSTALL_A_ID)})`)
-
-  await expect.poll(() => isPopupVisible(ctx.app, 'comfyTitlePopup.html'), {
-    timeout: 5_000, intervals: [100, 200],
-  }).toBe(false)
-
-  // Stopped pick from the chooser host runs `runAction('launch')` in place.
+  // The dashboard tile routes through main's new-window helper, which creates
+  // the target host before dispatching its launch.
   await expect.poll(async () => {
-    const calls = (await getIpcInvocations(ctx.app, 'run-action')) as { installationId?: string; actionId?: string }[]
-    return calls.some((c) => c.installationId === INSTALL_A_ID && c.actionId === 'launch')
-  }, { timeout: 10_000, intervals: [200, 500] }).toBe(true)
+    const calls = (await getIpcInvocations(ctx.app, 'open-install-new-window')) as { installationId?: string; focusedExisting?: boolean }[]
+    return calls.some((c) => c.installationId === INSTALL_A_ID && c.focusedExisting === false)
+  }, { timeout: 5_000, intervals: [100, 250] }).toBe(true)
 
-  // Same window — no new host spawned, no focus-existing. Sample the full window
-  // so a late `focus-comfy-window` IPC can't slip in (a poll would pass at t=0).
-  expect(await liveWindowCount(ctx.app)).toBe(before)
+  await expect.poll(() => liveWindowCount(ctx.app), { timeout: 5_000, intervals: [200, 400] }).toBe(before + 1)
   await expectNoIpcInvocation(ctx.app, 'focus-comfy-window', () => true, {
-    message: 'unexpected focus-comfy-window on a same-window launch',
+    message: 'unexpected focus-comfy-window on a stopped dashboard launch',
   })
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1625,10 +1625,15 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       }
     }
 
+    ipcMain.handle('open-install-new-window', (_event, installationId: string) =>
+      openInstallInNewWindow(installationId)
+    )
+
     /**
-     * Swap-in-place: picking a different install from a Comfy-instance window
-     * replaces the current install IN THE SAME WINDOW (workflow continuity). The
-     * current session is stopped, the window detaches to chooser-shape, then
+     * Route an instance-picker selection. Dashboard hosts preserve themselves
+     * and open the target in a new window. From a Comfy-instance window, a
+     * selection replaces the current install IN THE SAME WINDOW (workflow
+     * continuity). The current session is stopped, the window detaches to chooser-shape, then
      * re-attaches the picked install via the dashboard chooser's attach-claim
      * path. Short-circuits: target running elsewhere → focus it; target is the
      * host's own install → no-op; user cancels the confirm → no-op. Cross-window
@@ -1651,6 +1656,21 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
       // Picking the host's own install — picker already dismissed at
       // the IPC boundary, nothing more to do.
       if (parentEntry.installationId === installationId) return
+
+      // A dashboard-host picker selection preserves the dashboard and opens
+      // the target in a pre-created window. That window claims itself in place
+      // when its panel receives the forwarded pick.
+      if (parentEntry.installationId == null) {
+        // A running session normally has an attached entry and returns above.
+        // Preserve the renderer's focus-only fallback for startup/test races
+        // where session state arrives before that entry is registered.
+        if (_runningSessions.has(installationId)) {
+          deliverPickToEntry(parentEntry, installationId)
+          return
+        }
+        await openInstallInNewWindow(installationId)
+        return
+      }
 
       // Install-backed parent → swap by detaching first, then routing
       // through the chooser-pick path. Confirm only when the swap will

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -77,6 +77,8 @@ export function buildElectronApi(): ElectronApi {
     terminalRestart: (installationId) => ipcRenderer.invoke('terminal-restart', installationId),
     openInstallWindow: (installationId) =>
       ipcRenderer.invoke('open-install-window', installationId),
+    openInstallNewWindow: (installationId) =>
+      ipcRenderer.invoke('open-install-new-window', installationId),
     closeComfyWindow: (installationId, opts) =>
       ipcRenderer.invoke('close-comfy-window', installationId, opts),
     closeHostWindow: () => ipcRenderer.invoke('close-host-window'),

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -63,7 +63,10 @@ vi.mock('../views/ChooserView.vue', () => ({
     name: 'ChooserView',
     emits: ['pick', 'show-new-install'],
     template:
-      '<div data-testid="chooser-view"><button data-testid="chooser-new-install" @click="$emit(\'show-new-install\', \'workspace-1\')">New</button></div>'
+      '<div data-testid="chooser-view">' +
+      "<button data-testid=\"chooser-pick\" @click=\"$emit('pick', { id: 'test-id', name: 'Test Install', sourceLabel: 'Standalone', sourceCategory: 'local' })\">Open</button>" +
+      '<button data-testid="chooser-new-install" @click="$emit(\'show-new-install\', \'workspace-1\')">New</button>' +
+      '</div>'
   }
 }))
 vi.mock('../views/InstallWizardModal.vue', () => ({
@@ -317,6 +320,7 @@ function installMockApi(initial?: {
     focusComfyWindow: vi.fn(async () => {}),
     getListActions: vi.fn(async () => []),
     runAction: vi.fn(async () => ({ ok: true })),
+    openInstallNewWindow: vi.fn(async () => {}),
     // Picker thumbnail warm-up fetches the bundled-template options on the
     // first-use cold-start path; returning users must never trigger it.
     getFieldOptions: vi.fn(async () => []),
@@ -428,6 +432,26 @@ describe('PanelApp', () => {
       entrypoint: 'chooser',
       workspaceId: 'workspace-1'
     })
+  })
+
+  it('opens a dashboard instance in a new window', async () => {
+    window.history.replaceState({}, '', '/?panel=chooser&firstUseCompleted=true')
+    const api = (
+      window as unknown as {
+        api: {
+          openInstallNewWindow: ReturnType<typeof vi.fn>
+          claimAttachHost: ReturnType<typeof vi.fn>
+        }
+      }
+    ).api
+    const wrapper = mountPanel()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="chooser-pick"]').trigger('click')
+    await flushPromises()
+
+    expect(api.openInstallNewWindow).toHaveBeenCalledWith('test-id')
+    expect(api.claimAttachHost).not.toHaveBeenCalled()
   })
 
   it('returns to the underlying body when a takeover emits close', async () => {

--- a/src/renderer/src/panel/PanelApp.vue
+++ b/src/renderer/src/panel/PanelApp.vue
@@ -230,7 +230,11 @@ chooserHandoff = useChooserHandoff({
   showProgress: handleShowProgress,
   switchPanel
 })
-const { handleChooserPick, handleChooserShowNewInstall } = chooserHandoff
+const { handleChooserShowNewInstall } = chooserHandoff
+
+function handleDashboardPick(inst: Installation): void {
+  void window.api.openInstallNewWindow(inst.id)
+}
 
 // Boot-time restore: the host window is hidden until we tell main the outcome.
 // Use `performChooserLaunch` (NOT `handleChooserPick`) so a missing launch
@@ -298,10 +302,9 @@ useDeepLinkRouter({
   showAppUpdateRestartPrompt,
   showAppUpdateDownloadPrompt,
   pickInstallFromPicker: async (inst, pickOpts) => {
-    // Chooser-host pick (no installationId backing this host) → swap
-    // in-place via the same path the dashboard chooser uses, so the
-    // dashboard window becomes the picked install. Install-backed
-    // pick → spawn a new Comfy window for the picked install
+    // Main routes chooser-host picker selections through a pre-created target
+    // window. This callback claims that target in place. Install-backed picks
+    // spawn a new Comfy window for the picked install
     // (focus-or-launch contract — main already short-circuits to
     // focus-existing when the install is already running in another
     // window before this IPC fires, so we only ever see launches
@@ -334,7 +337,7 @@ useDeepLinkRouter({
 function handleProgressSuccessChoice(actionId: string, targetInstallationId: string): void {
   if (actionId === SUCCESS_ACTION_OPEN_INSTANCE) {
     // Cold-spawn chooser host (cross-instance Update that opened a
-    // fresh window for the target): `handleChooserPick` attaches the
+    // fresh window for the target): `performChooserLaunch` attaches the
     // install in-place, so this same window becomes the target's
     // window — no extra chooser hop, no orphan chooser left behind.
     // Install-backed host: fall back to `openInstallWindow`, which
@@ -342,7 +345,7 @@ function handleProgressSuccessChoice(actionId: string, targetInstallationId: str
     if (!installationId) {
       const inst = installationStore.getById(targetInstallationId)
       if (inst) {
-        void handleChooserPick(inst)
+        void chooserHandoff.performChooserLaunch(inst)
         return
       }
     }
@@ -598,7 +601,7 @@ onUnmounted(() => {
 
         <div v-else-if="activePanel === 'chooser'" class="panel-chooser">
           <ChooserView
-            @pick="handleChooserPick"
+            @pick="handleDashboardPick"
             @show-new-install="handleChooserShowNewInstall"
             @show-progress="handleShowProgress"
           />

--- a/src/renderer/src/panel/useChooserHandoff.ts
+++ b/src/renderer/src/panel/useChooserHandoff.ts
@@ -29,13 +29,13 @@ export interface ChooserHandoffApi {
     installationId: string,
     triggersInstanceStart?: boolean
   ) => Promise<void>
-  /** Shared launch path for chooser-tile clicks and first-use auto-launch. */
+  /** In-place launch path for first-use and pre-created target windows. */
   performChooserLaunch: (
     installation: Installation,
     onMissingLaunchAction?: () => void,
     opts?: { isRestart?: boolean }
   ) => Promise<ChooserLaunchOutcome>
-  /** Bound to ChooserView's `pick` emit. */
+  /** Launches into the current chooser host. */
   handleChooserPick: (installation: Installation, opts?: { isRestart?: boolean }) => Promise<void>
   /** Bound to ChooserView's `show-new-install` empty-state CTA. */
   handleChooserShowNewInstall: (workspaceId?: string) => void
@@ -89,7 +89,7 @@ export function useChooserHandoff(opts: ChooserHandoffOpts): ChooserHandoffApi {
     })
   }
 
-  /** Shared launch path for chooser-tile clicks and first-use auto-launch.
+  /** In-place launch path for first-use and pre-created target windows.
    *  `onMissingLaunchAction` diverges: tile click → new-install flow;
    *  auto-launch → no-op (the chained install already finished). */
   async function performChooserLaunch(

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -1182,6 +1182,8 @@ export interface ElectronApi {
    *  release-update so the newly-created destination install gets
    *  focus without swapping the source host. */
   openInstallWindow(installationId: string): Promise<boolean>
+  /** Open an installation in its own window while preserving the dashboard. */
+  openInstallNewWindow(installationId: string): Promise<void>
   /** Close the BrowserWindow that hosts the given installation's ComfyUI
    *  view (and its title-bar / panel WebContentsViews). Returns true if a
    *  window was found and closed. Used by the embedded install-settings


### PR DESCRIPTION
## Summary

Opening an instance from the dashboard now preserves the dashboard and launches the selected instance in a separate window. Already-running instances continue to focus their existing window, while install-backed window switching retains its current in-place behavior.

## Testing

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm exec vitest run src/renderer/src/panel/PanelApp.test.ts` (44 passed)
- `pnpm exec playwright test e2e/nav-matrix-dashboard.test.ts --project=windows` (3 passed)
- `pnpm exec electron-vite build`

## Change breakdown

Total changed lines: **117** (80 added, 37 deleted)

### Product code

- **5 files**
- **41 added, 14 deleted — 55 changed lines (47.0%)**
- `src/main/index.ts`
- `src/preload/api.ts`
- `src/renderer/src/panel/PanelApp.vue`
- `src/renderer/src/panel/useChooserHandoff.ts`
- `src/types/ipc.ts`

### Test code

- **2 files**
- **39 added, 23 deleted — 62 changed lines (53.0%)**
- `src/renderer/src/panel/PanelApp.test.ts`
- `e2e/nav-matrix-dashboard.test.ts`