### PR TITLE
fix(bootstrap): skip hosts with no published bootstrap instead of failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The app ships a minimal (~15–20 MB) standalone Python with `pygit2` baked in, 
 | `pnpm run bootstrap`       | Build locally via `scripts/build-bootstrap-python.mjs` (no system Python needed). Auto-detects the host platform and architecture; pass `--platform win-x64\|win-arm64\|mac-arm64\|linux-x64` for another. |
 | `pnpm run bootstrap:fetch` | Download a prebuilt archive from the [`bootstrap-v3`](https://github.com/Comfy-Org/Comfy-Desktop/releases/tag/bootstrap-v3) release (faster). Set `GITHUB_TOKEN` to authenticate.                          |
 
-Both write to `bootstrap-python/{win-x64,win-arm64,mac-arm64,linux-x64}/` (gitignored). The directory must exist before `pnpm run dev` or `pnpm run build:*`. `win-arm64` is the native Windows on Arm build (NVIDIA RTX Spark, Snapdragon X); the app picks `win-<process.arch>` in dev and ToDesktop's `targetOverrides` select it for the arm64 installer.
+Both write to `bootstrap-python/{win-x64,win-arm64,mac-arm64,linux-x64}/` (gitignored). The directory must exist before `pnpm run dev` or `pnpm run build:*`. Hosts outside that list — Linux ARM64 today — have no published bootstrap: the build script says so and exits 0, so `pnpm run init` still completes and the app falls back to system `git`. `win-arm64` is the native Windows on Arm build (NVIDIA RTX Spark, Snapdragon X); the app picks `win-<process.arch>` in dev and ToDesktop's `targetOverrides` select it for the arm64 installer.
 
 At runtime the main process picks a git backend in priority order ([`src/main/lib/ipc/index.ts`](src/main/lib/ipc/index.ts)): bootstrap pygit2 → standalone-install pygit2 → system `git`. Set `COMFY_FORCE_BOOTSTRAP_GIT=1` (or `pnpm run dev:bootstrap`) to verify the bundled path that ships to users without git.
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "init": "pnpm install && pnpm run bootstrap",
     "init:dev": "pnpm run init && pnpm run dev",
-    "predev": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-'+process.arch;if(!fs.existsSync('bootstrap-python/'+p))console.log('\\n\\x1b[33m⚠ Bootstrap python not found. Run \\\"pnpm run bootstrap\\\" for pre-install git support.\\x1b[0m\\n')\"",
+    "predev": "node scripts/build-bootstrap-python.mjs --check",
     "dev": "electron-vite dev",
-    "predev:bootstrap": "node -e \"const fs=require('fs'),p=process.platform==='win32'?'win-'+process.arch:process.platform==='darwin'?'mac-arm64':'linux-'+process.arch;if(!fs.existsSync('bootstrap-python/'+p)){console.log('Building bootstrap python...');require('child_process').execSync('node scripts/build-bootstrap-python.mjs',{stdio:'inherit'})}\"",
+    "predev:bootstrap": "node scripts/build-bootstrap-python.mjs --if-missing",
     "dev:bootstrap": "node -e \"process.env.COMFY_FORCE_BOOTSTRAP_GIT='1';require('child_process').execSync('electron-vite dev',{stdio:'inherit',env:process.env})\"",
     "build": "pnpm run typecheck && electron-vite build",
     "start": "electron-vite preview",

--- a/scripts/build-bootstrap-python.mjs
+++ b/scripts/build-bootstrap-python.mjs
@@ -11,8 +11,14 @@
  *
  * Usage:
  *   node build-bootstrap-python.mjs [--output DIR] [--platform PLATFORM]
+ *   node build-bootstrap-python.mjs --check       # warn if absent, build nothing
+ *   node build-bootstrap-python.mjs --if-missing  # build only when absent
  *
  * Platforms: win-x64, win-arm64, mac-arm64, linux-x64
+ *
+ * Hosts outside that list (Linux ARM64 today) have no published bootstrap.
+ * That is not an error — the app falls back to system git — so every mode
+ * reports it and exits 0 rather than failing `pnpm run init`.
  */
 import { spawnSync } from 'node:child_process'
 import { createWriteStream } from 'node:fs'
@@ -99,15 +105,16 @@ const STRIP_FILES = new Set([
   '_testcapi.pyd', '_tkinter.pyd', '_sqlite3.pyd',
 ])
 
+/** The bootstrap this host can run, or null when none is published for it.
+ *  The running Node's architecture is the one the resulting Python must
+ *  match. Never substitute linux-x64 on ARM64: that produces a bootstrap
+ *  which exists but cannot execute on the target machine. */
 function detectPlatform() {
   const sys = process.platform
-  // The running Node's architecture is the one the resulting Python must
-  // match. Do not silently substitute linux-x64 on ARM64: that produces a
-  // bootstrap which exists but cannot execute on the target machine.
   if (sys === 'win32') return process.arch === 'arm64' ? 'win-arm64' : 'win-x64'
   if (sys === 'darwin') return 'mac-arm64'
   if (sys === 'linux' && process.arch === 'x64') return 'linux-x64'
-  throw new Error(`Unsupported platform: ${sys} ${process.arch}`)
+  return null
 }
 
 function isWindowsPlatform(plat) {
@@ -115,13 +122,17 @@ function isWindowsPlatform(plat) {
 }
 
 function parseArgs(argv) {
-  const args = { output: 'bootstrap-python', platform: null }
+  const args = { output: 'bootstrap-python', platform: null, check: false, ifMissing: false }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--output') args.output = argv[++i]
     else if (a === '--platform') args.platform = argv[++i]
+    else if (a === '--check') args.check = true
+    else if (a === '--if-missing') args.ifMissing = true
     else if (a === '-h' || a === '--help') {
-      console.log('Usage: node build-bootstrap-python.mjs [--output DIR] [--platform PLATFORM]')
+      console.log(
+        'Usage: node build-bootstrap-python.mjs [--output DIR] [--platform PLATFORM] [--check] [--if-missing]'
+      )
       process.exit(0)
     }
   }
@@ -292,9 +303,26 @@ function runPython(pythonPath, args, opts = {}) {
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   const plat = args.platform || detectPlatform()
+  if (!plat) {
+    console.log(
+      `No bootstrap python is published for ${process.platform} ${process.arch}. ` +
+        'Skipping — Comfy Desktop falls back to system git.'
+    )
+    return
+  }
   const platInfo = PLATFORM_MAP[plat]
   if (!platInfo) throw new Error(`Unknown platform: ${plat}`)
   const outputDir = path.join(args.output, plat)
+
+  if (args.check) {
+    if (!(await isDir(outputDir))) {
+      console.log(
+        '\n\x1b[33m⚠ Bootstrap python not found. Run "pnpm run bootstrap" for pre-install git support.\x1b[0m\n'
+      )
+    }
+    return
+  }
+  if (args.ifMissing && (await isDir(outputDir))) return
 
   console.log(`Building bootstrap Python for ${plat}`)
   console.log(`  Python ${PYTHON_VERSION}, PBS release ${PBS_RELEASE}`)


### PR DESCRIPTION
Part of a stack of review fixes for #1486. Based on #1506.

## Summary

`detectPlatform` now throws on Linux ARM64, and both dev hooks call it unconditionally. `pnpm run init`, which is `pnpm install && pnpm run bootstrap` and the command the README gives new contributors, dies with a stack trace on that host after installing. `pnpm run dev:bootstrap` dies the same way before Electron starts, and `predev` points the developer at `pnpm run bootstrap`, the command that throws.

A host with no published bootstrap is a fact rather than an error: the app falls back to system git.

## Feature behavior

`detectPlatform` returns null for such hosts, and every mode reports the situation and exits 0. The script gains the two modes the hooks needed, `--check` to warn only and `--if-missing` to build when absent, so both `package.json` one-liners now just call it. The host-to-directory mapping each of them had copied lives only in `detectPlatform`.

An explicit `--platform` naming an unknown target still fails, so release builds, which always pass `--platform`, cannot silently skip.

## Test coverage and validation

Exercised the script with `process.platform` and `process.arch` stubbed:

- linux/arm64 under `--check`, `--if-missing` and no flag: prints "No bootstrap python is published for linux arm64" and exits 0.
- darwin/arm64 with the directory absent under `--check`: prints the same warning as before and exits 0.
- darwin/arm64 with the directory present: `--check` and `--if-missing` are silent, exit 0, and leave the directory untouched.
- An explicit unknown `--platform` still exits non-zero.

Full unit suite: 274 files, 4736 passed, 2 skipped. Typecheck, lint and format pass. README updated for the skip.

## Change breakdown

Total changed lines: 46 (37 added, 9 deleted).

### Product code

- 1 files; +34 / -6; 40 changed lines; 87.0% of total.
- scripts/build-bootstrap-python.mjs

### Test code

- 0 files; +0 / -0; 0 changed lines; 0%.

### Documentation

- 1 files; +1 / -1; 2 changed lines; 4.3% of total.
- README.md

### Configuration and CI

- 1 files; +2 / -2; 4 changed lines; 8.7% of total.
- package.json

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.
