### PR TITLE
fix(linux): restore the ToDesktop platform-level resource fallback

### DIFF
--- a/src/main/sources/standalone/arm64Packaging.test.ts
+++ b/src/main/sources/standalone/arm64Packaging.test.ts
@@ -9,16 +9,45 @@ interface ExtraResource {
 }
 
 interface ToDesktopConfig {
-  targetOverrides?: {
-    linux?: Record<string, { extraResources?: ExtraResource[] }>
-  }
+  extraResources?: ExtraResource[]
+  targetOverrides?: Record<string, Record<string, { extraResources?: ExtraResource[] }>>
+  platformOverrides?: Record<string, { extraResources?: ExtraResource[] }>
 }
 
+function readToDesktopConfig(): ToDesktopConfig {
+  return JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'todesktop.json'), 'utf-8')
+  ) as ToDesktopConfig
+}
+
+const destinations = (resources: ExtraResource[] = []): string[] =>
+  resources.map((resource) => resource.to).sort()
+
 describe('Linux ARM64 packaging', () => {
+  // A target list replaces, rather than merges with, the platform list, and
+  // ToDesktop decides server-side which architectures a platform builds. An
+  // architecture we did not enumerate falls back to `platformOverrides`, and
+  // without one it lands on the top-level list — `./lib` alone, so the
+  // package ships with no apparmor-profile and no bootstrap-python.
+  it('keeps a platform-level fallback for every platform with per-target overrides', () => {
+    const config = readToDesktopConfig()
+    const platforms = Object.keys(config.targetOverrides ?? {})
+    expect(platforms.length).toBeGreaterThan(0)
+
+    for (const platform of platforms) {
+      const fallback = config.platformOverrides?.[platform]
+      expect(fallback, `platformOverrides.${platform} is missing`).toBeDefined()
+      for (const [arch, target] of Object.entries(config.targetOverrides![platform]!)) {
+        expect(
+          destinations(fallback!.extraResources),
+          `platformOverrides.${platform} must cover every destination of targetOverrides.${platform}.${arch}`
+        ).toEqual(destinations(target.extraResources))
+      }
+    }
+  })
+
   it('uses matching ToDesktop resource paths with a separate ARM64 placeholder', () => {
-    const config = JSON.parse(
-      fs.readFileSync(path.join(process.cwd(), 'todesktop.json'), 'utf-8')
-    ) as ToDesktopConfig
+    const config = readToDesktopConfig()
     const linuxTargets = config.targetOverrides?.linux
     const x64Resources = linuxTargets?.x64?.extraResources ?? []
     const arm64Resources = linuxTargets?.arm64?.extraResources ?? []

--- a/todesktop.json
+++ b/todesktop.json
@@ -114,6 +114,16 @@
         { "from": "./lib", "to": "lib" },
         { "from": "./bootstrap-python/mac-arm64", "to": "bootstrap-python" }
       ]
+    },
+    "linux": {
+      "extraResources": [
+        { "from": "./lib", "to": "lib" },
+        { "from": "resources/apparmor-profile", "to": "apparmor-profile" },
+        {
+          "from": "./todesktop-targets/linux-x64/bootstrap-python",
+          "to": "bootstrap-python"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Part of a stack of review fixes for #1486. Based on #1503.

## Summary

#1486 replaced `platformOverrides.linux` with per-architecture `targetOverrides`, leaving Linux with no platform-level fallback while Windows keeps both. A ToDesktop target list replaces the platform list rather than merging with it, and ToDesktop decides server-side which architectures a platform builds, so any Linux target outside the x64 and arm64 keys now falls through to the top-level list: `./lib` alone.

Such a package ships without `resources/apparmor-profile`. `scripts/after-install.sh` then fails its `apparmor_parser` probe, prints the misleading "this version of AppArmor does not support the bundled profile" message and skips installation, leaving the Electron sandbox blocked on Ubuntu 24.04 and later, with nothing failing at build time.

## Feature behavior

Restores `platformOverrides.linux`, carrying the same three resources as the x64 target and sourcing bootstrap-python from the same staged directory. This mirrors the shape Windows already has. The per-target overrides are unchanged, so the architecture split #1486 introduced still applies wherever ToDesktop honours it.

## Test coverage and validation

- A new test requires every platform with per-target overrides to have a platform-level fallback covering the same destinations. It fails with "platformOverrides.linux is missing" when the block is deleted, verified by deleting it.
- The rule covers Windows as well, which had no such coverage.
- Full unit suite: 274 files, 4736 passed, 2 skipped. Typecheck, lint and format pass.
- No remote ToDesktop build was submitted.

## Change breakdown

Total changed lines: 51 (45 added, 6 deleted).

### Product code

- 0 files; +0 / -0; 0 changed lines; 0%.

### Test code

- 1 files; +35 / -6; 41 changed lines; 80.4% of total.
- src/main/sources/standalone/arm64Packaging.test.ts

### Documentation

- 0 files; +0 / -0; 0 changed lines; 0%.

### Configuration and CI

- 1 files; +10 / -0; 10 changed lines; 19.6% of total.
- todesktop.json

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.
