### PR TITLE
fix(git): stop telling packaged users to run a dev bootstrap command

### DIFF
--- a/src/main/lib/ipc/index.ts
+++ b/src/main/lib/ipc/index.ts
@@ -217,10 +217,17 @@ export function register(callbacks: RegisterCallbacks = {}): Promise<void> {
         return
       }
 
+      // The "build it" hint is for developers. A packaged app that reaches
+      // here ships no bootstrap for its platform (Linux ARM64 today), so the
+      // command does not exist for the user and the log would send whoever
+      // reads it — support included — after a packaging defect that isn't one.
       console.warn(
-        '[ipc] Bootstrap pygit2 not available — bootstrap-python/<platform>/ is missing. ' +
-          'Run "pnpm run bootstrap" (or "pnpm run bootstrap:fetch") to build it. ' +
-          'Falling back to standalone-install pygit2 / system git.'
+        app.isPackaged
+          ? `[ipc] No bundled bootstrap python for ${process.platform}-${process.arch}. ` +
+              'Falling back to standalone-install pygit2 / system git.'
+          : '[ipc] Bootstrap pygit2 not available — bootstrap-python/<platform>/ is missing. ' +
+              'Run "pnpm run bootstrap" (or "pnpm run bootstrap:fetch") to build it. ' +
+              'Falling back to standalone-install pygit2 / system git.'
       )
 
       if (forceBootstrap) {


### PR DESCRIPTION
Part of a stack of review fixes for #1486. Based on #1507.

## Summary

After #1486 a packaged Linux ARM64 app ships a `bootstrap-python` directory holding only a README, so `tryConfigureBootstrapPygit2` returns false and the git backend falls through. The warning it logs claims `bootstrap-python/<platform>/` is missing and tells the reader to run `pnpm run bootstrap`.

That is developer guidance in an end user's log. It lands in the app log once per launch, so a bug report built from it points at a packaging defect that is not one, and names a command the user does not have. After #1507 that command exits without building on this host anyway.

## Feature behavior

Unpackaged runs keep the existing hint, which is still correct for a developer who has not built the bootstrap. Packaged runs state the platform plainly and name the fallback. Behaviour is otherwise unchanged: the same fallback chain runs, and no telemetry is emitted on this path either way.

## Test coverage and validation

- Log-message branch only, gated on `app.isPackaged`; no behavioural change to cover.
- Full unit suite: 274 files, 4736 passed, 2 skipped. Typecheck, lint and format pass.

## Change breakdown

Total changed lines: 13 (10 added, 3 deleted).

### Product code

- 1 files; +10 / -3; 13 changed lines; 100.0% of total.
- src/main/lib/ipc/index.ts

### Test code

- 0 files; +0 / -0; 0 changed lines; 0%.

### Documentation

- 0 files; +0 / -0; 0 changed lines; 0%.

### Configuration and CI

- 0 files; +0 / -0; 0 changed lines; 0%.

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.
