### PR TITLE
feat(install): say why ARM64 Linux has no local runtime

### DIFF
--- a/src/main/lib/gpu.test.ts
+++ b/src/main/lib/gpu.test.ts
@@ -11,6 +11,7 @@ import {
   parseRocmSmiDriverVersion,
   parseWmiDriverVersions,
   checkLinuxAmdKfdAccess,
+  validateHardware,
   type SystemGpuEntry
 } from './gpu'
 
@@ -279,5 +280,38 @@ describe('checkLinuxAmdKfdAccess', () => {
     const node = path.join(tmpDir, 'kfd')
     fs.writeFileSync(node, '')
     expect(await checkLinuxAmdKfdAccess(node)).toBeNull()
+  })
+})
+
+describe('validateHardware architecture gate', () => {
+  const realPlatform = process.platform
+  const realArch = process.arch
+  const setHost = (platform: string, arch: string): void => {
+    Object.defineProperty(process, 'platform', { value: platform })
+    Object.defineProperty(process, 'arch', { value: arch })
+  }
+
+  afterEach(() => {
+    setHost(realPlatform, realArch)
+  })
+
+  // Without this the wizard filters every bundle out and shows a bare "No
+  // options available", which the user cannot tell from an R2 outage.
+  it('blocks the local install on an architecture with no published bundle', async () => {
+    setHost('linux', 'arm64')
+    const result = await validateHardware()
+
+    expect(result.supported).toBe(false)
+    expect(result.error).toMatch(/ARM64 Linux/)
+    // The other half of the message: this machine is still useful.
+    expect(result.error).toMatch(/cloud or remote/)
+  })
+
+  it('does not gate an x64 Linux host on architecture', async () => {
+    setHost('linux', 'x64')
+    const result = await validateHardware()
+
+    // May still warn about the AMD compute node; it must not be blocked here.
+    expect(result.error).toBeUndefined()
   })
 })

--- a/src/main/lib/gpu.ts
+++ b/src/main/lib/gpu.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process'
 import fs from 'fs'
 import type { HardwareValidation, NvidiaDriverCheck } from '../../types/ipc'
+import { unsupportedHostReason } from '../sources/standalone/envPaths'
 
 type GpuId = 'nvidia' | 'amd' | 'intel' | 'mps'
 
