### PR TITLE
test(standalone): derive the fixture vendor id for every host architecture

### DIFF
--- a/src/main/sources/standalone/index.test.ts
+++ b/src/main/sources/standalone/index.test.ts
@@ -20,18 +20,28 @@ import { resetTemplateCatalogCache } from './templateCatalog'
 import { CURATED_TEMPLATES, NO_TEMPLATE_VALUE, INDEX_URL } from './curatedTemplates'
 import { fetchJSON } from '../../lib/fetch'
 import { getLatestStableTag } from '../../lib/comfyui-releases'
-import { PLATFORM_PREFIX } from './envPaths'
+import { PLATFORM_PREFIX, variantMatchesHost } from './envPaths'
 import type { FieldOption } from '../../types/sources'
 import type { InstallationRecord } from '../../installations'
 
 const mockedFetchJSON = vi.mocked(fetchJSON)
 const mockedGetLatestStableTag = vi.mocked(getLatestStableTag)
 
-// Use the running platform's vendor prefix (and, on Windows, the running
-// architecture's suffix) so tests work on win32/darwin/linux CI runners and on
-// native ARM64 Windows dev machines alike — the wizard filters by both.
-const ARCH_SUFFIX = process.platform === 'win32' && process.arch === 'arm64' ? '-arm64' : ''
+// Use the running platform's vendor prefix and architecture suffix so tests
+// pass on every runner and dev machine — the wizard filters by both. Mirrors
+// `variantMatchesHostArch`: macOS bundles are unsuffixed ARM64, every other
+// platform needs `-arm64` on an ARM64 host.
+const ARCH_SUFFIX = process.arch === 'arm64' && process.platform !== 'darwin' ? '-arm64' : ''
 const VENDOR_ID = `${PLATFORM_PREFIX[process.platform] || 'win-'}nvidia${ARCH_SUFFIX}`
+
+// Guard the line above: when the host filter and this id disagree, every
+// release/variant assertion below returns an empty list and fails for a
+// reason that points nowhere near the cause.
+describe('test fixture', () => {
+  it('derives a vendor id the host architecture filter accepts', () => {
+    expect(variantMatchesHost(VENDOR_ID)).toBe(true)
+  })
+})
 
 // --- Helpers ---
 


### PR DESCRIPTION
Part of a stack of review fixes for #1486, now merged. Based on `main`; #1504–#1509 continue from this PR.

## Summary

The standalone test fixture built its vendor id from the running host but appended the `-arm64` suffix only on Windows. On a Linux ARM64 host it produced `linux-nvidia`, which the architecture filter added in #1486 now rejects, so seven release and variant tests failed there while passing on x64 CI.

## Feature behavior

No product change. The fixture now mirrors `variantMatchesHostArch`: macOS bundles are unsuffixed ARM64, every other platform needs the suffix on an ARM64 host.

## Test coverage and validation

- A new guard test asserts the fixture id is one the host filter accepts, so a future divergence fails once with a message that names the cause, rather than as seven unrelated assertion failures.
- Ran the file with `process.platform` and `process.arch` stubbed to win32/x64, win32/arm64, darwin/arm64, linux/x64 and linux/arm64: 49 tests pass in all five. Against the base branch, linux/arm64 fails 7.
- Full unit suite: 274 files, 4736 passed, 2 skipped. Repeated with the whole suite stubbed as linux/arm64, same result.
- Typecheck, lint and format all pass.

## Change breakdown

Total changed lines: 20 (15 added, 5 deleted).

### Product code

- 0 files; +0 / -0; 0 changed lines; 0%.

### Test code

- 1 files; +15 / -5; 20 changed lines; 100.0% of total.
- src/main/sources/standalone/index.test.ts

### Documentation

- 0 files; +0 / -0; 0 changed lines; 0%.

### Configuration and CI

- 0 files; +0 / -0; 0 changed lines; 0%.

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.

