### PR TITLE
test: clean up PanelApp scopes between tests

### DIFF
--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment-options {"settings":{"navigation":{"disableChildFrameNavigation":true}}}
 // Keep the feedback iframe in the DOM without loading the external support site.
-import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const installWizardOpen = vi.hoisted(() => vi.fn())
 
@@ -368,34 +368,6 @@ describe('PanelApp', () => {
     // gating path (where the takeover should mount) override the URL
     // back to one without this param and flip `mockState.settings.firstUseCompleted`.
     window.history.replaceState({}, '', '/?installationId=test-id&firstUseCompleted=true')
-  })
-
-  it('cancels pending media prefetch during automatic test teardown', async () => {
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
-    vi.stubGlobal('requestIdleCallback', undefined)
-    const schedule = vi.spyOn(window, 'setTimeout')
-    const cancel = vi.spyOn(window, 'clearTimeout')
-    const pending: { timer?: number; wrapper?: ReturnType<typeof mountPanel> } = {}
-    // Runs after afterEach: prove the suite's automatic unmount canceled the
-    // timeout, without letting a real timer race happy-dom's destruction.
-    onTestFinished(() => {
-      try {
-        expect(cancel).toHaveBeenCalledWith(pending.timer)
-      } finally {
-        // Also clean up if the assertion fails when the teardown regresses.
-        if (pending.wrapper?.exists()) pending.wrapper.unmount()
-        vi.restoreAllMocks()
-        vi.useRealTimers()
-        vi.unstubAllGlobals()
-      }
-    })
-
-    pending.wrapper = mountPanel()
-    await flushPromises()
-    const scheduled = schedule.mock.calls.findIndex(([, delay]) => delay === 50)
-    expect(scheduled).toBeGreaterThanOrEqual(0)
-    pending.timer = schedule.mock.results[scheduled]!.value
-    expect(cancel).not.toHaveBeenCalledWith(pending.timer)
   })
 
   it('renders the comfy-lifecycle body by default for install-backed hosts', async () => {

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment-options {"settings":{"navigation":{"disableChildFrameNavigation":true}}}
+// Keep the feedback iframe in the DOM without loading the external support site.
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 const installWizardOpen = vi.hoisted(() => vi.fn())
 
@@ -123,13 +125,16 @@ vi.mock('../views/MigrateConfirmTakeover.vue', () => ({
     methods: { open: vi.fn() }
   }
 }))
-import { mount, flushPromises } from '@vue/test-utils'
+import { enableAutoUnmount, mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { createPinia, setActivePinia } from 'pinia'
 import PanelApp from './PanelApp.vue'
 import { __resetLauncherPrefsForTest } from '../composables/useLauncherPrefs'
 import { useOverlay } from '../composables/useOverlay'
 import { TELEMETRY_ACTION_EVENT_NAME, type TelemetryActionEventDetail } from '../lib/telemetry'
+
+// Dispose panel scopes before happy-dom tears down document, including queued media prefetches.
+enableAutoUnmount(afterEach)
 
 const messages = {
   en: {
@@ -363,6 +368,34 @@ describe('PanelApp', () => {
     // gating path (where the takeover should mount) override the URL
     // back to one without this param and flip `mockState.settings.firstUseCompleted`.
     window.history.replaceState({}, '', '/?installationId=test-id&firstUseCompleted=true')
+  })
+
+  it('cancels pending media prefetch during automatic test teardown', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    vi.stubGlobal('requestIdleCallback', undefined)
+    const schedule = vi.spyOn(window, 'setTimeout')
+    const cancel = vi.spyOn(window, 'clearTimeout')
+    const pending: { timer?: number; wrapper?: ReturnType<typeof mountPanel> } = {}
+    // Runs after afterEach: prove the suite's automatic unmount canceled the
+    // timeout, without letting a real timer race happy-dom's destruction.
+    onTestFinished(() => {
+      try {
+        expect(cancel).toHaveBeenCalledWith(pending.timer)
+      } finally {
+        // Also clean up if the assertion fails when the teardown regresses.
+        if (pending.wrapper?.exists()) pending.wrapper.unmount()
+        vi.restoreAllMocks()
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+      }
+    })
+
+    pending.wrapper = mountPanel()
+    await flushPromises()
+    const scheduled = schedule.mock.calls.findIndex(([, delay]) => delay === 50)
+    expect(scheduled).toBeGreaterThanOrEqual(0)
+    pending.timer = schedule.mock.results[scheduled]!.value
+    expect(cancel).not.toHaveBeenCalledWith(pending.timer)
   })
 
   it('renders the comfy-lifecycle body by default for install-backed hosts', async () => {


### PR DESCRIPTION
## Problem and change

`PanelApp.test.ts` left mounted component scopes alive after each test. A queued media-prefetch timeout could then run after happy-dom removed `document`, failing the unit-test job with an unhandled `ReferenceError` even when every test assertion passed. This caused the [Test job failure on #1501](https://github.com/Comfy-Org/Comfy-Desktop/actions/runs/34291193358/job/102277886476).

Enable Vue Test Utils automatic unmount after each panel test so scope disposal cancels pending work before DOM teardown. Disable child-frame navigation in this test file so the existing feedback-iframe URL assertions do not load the external support site. Product behavior is unchanged.

## Test coverage and validation

- Existing panel suite: 43 tests passed, including the feedback iframe and URL assertions. No new test cases.
- Full unit suite: 272 files passed; 4,717 tests passed and 2 skipped; no unhandled errors.
- Integration suite: 41 tests passed across 6 files.
- Typecheck, lint, formatting, and bridge declaration checks passed.

## Change breakdown

Total changed lines: **9** (7 added + 2 deleted), excluding merge-only changes.

| Category | File count | Paths | Added | Deleted | Share of changed lines |
| --- | ---: | --- | ---: | ---: | ---: |
| Product code | 0 | None | 0 | 0 | 0% |
| Test code | 1 | `src/renderer/src/panel/PanelApp.test.ts` | 7 | 2 | 100% |

No documentation, standalone configuration, generated files, lockfiles, or vendored code changed.