@@ -559,9 +560,17 @@ export async function checkLinuxAmdKfdAccess(kfdPath = KFD_PATH): Promise<string
 }
 
 /** Validate hardware for standalone install. Rejects Intel Macs (MPS needs
- *  Apple Silicon); surfaces a non-blocking warning when a Linux AMD GPU is
- *  present but its compute device node is missing or inaccessible. */
+ *  Apple Silicon) and architectures with no published bundle; surfaces a
+ *  non-blocking warning when a Linux AMD GPU is present but its compute
+ *  device node is missing or inaccessible. */
 async function validateHardware(): Promise<HardwareValidation> {
+  // Ask before probing the GPU: no bundle exists for this architecture, so
+  // whatever the GPU turns out to be, the local install has nothing to offer.
+  // Reporting it here gets the wizard's existing explain-and-block treatment
+  // instead of an empty release list the user cannot tell from an outage.
+  const unsupportedHost = unsupportedHostReason()
+  if (unsupportedHost) return { supported: false, error: unsupportedHost }
+
   if (process.platform === 'darwin') {
     const gpu = await detectMacGPU()
     if (!gpu) {

--- a/src/main/sources/standalone/envPaths.test.ts
+++ b/src/main/sources/standalone/envPaths.test.ts
@@ -16,6 +16,7 @@ import {
   recommendVariant,
   stripPlatform,
   variantAccel,
+  unsupportedHostReason,
   variantMatchesHost,
   variantMatchesHostArch
 } from './envPaths'
@@ -207,6 +208,31 @@ describe('architecture-specific vendor ids', () => {
       setHost('linux', 'arm')
       expect(variantMatchesHostArch('linux-nvidia')).toBe(false)
       expect(variantMatchesHostArch('linux-nvidia-arm64')).toBe(false)
+    })
+  })
+
+  describe('unsupportedHostReason', () => {
+    // The filter and the reason have to agree: a host the filter empties out
+    // must have something to say, or the wizard shows a bare "no options".
+    const CATALOG = ['win-nvidia', 'win-nvidia-arm64', 'mac-mps', 'linux-nvidia']
+
+    it('explains the ARM64 Linux gap the architecture filter creates', () => {
+      setHost('linux', 'arm64')
+      expect(CATALOG.some(variantMatchesHost)).toBe(false)
+      expect(unsupportedHostReason()).toMatch(/ARM64 Linux/)
+    })
+
+    it('stays silent on hosts the catalog serves', () => {
+      for (const [platform, arch] of [
+        ['win32', 'x64'],
+        ['win32', 'arm64'],
+        ['darwin', 'arm64'],
+        ['linux', 'x64']
+      ] as const) {
+        setHost(platform, arch)
+        expect(CATALOG.some(variantMatchesHost), `${platform}/${arch}`).toBe(true)
+        expect(unsupportedHostReason(), `${platform}/${arch}`).toBeNull()
+      }
     })
   })
 

--- a/src/main/sources/standalone/envPaths.ts
+++ b/src/main/sources/standalone/envPaths.ts
@@ -79,6 +79,25 @@ export function variantMatchesHostArch(variantId: string): boolean {
   return false
 }
 
+/**
+ * Why the running host has no standalone bundle at all, or null when it has
+ * some. `variantMatchesHostArch` filters an ARM64 Linux app down to nothing,
+ * and an empty option list reads exactly like an R2 outage — so the reason
+ * lives here, next to the filter that creates it, and `validateHardware`
+ * turns it into the same block-and-explain the wizard already gives an Intel
+ * Mac. Delete this carve-out when `linux-*-arm64` bundles ship; the filter
+ * above accepts them with no further change.
+ */
+export function unsupportedHostReason(): string | null {
+  if (process.platform === 'linux' && process.arch === 'arm64') {
+    return (
+      'ComfyUI does not publish a local runtime for ARM64 Linux yet. ' +
+      'You can still connect this machine to cloud or remote workspaces.'
+    )
+  }
+  return null
+}
+
 /** True when a vendor id targets the running platform, with or without the
  *  `beta-` prefix (`win-nvidia` and `beta-win-nvidia-arm64` on Windows). */
 export function variantMatchesHostPlatform(variantId: string): boolean {


### PR DESCRIPTION
Part of a stack of review fixes for #1486. Based on #1508. Top of the stack.

## Summary

#1486 correctly stops a Linux ARM64 app from selecting x64 bundles, but the resulting state is returned as a bare empty list. It reaches the user as "No options available" and telemetry as `express.fallback` with reason `precondition_failed`, which is also what an empty or mis-published catalog produces. The one state we know exactly was indistinguishable from the one we do not, so a user cannot tell "wait for an ARM64 bundle" from "retry later", and metrics cannot separate this deliberate gap from a real catalog regression.

## Feature behavior

The reason now lives next to the filter that creates it, as `unsupportedHostReason` in `envPaths.ts`, and `validateHardware` reports it. Linux ARM64 therefore takes the explain-and-block path the wizard already gives an Intel Mac: a message naming the platform, and express install falling back with `unsupported_hardware`.

Cloud and remote workspaces are unaffected. The wizard blocks only the standalone source card, and the message says so. No new i18n key or renderer plumbing is introduced; this reuses the existing hardware-validation mechanism end to end.

Removing the carve-out when `linux-*-arm64` bundles ship is a one-function deletion. The architecture filter already accepts suffixed ids with no further change.

## Test coverage and validation

- `unsupportedHostReason` is tested against the filter it must agree with: on linux/arm64 no catalog id survives `variantMatchesHost` and a reason is returned; on win32/x64, win32/arm64, darwin/arm64 and linux/x64 at least one id survives and the reason is null. That pairing is what keeps the two from drifting apart.
- `validateHardware` blocks on linux/arm64 with a message naming the platform and the cloud alternative, and does not gate linux/x64 on architecture.
- Full unit suite: 274 files, 4736 passed, 2 skipped. Repeated with the whole suite stubbed as linux/arm64: identical result.
- Typecheck, lint and format pass.

## Change breakdown

Total changed lines: 92 (90 added, 2 deleted).

### Product code

- 2 files; +30 / -2; 32 changed lines; 34.8% of total.
- src/main/lib/gpu.ts
- src/main/sources/standalone/envPaths.ts

### Test code

- 2 files; +60 / -0; 60 changed lines; 65.2% of total.
- src/main/lib/gpu.test.ts
- src/main/sources/standalone/envPaths.test.ts

### Documentation

- 0 files; +0 / -0; 0 changed lines; 0%.

### Configuration and CI

- 0 files; +0 / -0; 0 changed lines; 0%.

### Generated files

- 0 files; +0 / -0; 0 changed lines; 0%.

### Lockfiles

- 0 files; +0 / -0; 0 changed lines; 0%.

### Vendored code

- 0 files; +0 / -0; 0 changed lines; 0%.
