### PR TITLE
Make instance creation workspace-aware

### DIFF
--- a/e2e/chooser.test.ts
+++ b/e2e/chooser.test.ts
@@ -43,6 +43,13 @@ test.afterAll(async () => {
 test('chooser body renders on cold start @windows @macos @linux', async () => {
   await expectChooserVisible(ctx.panel)
   expect(await ctx.panel.exists('.chooser-tile-new')).toBe(true)
+  expect(
+    (
+      await ctx.panel.textOf(
+        '[data-testid="devplatform-workspace-selector"] .workspace-selector__name',
+      )
+    )?.trim(),
+  ).toBe('Personal')
 })
 
 test('title bar shows install-less pill on chooser host @windows @macos @linux', async () => {
@@ -53,6 +60,7 @@ test('title bar shows install-less pill on chooser host @windows @macos @linux',
 test('clicking New Install tile opens the new-install takeover @windows @macos @linux', async () => {
   await clickNewInstallTile(ctx.panel)
   await expectTakeoverOpen(ctx.panel)
+  expect(await ctx.panel.exists('[data-testid="workspace-install-source-managed"]')).toBe(true)
   await dismissOverlay(ctx.panel)
   await expectChooserVisible(ctx.panel)
 })

--- a/locales/en.json
+++ b/locales/en.json
@@ -360,7 +360,6 @@
     "chooseMethod": "Choose Install Method",
     "configuration": "Configuration",
     "configureTitle": "Create a New Instance",
-    "configureWorkspaceLead": "Select a release to install.",
     "detectedGpuLabel": "Detected GPU",
     "notAvailableRemote": "Not available in Remote Connection mode",
     "helpImproveTitle": "Help improve Comfy",

--- a/locales/en.json
+++ b/locales/en.json
@@ -372,10 +372,9 @@
     "changeInstallType": "Change Install Type",
     "nameWhitespace": "Enter a name, or leave blank to use the suggested one.",
     "urlInvalid": "Enter a valid URL (e.g. http://localhost:8188).",
-    "buildSourceLabel": "Select build",
-    "managedBuilds": "Managed",
-    "publicBuilds": "Public",
-    "workspaceBuildLabel": "Build",
+    "managedBuilds": "Managed Builds",
+    "publicBuilds": "Public Builds",
+    "workspaceBuildLabel": "Release",
     "selectWorkspaceBuild": "Select a Build",
     "noCompatibleBuilds": "No compatible Builds are available to install.",
     "refreshWorkspaceBuilds": "Refresh Builds",
@@ -390,7 +389,7 @@
     "buildModels": "Models",
     "buildCustomNodes": "Custom nodes",
     "buildSize": "Size",
-    "buildTarget": "Release target"
+    "buildTarget": "Hardware"
   },
   "templateQuit": {
     "title": "Template models are still downloading",
@@ -1298,7 +1297,6 @@
     },
     "workspace": {
       "personalLabel": "Personal",
-      "unmanagedLabel": "No workspace",
       "switchLabel": "Workspace",
       "currentFallback": "Current workspace",
       "instanceCountLabel": "INSTANCES",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -360,7 +360,6 @@
     "chooseMethod": "选择安装方式",
     "configuration": "配置",
     "configureTitle": "新建实例",
-    "configureWorkspaceLead": "选择要安装的发布版本。",
     "detectedGpuLabel": "检测到的 GPU",
     "notAvailableRemote": "远程连接模式下不可用",
     "helpImproveTitle": "帮助改进 Comfy",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -372,7 +372,6 @@
     "changeInstallType": "更改安装类型",
     "nameWhitespace": "输入名称，或留空使用建议名称。",
     "urlInvalid": "请输入有效 URL（例如 http://localhost:8188）。",
-    "buildSourceLabel": "选择构建",
     "managedBuilds": "托管",
     "publicBuilds": "公共",
     "workspaceBuildLabel": "构建",
@@ -1298,7 +1297,6 @@
     },
     "workspace": {
       "personalLabel": "个人",
-      "unmanagedLabel": "无工作区",
       "switchLabel": "工作区",
       "currentFallback": "当前工作区",
       "instanceCountLabel": "实例",

--- a/src/main/installations.test.ts
+++ b/src/main/installations.test.ts
@@ -243,6 +243,39 @@ describe('installations.associateUnownedBuildInstalls', () => {
   })
 })
 
+describe('installations.reassignWorkspace', () => {
+  it('re-keys exact workspace matches and preserves Personal and team records', async () => {
+    const installations = await loadInstallations()
+    const remotePersonal = await installations.add({
+      name: 'Remote Personal',
+      installPath: path.join(tmpRoot, 'remote-personal'),
+      sourceId: 'comfybuilder',
+      workspaceId: 'server-personal-id',
+      status: 'installed'
+    })
+    const localPersonal = await installations.add({
+      name: 'Local Personal',
+      installPath: path.join(tmpRoot, 'local-personal'),
+      sourceId: 'standalone',
+      status: 'installed'
+    })
+    const team = await installations.add({
+      name: 'Team',
+      installPath: path.join(tmpRoot, 'team'),
+      sourceId: 'comfybuilder',
+      workspaceId: 'team-id',
+      status: 'installed'
+    })
+
+    const updated = await installations.reassignWorkspace('server-personal-id', 'personal')
+
+    expect(updated.map((record) => record.id)).toEqual([remotePersonal.id])
+    expect((await installations.get(remotePersonal.id))!.workspaceId).toBe('personal')
+    expect((await installations.get(localPersonal.id))!.workspaceId).toBeUndefined()
+    expect((await installations.get(team.id))!.workspaceId).toBe('team-id')
+  })
+})
+
 describe('installations.getRecent', () => {
   it('returns null when no installs have been launched', async () => {
     const installations = await loadInstallations()

--- a/src/main/installations.ts
+++ b/src/main/installations.ts
@@ -317,6 +317,32 @@ export async function update(
   return updated
 }
 
+/** Re-key installations from one workspace to another. */
+export async function reassignWorkspace(
+  fromWorkspaceId: string,
+  toWorkspaceId: string
+): Promise<InstallationRecord[]> {
+  if (!fromWorkspaceId || !toWorkspaceId || fromWorkspaceId === toWorkspaceId) return []
+
+  const updated = await enqueue(async () => {
+    const list = await loadForWrite()
+    const changed: InstallationRecord[] = []
+    for (let index = 0; index < list.length; index++) {
+      const existing = list[index]!
+      if (existing.workspaceId !== fromWorkspaceId) continue
+      const next = { ...existing, workspaceId: toWorkspaceId }
+      list[index] = next
+      changed.push(next)
+    }
+    if (changed.length > 0) await save(list)
+    return changed
+  })
+
+  for (const record of updated) installationEvents.emit('updated', record)
+  if (updated.length > 0) installationEvents.emit('changed')
+  return updated
+}
+
 /**
  * Associate unowned Builder build installs with a workspace using exact ids
  * returned by that workspace. The check and write share the mutation queue, so

--- a/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   add: vi.fn(),
   get: vi.fn(),
   update: vi.fn(),
+  reassignWorkspace: vi.fn(),
   associateUnownedBuildInstalls: vi.fn(),
   list: vi.fn(async () => [] as Record<string, unknown>[]),
   uniqueName: vi.fn(async (n: string) => n),
@@ -88,6 +89,7 @@ vi.mock('./shared', () => ({
     add: mocks.add,
     get: mocks.get,
     update: mocks.update,
+    reassignWorkspace: mocks.reassignWorkspace,
     associateUnownedBuildInstalls: mocks.associateUnownedBuildInstalls,
     list: mocks.list
   },
@@ -151,6 +153,9 @@ describe('registerDevPlatformHandlers', () => {
     mocks.getSnapshotCount.mockResolvedValue(3)
     mocks.buildExportEnvelope.mockReturnValue({ type: 'comfyui-desktop-2-snapshot' })
     mocks.listBuilds.mockResolvedValue([])
+    mocks.listWorkspaces.mockResolvedValue([
+      { id: 'w1', name: 'Personal', type: 'personal', role: 'owner' }
+    ])
     mocks.listWorkspaceMembers.mockResolvedValue([])
     mocks.createBuildDraft.mockResolvedValue({
       buildId: 'build-1',
@@ -207,6 +212,25 @@ describe('registerDevPlatformHandlers', () => {
     await handler('comfybuilder:signOut')({})
 
     expect(panel).toHaveBeenCalledWith('comfybuilder:authChanged', { signedIn: false })
+  })
+
+  it('merges the server Personal workspace into the stable local identity', async () => {
+    const workspaces = [
+      {
+        id: 'server-personal-id',
+        name: 'Personal workspace',
+        type: 'team',
+        role: 'owner'
+      },
+      { id: 'team-id', name: 'Team', type: 'team', role: 'member' }
+    ]
+    mocks.listWorkspaces.mockResolvedValue(workspaces)
+
+    await expect(handler('comfybuilder:listWorkspaces')({})).resolves.toEqual(workspaces)
+    expect(mocks.reassignWorkspace).toHaveBeenCalledExactlyOnceWith(
+      'server-personal-id',
+      'personal'
+    )
   })
 
   it('opens the explicitly selected workspace Builds page', async () => {
@@ -490,6 +514,7 @@ describe('registerDevPlatformHandlers', () => {
     ['missing an active workspace', { signedIn: true }, 'No active workspace.']
   ])('refuses promotion when %s', async (_label, status, message) => {
     mocks.status.mockReturnValue(status)
+    if (status.signedIn && !('workspaceId' in status)) mocks.listWorkspaces.mockResolvedValue([])
 
     const result = await handler('comfybuilder:promoteLocalInstance')({}, 'local-1')
 

--- a/src/main/lib/ipc/registerDevPlatformHandlers.ts
+++ b/src/main/lib/ipc/registerDevPlatformHandlers.ts
@@ -48,6 +48,11 @@ import { allocateInstallIdentity } from './installIdentity'
 import { COMFYBUILDER_INSTALL_DEFAULTS } from '../../sources/comfybuilder/constants'
 import type { InstallationRecord } from '../../installations'
 import type { InstallBuildRequest, InstallBuildResult } from '../../../types/ipc'
+import {
+  isPersonalWorkspace,
+  PERSONAL_WORKSPACE_ID,
+  workspaceContextId
+} from '../../../shared/workspaces'
 
 /** IPC channels for the dev-platform bridge. Kept together so a rename can't desync. */
 export const DEVPLATFORM_CHANNELS = {
@@ -190,10 +195,14 @@ export function registerDevPlatformHandlers(): void {
 
   ipcMain.handle(DEVPLATFORM_CHANNELS.getAuthStatus, (): AuthStatus => session.status())
 
-  ipcMain.handle(
-    DEVPLATFORM_CHANNELS.listWorkspaces,
-    (): Promise<Workspace[]> => session.listWorkspaces()
-  )
+  ipcMain.handle(DEVPLATFORM_CHANNELS.listWorkspaces, async (): Promise<Workspace[]> => {
+    const workspaces = await session.listWorkspaces()
+    const personal = workspaces.find(isPersonalWorkspace)
+    if (personal) {
+      await installations.reassignWorkspace(personal.id, PERSONAL_WORKSPACE_ID)
+    }
+    return workspaces
+  })
 
   ipcMain.handle(
     DEVPLATFORM_CHANNELS.openBuildsPage,
@@ -236,7 +245,15 @@ export function registerDevPlatformHandlers(): void {
         }
         const status = session.status()
         if (!status.signedIn) return { ok: false, message: 'Not signed in.' }
-        const workspaceId = inst.workspaceId || status.workspaceId
+        let workspaceId: string | undefined
+        if (!inst.workspaceId || inst.workspaceId === PERSONAL_WORKSPACE_ID) {
+          workspaceId =
+            workspaceContextId(status) === PERSONAL_WORKSPACE_ID
+              ? status.workspaceId
+              : (await session.listWorkspaces()).find(isPersonalWorkspace)?.id
+        } else {
+          workspaceId = inst.workspaceId
+        }
         if (!workspaceId) return { ok: false, message: 'No active workspace.' }
         if (status.workspaceId !== workspaceId) {
           clearVersionCache()
@@ -305,7 +322,12 @@ export function registerDevPlatformHandlers(): void {
   // map lets a row whose newer build runs here surface as `update-available`.
   ipcMain.handle(DEVPLATFORM_CHANNELS.listBuilds, async (): Promise<BuildRow[]> => {
     if (!session.isSignedIn()) return []
-    const workspaceId = session.status().workspaceId
+    const status = session.status()
+    const workspaceId = status.workspaceId
+    const localWorkspaceId = workspaceContextId(status)
+    if (localWorkspaceId === PERSONAL_WORKSPACE_ID && workspaceId) {
+      await installations.reassignWorkspace(workspaceId, PERSONAL_WORKSPACE_ID)
+    }
     const cacheGeneration = getVersionCacheGeneration()
     const host = await resolveHost()
     const client = getBuilderClient()
@@ -321,7 +343,7 @@ export function registerDevPlatformHandlers(): void {
     if (workspaceId && session.status().workspaceId === workspaceId) {
       try {
         await installations.associateUnownedBuildInstalls(
-          workspaceId,
+          localWorkspaceId,
           new Set(builds.map((build) => build.id))
         )
       } catch (err) {
@@ -333,7 +355,7 @@ export function registerDevPlatformHandlers(): void {
         client,
         host,
         builds,
-        await installedBuildVersions(workspaceId),
+        await installedBuildVersions(localWorkspaceId),
         cacheGeneration
       ),
       membersPromise
@@ -358,7 +380,8 @@ export function registerDevPlatformHandlers(): void {
     DEVPLATFORM_CHANNELS.installBuild,
     async (_event, request: InstallBuildRequest): Promise<InstallBuildResult> => {
       if (!session.isSignedIn()) return { ok: false, message: 'Not signed in.' }
-      const workspaceId = session.status().workspaceId
+      const status = session.status()
+      const workspaceId = status.workspaceId
       if (!workspaceId) return { ok: false, message: 'No active workspace.' }
       if (!request || typeof request !== 'object') {
         return { ok: false, message: 'Invalid build install request.' }
@@ -420,7 +443,7 @@ export function registerDevPlatformHandlers(): void {
           sourceId: COMFYBUILDER_SOURCE_ID,
           sourceLabel: COMFYBUILDER_SOURCE_LABEL,
           installPath: identity.installPath,
-          workspaceId,
+          workspaceId: workspaceContextId(status),
           distributionId: buildId,
           distributionName: build.name,
           version: String(resolved.version),

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -73,6 +73,9 @@ export interface KnownSettings {
    *  install (the user ticked "Don't show this again"). Only ever set once the
    *  user already has ≥1 local install. Default false — show the step. */
   skipTemplatePickerStep?: boolean
+  /** Stable dashboard workspace scope. Used by New Instance entry points that
+   *  originate outside the dashboard renderer, such as the title menu. */
+  dashboardWorkspaceId?: string
   /** Version of a Desktop update whose installer finished downloading in a
    *  previous session and is staged on disk. Gates the bounded startup
    *  install check so boots without a staged update aren't delayed. Cleared
@@ -274,6 +277,7 @@ const SETTINGS_SCHEMA = {
     nullable: false,
     telemetry: { policy: 'value', toTelemetry: (raw) => raw === true }
   },
+  dashboardWorkspaceId: { nullable: false, telemetry: { policy: 'omit' } },
   pendingDownloadedUpdateVersion: { nullable: true, telemetry: { policy: 'omit' } },
   lastStartupUpdateAttemptVersion: { nullable: true, telemetry: { policy: 'omit' } },
   startupInstallNotReadyVersion: { nullable: true, telemetry: { policy: 'omit' } },

--- a/src/renderer/src/components/BrandBackground.vue
+++ b/src/renderer/src/components/BrandBackground.vue
@@ -8,15 +8,22 @@ import beam2Svg from '../assets/lighting/beam_2.svg?raw'
 withDefaults(
   defineProps<{
     vignette?: boolean
+    scrollContent?: boolean
   }>(),
-  { vignette: false }
+  { vignette: false, scrollContent: false }
 )
 </script>
 
 <template>
   <div class="brand-background" data-theme="dark">
     <div class="brand-outer-frame">
-      <div class="brand-inner-frame" :class="{ 'brand-inner-frame--vignette': vignette }">
+      <div
+        class="brand-inner-frame"
+        :class="{
+          'brand-inner-frame--vignette': vignette,
+          'brand-inner-frame--scroll-content': scrollContent
+        }"
+      >
         <div class="brand-beam" aria-hidden="true" v-html="beamSvg" />
         <div class="brand-beam brand-beam--2" aria-hidden="true" v-html="beam2Svg" />
         <slot />
@@ -81,5 +88,9 @@ withDefaults(
   background:
     radial-gradient(circle 196px at 50% 50%, #151317 0%, #151317 35%, var(--neutral-800) 100%),
     var(--neutral-800);
+}
+.brand-inner-frame--scroll-content {
+  justify-content: flex-start;
+  overflow-y: auto;
 }
 </style>

--- a/src/renderer/src/components/BrandTakeoverLayout.vue
+++ b/src/renderer/src/components/BrandTakeoverLayout.vue
@@ -12,9 +12,10 @@ withDefaults(
   defineProps<{
     theme?: 'dark' | 'light'
     vignette?: boolean
+    scrollContent?: boolean
     ariaLabel?: string
   }>(),
-  { theme: 'dark', vignette: false, ariaLabel: undefined }
+  { theme: 'dark', vignette: false, scrollContent: false, ariaLabel: undefined }
 )
 
 const rootRef = ref<HTMLElement | null>(null)
@@ -56,7 +57,7 @@ onBeforeUnmount(() => {
       :aria-label="ariaLabel"
       tabindex="-1"
     >
-      <BrandBackground :vignette="vignette">
+      <BrandBackground :vignette="vignette" :scroll-content="scrollContent">
         <div class="brand-logo-row">
           <ComfyCLogo class="brand-logo" />
         </div>

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -430,6 +430,21 @@ describe('PanelApp', () => {
     })
   })
 
+  it('opens menu-driven New Instance in the persisted dashboard workspace', async () => {
+    mockState.settings.dashboardWorkspaceId = 'workspace-saved'
+    mountPanel()
+    await flushPromises()
+    installWizardOpen.mockClear()
+
+    mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'new-install' }))
+    await flushPromises()
+
+    expect(installWizardOpen).toHaveBeenCalledWith({
+      entrypoint: 'titlebar',
+      workspaceId: 'workspace-saved'
+    })
+  })
+
   it('returns to the underlying body when a takeover emits close', async () => {
     window.history.replaceState({}, '', '/?panel=new-install&firstUseCompleted=true')
     const wrapper = mountPanel()

--- a/src/renderer/src/panel/PanelApp.test.ts
+++ b/src/renderer/src/panel/PanelApp.test.ts
@@ -190,6 +190,7 @@ interface MockApiState {
   getInstallations: ReturnType<typeof vi.fn>
   openExternal: ReturnType<typeof vi.fn>
   getAppVersion: ReturnType<typeof vi.fn>
+  getSetting: ReturnType<typeof vi.fn>
   /** Per-key getSetting values. Tests that need first-use takeover to
    *  auto-mount can flip `firstUseCompleted` to false here. Default is
    *  `true` so existing tests don't trip the takeover. */
@@ -216,6 +217,7 @@ function installMockApi(initial?: {
     getInstallations: vi.fn(async () => state.installations),
     openExternal: vi.fn(async () => {}),
     getAppVersion: vi.fn(async () => '0.5.0'),
+    getSetting: vi.fn(async (key: string) => state.settings[key]),
     settings: { firstUseCompleted: true, ...initial?.settings },
     installUpdate: vi.fn(async () => {}),
     downloadUpdate: vi.fn(async () => {})
@@ -293,7 +295,7 @@ function installMockApi(initial?: {
     ackAdoptPrompt: vi.fn(),
     respondAdoptPrompt: vi.fn(),
     onErrorDetail: vi.fn(() => () => {}),
-    getSetting: vi.fn(async (key: string) => state.settings[key]),
+    getSetting: state.getSetting,
     setSetting: vi.fn(async (key: string, value: unknown) => {
       state.settings[key] = value
     }),
@@ -428,6 +430,7 @@ describe('PanelApp', () => {
       entrypoint: 'chooser',
       workspaceId: 'workspace-1'
     })
+    expect(mockState.getSetting).not.toHaveBeenCalledWith('dashboardWorkspaceId')
   })
 
   it('opens menu-driven New Instance in the persisted dashboard workspace', async () => {
@@ -442,6 +445,24 @@ describe('PanelApp', () => {
     expect(installWizardOpen).toHaveBeenCalledWith({
       entrypoint: 'titlebar',
       workspaceId: 'workspace-saved'
+    })
+  })
+
+  it('opens menu-driven New Instance in Personal when the dashboard workspace read fails', async () => {
+    mockState.getSetting.mockImplementation(async (key: string) => {
+      if (key === 'dashboardWorkspaceId') throw new Error('settings unavailable')
+      return mockState.settings[key]
+    })
+    mountPanel()
+    await flushPromises()
+    installWizardOpen.mockClear()
+
+    mockState.panelSwitchCallbacks.forEach((cb) => cb({ panel: 'new-install' }))
+    await flushPromises()
+
+    expect(installWizardOpen).toHaveBeenCalledWith({
+      entrypoint: 'titlebar',
+      workspaceId: 'personal'
     })
   })
 

--- a/src/renderer/src/panel/useChooserHandoff.ts
+++ b/src/renderer/src/panel/useChooserHandoff.ts
@@ -12,7 +12,7 @@ export interface ChooserHandoffOpts {
   switchPanel: (
     panel: PanelKey,
     entrypoint?: string,
-    newInstallOpts?: { workspaceId?: string }
+    newInstallOpts?: { workspaceId: string }
   ) => Promise<void>
 }
 
@@ -38,7 +38,7 @@ export interface ChooserHandoffApi {
   /** Bound to ChooserView's `pick` emit. */
   handleChooserPick: (installation: Installation, opts?: { isRestart?: boolean }) => Promise<void>
   /** Bound to ChooserView's `show-new-install` empty-state CTA. */
-  handleChooserShowNewInstall: (workspaceId?: string) => void
+  handleChooserShowNewInstall: (workspaceId: string) => void
   /** Picker variant of `performChooserLaunch` without
    *  `prepareChooserHostHandoff`, so the install-backed host isn't
    *  swapped out; launch lands in a fresh window. */
@@ -154,7 +154,7 @@ export function useChooserHandoff(opts: ChooserHandoffOpts): ChooserHandoffApi {
     return 'launched'
   }
 
-  function handleChooserShowNewInstall(workspaceId?: string): void {
+  function handleChooserShowNewInstall(workspaceId: string): void {
     // Empty-state CTA opens new-install as a takeover above the chooser
     // body, so dismissing it returns the user to the chooser.
     void opts.switchPanel('new-install', 'chooser', { workspaceId })

--- a/src/renderer/src/panel/usePanelOverlays.ts
+++ b/src/renderer/src/panel/usePanelOverlays.ts
@@ -10,6 +10,7 @@ import { useProgressStore } from '../stores/progressStore'
 import { emitTelemetryAction } from '../lib/telemetry'
 import type { ActionResult, ShowProgressOpts } from '../types/ipc'
 import type { FirstUseMode } from '../../../shared/firstUseMode'
+import { DASHBOARD_WORKSPACE_SETTING, PERSONAL_WORKSPACE_ID } from '../../../shared/workspaces'
 
 /**
  * Panel body modes available in the WebContentsView.
@@ -381,9 +382,15 @@ export function usePanelOverlays(opts: UsePanelOverlaysOpts): UsePanelOverlaysAp
       const cameFromLocalBranch = opts.firstUseChain
         ? opts.firstUseChain.consumeCameFromLocalBranch() === true
         : false
+      const persistedWorkspaceId = await window.api.getSetting(DASHBOARD_WORKSPACE_SETTING)
+      const workspaceId =
+        newInstallOpts.workspaceId ??
+        (typeof persistedWorkspaceId === 'string' && persistedWorkspaceId.trim()
+          ? persistedWorkspaceId
+          : PERSONAL_WORKSPACE_ID)
       await newInstallRef.value?.open({
         entrypoint,
-        ...newInstallOpts,
+        workspaceId,
         ...(cameFromLocalBranch ? { cameFromLocalBranch } : {})
       })
     } else if (component === 'track') trackRef.value?.open()

--- a/src/renderer/src/panel/usePanelOverlays.ts
+++ b/src/renderer/src/panel/usePanelOverlays.ts
@@ -382,12 +382,16 @@ export function usePanelOverlays(opts: UsePanelOverlaysOpts): UsePanelOverlaysAp
       const cameFromLocalBranch = opts.firstUseChain
         ? opts.firstUseChain.consumeCameFromLocalBranch() === true
         : false
-      const persistedWorkspaceId = await window.api.getSetting(DASHBOARD_WORKSPACE_SETTING)
-      const workspaceId =
-        newInstallOpts.workspaceId ??
-        (typeof persistedWorkspaceId === 'string' && persistedWorkspaceId.trim()
-          ? persistedWorkspaceId
-          : PERSONAL_WORKSPACE_ID)
+      let workspaceId = newInstallOpts.workspaceId
+      if (!workspaceId) {
+        const persistedWorkspaceId = await window.api
+          .getSetting(DASHBOARD_WORKSPACE_SETTING)
+          .catch(() => undefined)
+        workspaceId =
+          typeof persistedWorkspaceId === 'string' && persistedWorkspaceId.trim()
+            ? persistedWorkspaceId
+            : PERSONAL_WORKSPACE_ID
+      }
       await newInstallRef.value?.open({
         entrypoint,
         workspaceId,

--- a/src/renderer/src/stores/authStore.ts
+++ b/src/renderer/src/stores/authStore.ts
@@ -2,6 +2,7 @@ import { computed, onScopeDispose, ref } from 'vue'
 import { defineStore } from 'pinia'
 
 import type { AuthStatus, ElectronApi, Workspace } from '../../../types/ipc'
+import { isPersonalWorkspace } from '../../../shared/workspaces'
 import type { Build } from '../devplatform/types'
 
 /**
@@ -145,6 +146,7 @@ export const useAuthStore = defineStore('auth', () => {
   })
 
   const isSignedIn = computed(() => status.value.signedIn)
+  const personalWorkspace = computed(() => workspaces.value.find(isPersonalWorkspace) ?? null)
 
   /** The builds published to the signed-in workspace, as display rows. */
   async function fetchBuilds(): Promise<Build[]> {
@@ -181,6 +183,7 @@ export const useAuthStore = defineStore('auth', () => {
     workspacesError,
     buildsError,
     isSignedIn,
+    personalWorkspace,
     fetchStatus,
     signIn,
     signOut,

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -662,6 +662,10 @@ describe('ChooserView', () => {
     expect(wrapper.get('[data-testid="devplatform-workspace-selector"]').text()).toContain(
       'Personal'
     )
+    expect(wrapper.get('.chooser-workspace-controls').classes()).toContain(
+      'chooser-workspace-controls--no-refresh'
+    )
+    expect(wrapper.find('[data-testid="chooser-workspace-refresh"]').exists()).toBe(false)
   })
 
   it('renders the dashboard as one left-aligned instance grid', async () => {
@@ -685,6 +689,7 @@ describe('ChooserView', () => {
     const controls = wrapper.get('.chooser-workspace-controls')
     const selector = wrapper.get('[data-testid="devplatform-workspace-selector"]')
     const refresh = wrapper.get('[data-testid="chooser-workspace-refresh"]')
+    expect(controls.classes()).not.toContain('chooser-workspace-controls--no-refresh')
     expect(controls.element.parentElement).toBe(workspaceBar.element)
     expect(selector.element.closest('.chooser-workspace-controls')).toBe(controls.element)
     expect(

--- a/src/renderer/src/views/ChooserView.test.ts
+++ b/src/renderer/src/views/ChooserView.test.ts
@@ -70,7 +70,6 @@ const messages = {
     devPlatform: {
       workspace: {
         personalLabel: 'Personal',
-        unmanagedLabel: 'No workspace',
         switchLabel: 'Workspace',
         currentFallback: 'Current workspace',
         instanceCountLabel: 'INSTANCES',
@@ -95,6 +94,7 @@ interface MockApi {
   onInstallationsChanged: ReturnType<typeof vi.fn>
   onInstallationsVersionsUpdated: ReturnType<typeof vi.fn>
   getSetting: ReturnType<typeof vi.fn>
+  setSetting: ReturnType<typeof vi.fn>
   runAction: ReturnType<typeof vi.fn>
   // progressStore subscribes to onErrorDetail at construction time.
   onErrorDetail: ReturnType<typeof vi.fn>
@@ -112,6 +112,7 @@ function installMockApi(initial: Installation[]): MockApi {
     onInstallationsChanged: vi.fn(() => () => {}),
     onInstallationsVersionsUpdated: vi.fn(() => () => {}),
     getSetting: vi.fn().mockResolvedValue(undefined),
+    setSetting: vi.fn().mockResolvedValue(undefined),
     runAction: vi.fn().mockResolvedValue({ ok: true }),
     onErrorDetail: vi.fn(() => () => {}),
     focusComfyWindow: vi.fn().mockResolvedValue(true),
@@ -208,8 +209,7 @@ describe('ChooserView', () => {
     const wrapper = mountChooser()
     await flushPromises()
     await wrapper.find('.chooser-tile-new').trigger('click')
-    expect(wrapper.emitted('show-new-install')).toBeDefined()
-    expect(wrapper.emitted('show-new-install')!.length).toBe(1)
+    expect(wrapper.emitted('show-new-install')).toEqual([['personal']])
   })
 
   it('renders a cloud install through the same tile component as local installs', async () => {
@@ -629,7 +629,7 @@ describe('ChooserView', () => {
     expect(wrapper.text()).not.toContain('WrongPlatformThing')
   })
 
-  it('shows only installs without a workspace when signed out', async () => {
+  it('shows the Personal workspace and its legacy and canonical installs when signed out', async () => {
     installMockApi([
       makeInstall({
         id: 'builder-1',
@@ -638,6 +638,12 @@ describe('ChooserView', () => {
         distributionId: 'd-unassigned',
         status: 'installed'
       } as unknown as Partial<Installation>),
+      makeInstall({
+        id: 'personal-1',
+        name: 'Personal Studio',
+        workspaceId: 'personal',
+        status: 'installed'
+      }),
       makeInstall({
         id: 'builder-2',
         name: 'Workspace Studio',
@@ -651,8 +657,11 @@ describe('ChooserView', () => {
     await flushPromises()
     const names = wrapper.findAll('.chooser-tile-name').map((w) => w.text())
     expect(names).toContain('Unassigned Studio')
+    expect(names).toContain('Personal Studio')
     expect(names).not.toContain('Workspace Studio')
-    expect(wrapper.find('[data-testid="devplatform-workspace-selector"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="devplatform-workspace-selector"]').text()).toContain(
+      'Personal'
+    )
   })
 
   it('renders the dashboard as one left-aligned instance grid', async () => {
@@ -740,7 +749,7 @@ describe('ChooserView', () => {
     const wrapper = mountChooser()
     await flushPromises()
     await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
-    await wrapper.get('[data-testid="devplatform-workspace-unmanaged"]').trigger('click')
+    await wrapper.get('[data-testid="devplatform-workspace-personal"]').trigger('click')
     await flushPromises()
 
     const tile = wrapper.find(`[data-testid="${TID.dashboardTile('local')}"]`)
@@ -790,7 +799,7 @@ describe('ChooserView', () => {
       await flushPromises()
       if (useUnmanaged) {
         await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
-        await wrapper.get('[data-testid="devplatform-workspace-unmanaged"]').trigger('click')
+        await wrapper.get('[data-testid="devplatform-workspace-personal"]').trigger('click')
         await flushPromises()
       }
 
@@ -858,7 +867,7 @@ describe('ChooserView', () => {
     expect(wrapper.text()).not.toContain('AvailableThing')
   })
 
-  it('switches between No workspace and workspaces without leaking other-workspace installs', async () => {
+  it('switches between Personal and team workspaces without leaking other-workspace installs', async () => {
     const api = installMockApiSignedIn(
       [
         makeInstall({ id: 'local', name: 'LocalThing' }),
@@ -897,7 +906,7 @@ describe('ChooserView', () => {
     expect(wrapper.text()).not.toContain('LocalThing')
 
     await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
-    await wrapper.get('[data-testid="devplatform-workspace-unmanaged"]').trigger('click')
+    await wrapper.get('[data-testid="devplatform-workspace-personal"]').trigger('click')
     await flushPromises()
     expect(wrapper.text()).toContain('LocalThing')
     expect(wrapper.text()).not.toContain('Workspace A Build')
@@ -918,7 +927,7 @@ describe('ChooserView', () => {
     expect(wrapper.text()).not.toContain('Workspace B Build')
   })
 
-  it('emits the selected workspace only for workspace-scoped New Instance', async () => {
+  it('always emits the selected workspace for New Instance', async () => {
     installMockApiSignedIn([], [], { id: 'w1', name: 'Comfy Design Team' })
     const wrapper = mountChooser()
     await flushPromises()
@@ -927,10 +936,10 @@ describe('ChooserView', () => {
     expect(wrapper.emitted('show-new-install')?.at(-1)).toEqual(['w1'])
 
     await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
-    await wrapper.get('[data-testid="devplatform-workspace-unmanaged"]').trigger('click')
+    await wrapper.get('[data-testid="devplatform-workspace-personal"]').trigger('click')
     await flushPromises()
     await wrapper.get('.chooser-tile-new').trigger('click')
-    expect(wrapper.emitted('show-new-install')?.at(-1)).toEqual([])
+    expect(wrapper.emitted('show-new-install')?.at(-1)).toEqual(['personal'])
   })
 
   it('shows the no-matches state for the selected workspace search', async () => {

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -20,6 +20,11 @@ import DevPlatformAccountChip from './devplatform/DevPlatformAccountChip.vue'
 import DevPlatformWorkspaceSelector from './devplatform/DevPlatformWorkspaceSelector.vue'
 import { resolvePickerTab } from '../lib/pickerTabs'
 import type { CloudUserTier, Installation, ShowProgressOpts } from '../types/ipc'
+import {
+  DASHBOARD_WORKSPACE_SETTING,
+  PERSONAL_WORKSPACE_ID,
+  workspaceContextId
+} from '../../../shared/workspaces'
 
 /**
  * Chooser view - recents grid.
@@ -28,8 +33,9 @@ import type { CloudUserTier, Installation, ShowProgressOpts } from '../types/ipc
  * window hosts this as the Comfy tab body when no install backs the
  * entry.
  *
- * Signed-in users choose either No workspace or one authenticated workspace.
- * The grid contains only installed instances in that scope.
+ * Every user has a local Personal workspace. Signed-in users additionally see
+ * authenticated team workspaces; the server Personal workspace merges into
+ * the local Personal scope.
  * Available Builds belong in the workspace New Instance flow, not this grid.
  */
 
@@ -47,7 +53,7 @@ const emit = defineEmits<{
    *  open a fresh window, or hand off to a launch flow. */
   pick: [installation: Installation]
   /** User triggered the new-install flow in the current dashboard scope. */
-  'show-new-install': [workspaceId?: string]
+  'show-new-install': [workspaceId: string]
   /** A long-running action was kicked off from the inline Manage...
    *  DetailModal. Forwarded to PanelApp so it can wire the operation
    *  through `progressStore`. */
@@ -91,14 +97,28 @@ defineExpose({ activeFilter })
 
 // --- Dashboard scope ---
 
-const selectedWorkspaceId = ref<string | null>(null)
+const selectedWorkspaceId = ref(PERSONAL_WORKSPACE_ID)
 let dashboardScopeInitialized = false
 
+function setSelectedWorkspace(workspaceId: string): void {
+  selectedWorkspaceId.value = workspaceId
+  void window.api.setSetting(DASHBOARD_WORKSPACE_SETTING, workspaceId)
+}
+
+const selectedWorkspaceModel = computed({
+  get: () => selectedWorkspaceId.value,
+  set: setSelectedWorkspace
+})
+
 watch(
-  () => ({ signedIn: authStore.isSignedIn, workspaceId: authStore.status.workspaceId }),
+  () => ({
+    signedIn: authStore.isSignedIn,
+    workspaceId: authStore.status.workspaceId,
+    workspaceType: authStore.status.workspaceType
+  }),
   (next, previous) => {
     if (!next.signedIn) {
-      selectedWorkspaceId.value = null
+      setSelectedWorkspace(PERSONAL_WORKSPACE_ID)
       dashboardScopeInitialized = false
       return
     }
@@ -110,23 +130,26 @@ watch(
       void authStore.fetchBuilds()
     }
     if (!dashboardScopeInitialized) {
-      selectedWorkspaceId.value = next.workspaceId ?? null
+      setSelectedWorkspace(workspaceContextId(authStore.status))
       dashboardScopeInitialized = true
       return
     }
     // Follow an external authenticated workspace switch only while the user is
-    // viewing that workspace. An explicit No workspace selection remains local.
-    if (selectedWorkspaceId.value !== null && selectedWorkspaceId.value === previous?.workspaceId) {
-      selectedWorkspaceId.value = next.workspaceId ?? null
+    // viewing that workspace. An explicit Personal/team selection remains local.
+    if (
+      previous &&
+      selectedWorkspaceId.value === workspaceContextId(previous) &&
+      workspaceContextId(authStore.status) !== selectedWorkspaceId.value
+    ) {
+      setSelectedWorkspace(workspaceContextId(authStore.status))
     }
   },
   { immediate: true }
 )
 
 function installationIsInSelectedScope(inst: Installation): boolean {
-  if (!authStore.isSignedIn) return inst.workspaceId === undefined
-  return selectedWorkspaceId.value === null
-    ? inst.workspaceId === undefined
+  return selectedWorkspaceId.value === PERSONAL_WORKSPACE_ID
+    ? inst.workspaceId === undefined || inst.workspaceId === PERSONAL_WORKSPACE_ID
     : inst.workspaceId === selectedWorkspaceId.value
 }
 
@@ -316,11 +339,7 @@ onMounted(async () => {
   }
 })
 function handleNewInstallClick(): void {
-  if (authStore.isSignedIn && selectedWorkspaceId.value) {
-    emit('show-new-install', selectedWorkspaceId.value)
-  } else {
-    emit('show-new-install')
-  }
+  emit('show-new-install', selectedWorkspaceId.value)
 }
 
 const gridHandlers = {
@@ -338,11 +357,7 @@ const gridHandlers = {
 
 <template>
   <BrandBackground v-show="props.visible" class="chooser-bg">
-    <div
-      class="chooser-view"
-      :class="{ 'chooser-view--workspace': authStore.isSignedIn }"
-      :style="{ '--rows': clusterRows }"
-    >
+    <div class="chooser-view chooser-view--workspace" :style="{ '--rows': clusterRows }">
       <!-- Signed-in account identity, pinned outside the centered content column. -->
       <div class="chooser-account">
         <DevPlatformAccountChip />
@@ -361,10 +376,11 @@ const gridHandlers = {
         </div>
       </div>
 
-      <div v-if="authStore.isSignedIn" class="chooser-workspace-bar">
+      <div class="chooser-workspace-bar">
         <div class="chooser-workspace-controls">
-          <DevPlatformWorkspaceSelector v-model="selectedWorkspaceId" />
+          <DevPlatformWorkspaceSelector v-model="selectedWorkspaceModel" />
           <button
+            v-if="authStore.isSignedIn"
             type="button"
             class="chooser-workspace-refresh"
             :disabled="refreshingWorkspace"
@@ -659,7 +675,8 @@ const gridHandlers = {
   background: var(--chooser-surface-border);
 }
 .chooser-workspace-controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px;
   flex: 0 1 290px;
   align-items: center;
   gap: 8px;
@@ -679,7 +696,7 @@ const gridHandlers = {
   font-weight: 600;
 }
 .chooser-workspace-controls :deep(.workspace-selector) {
-  flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
 }
 .chooser-workspace-controls :deep(.workspace-selector__face) {
@@ -688,6 +705,12 @@ const gridHandlers = {
   width: 100%;
   min-width: 180px;
   padding: 4px 8px;
+}
+.chooser-workspace-controls :deep(.workspace-selector__menu) {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
 }
 .chooser-workspace-refresh {
   display: inline-flex;

--- a/src/renderer/src/views/ChooserView.vue
+++ b/src/renderer/src/views/ChooserView.vue
@@ -377,7 +377,10 @@ const gridHandlers = {
       </div>
 
       <div class="chooser-workspace-bar">
-        <div class="chooser-workspace-controls">
+        <div
+          class="chooser-workspace-controls"
+          :class="{ 'chooser-workspace-controls--no-refresh': !authStore.isSignedIn }"
+        >
           <DevPlatformWorkspaceSelector v-model="selectedWorkspaceModel" />
           <button
             v-if="authStore.isSignedIn"
@@ -675,12 +678,22 @@ const gridHandlers = {
   background: var(--chooser-surface-border);
 }
 .chooser-workspace-controls {
+  --chooser-workspace-refresh-size: 30px;
+  --chooser-workspace-refresh-gap: 8px;
+
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 30px;
+  grid-template-columns: minmax(0, 1fr) var(--chooser-workspace-refresh-size);
   flex: 0 1 290px;
   align-items: center;
-  gap: 8px;
+  gap: var(--chooser-workspace-refresh-gap);
   min-width: 0;
+}
+.chooser-workspace-controls--no-refresh {
+  grid-template-columns: minmax(0, 1fr);
+  flex-basis: calc(
+    290px - var(--chooser-workspace-refresh-size) - var(--chooser-workspace-refresh-gap)
+  );
+  gap: 0;
 }
 .chooser-workspace-count {
   display: flex;
@@ -716,8 +729,8 @@ const gridHandlers = {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: var(--chooser-workspace-refresh-size);
+  height: var(--chooser-workspace-refresh-size);
   padding: 0;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -757,6 +770,12 @@ const gridHandlers = {
 
   .chooser-workspace-controls {
     flex-basis: 100%;
+  }
+
+  .chooser-workspace-controls--no-refresh {
+    flex-basis: calc(
+      100% - var(--chooser-workspace-refresh-size) - var(--chooser-workspace-refresh-gap)
+    );
   }
 
   .chooser-workspace-count {

--- a/src/renderer/src/views/InstallWizardModal.test.ts
+++ b/src/renderer/src/views/InstallWizardModal.test.ts
@@ -19,7 +19,11 @@ function mountModal() {
   return mount(InstallWizardModal, {
     global: {
       plugins: [makeI18n(), pinia],
-      stubs: { BrandTakeoverLayout: { template: '<div><slot /></div>' } }
+      stubs: {
+        BrandTakeoverLayout: {
+          template: '<div><slot /><slot name="footer-left" /><slot name="footer" /></div>'
+        }
+      }
     }
   })
 }
@@ -233,7 +237,11 @@ describe('InstallWizardModal workspace Builds', () => {
 
   it('switches directly from Managed to a peer source tab', async () => {
     ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { id: 'standalone', label: 'Standalone', fields: [] },
+      {
+        id: 'standalone',
+        label: 'Standalone',
+        fields: [{ id: 'version', label: 'Version', type: 'select' }]
+      },
       {
         id: 'remote',
         label: 'Remote Connection',
@@ -255,6 +263,14 @@ describe('InstallWizardModal workspace Builds', () => {
     )
     expect(wrapper.find('[data-testid="workspace-build-field"]').exists()).toBe(false)
     expect(wrapper.get('#source-fields').text()).toContain('Server URL')
+    expect(window.api.getFieldOptions).not.toHaveBeenCalled()
+    expect(window.api.validateHardware).not.toHaveBeenCalled()
+
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
+    await flushPromises()
+
+    expect(window.api.validateHardware).toHaveBeenCalledOnce()
+    expect(window.api.getFieldOptions).toHaveBeenCalledOnce()
   })
 
   it('shows Build metadata in the dropdown without a separate details panel', async () => {
@@ -459,7 +475,7 @@ describe('InstallWizardModal workspace Builds', () => {
     await wrapper.get('[data-testid="workspace-install-source-managed"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.get('.brand-lead').text()).toBe('Select a release to install.')
+    expect(wrapper.get('.brand-lead').text()).toBe('Set up a fresh ComfyUI environment.')
     expect(wrapper.get('[data-testid="workspace-build-field"]').exists()).toBe(true)
     expect(wrapper.find('.config-advanced').exists()).toBe(false)
     expect(wrapper.getComponent(PathDiskInfo).props('estimatedSize')).toBe(4_500)
@@ -512,7 +528,7 @@ describe('InstallWizardModal workspace Builds', () => {
     signInToWorkspace([{ id: 'none', name: 'No Build Yet', state: 'no-build' }])
     const wrapper = await openWorkspaceModal()
 
-    expect(wrapper.get('.brand-lead').text()).toBe('Select a release to install.')
+    expect(wrapper.get('.brand-lead').text()).toBe('Set up a fresh ComfyUI environment.')
     expect(wrapper.get('[data-testid="workspace-build-field"]').text()).toContain(
       'No compatible Builds are available to install.'
     )

--- a/src/renderer/src/views/InstallWizardModal.test.ts
+++ b/src/renderer/src/views/InstallWizardModal.test.ts
@@ -90,6 +90,46 @@ describe('InstallWizardModal heading', () => {
     const fieldLabel = wrapper.get('#source-fields label')
     expect(fieldLabel.classes()).toContain('config-label')
     expect(fieldLabel.text()).toBe('ComfyUI version')
+    expect(
+      wrapper
+        .get('[data-testid="install-source-tabs"]')
+        .findAll('button')
+        .map((button) => button.text())
+    ).toEqual(['Public Builds', 'Managed Builds'])
+    expect(
+      wrapper.get('[data-testid="install-source-standalone"]').attributes('aria-checked')
+    ).toBe('true')
+    expect(
+      wrapper.get('[data-testid="workspace-install-source-managed"]').attributes('aria-checked')
+    ).toBe('false')
+  })
+
+  it('starts sign-in when a signed-out user selects Managed Builds', async () => {
+    ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'standalone', label: 'Standalone', fields: [] }
+    ])
+    const status = {
+      signedIn: true,
+      workspaceId: 'personal-server-id',
+      workspaceType: 'personal'
+    }
+    ;(window.api.comfybuilder.signIn as ReturnType<typeof vi.fn>).mockResolvedValue(status)
+    ;(window.api.comfybuilder.listBuilds as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'ready', name: 'Ready Build', state: 'installable' }
+    ])
+    const wrapper = mountModal()
+    ;(wrapper.vm as unknown as { open: () => Promise<void> }).open()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="workspace-install-source-managed"]').trigger('click')
+    await flushPromises()
+
+    expect(window.api.comfybuilder.signIn).toHaveBeenCalledOnce()
+    expect(window.api.comfybuilder.listBuilds).toHaveBeenCalledOnce()
+    expect(
+      wrapper.get('[data-testid="workspace-install-source-managed"]').attributes('aria-checked')
+    ).toBe('true')
+    expect(wrapper.get('[data-testid="workspace-build-field"]').text()).toContain('Ready Build')
   })
 })
 
@@ -145,6 +185,11 @@ describe('InstallWizardModal workspace Builds', () => {
   }
 
   it('shows compatible Builds even when their releases are already installed', async () => {
+    ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'standalone', label: 'Standalone', fields: [] },
+      { id: 'portable', label: 'Portable', fields: [] },
+      { id: 'remote', label: 'Remote Connection', fields: [] }
+    ])
     signInToWorkspace([
       { id: 'ready', name: 'Ready Build', state: 'installable' },
       { id: 'none', name: 'No Build Yet', state: 'no-build' },
@@ -164,9 +209,18 @@ describe('InstallWizardModal workspace Builds', () => {
       wrapper.get('[data-testid="workspace-install-source-managed"]').attributes()
     ).toMatchObject({ 'aria-checked': 'true' })
     expect(
-      wrapper.get('[data-testid="workspace-install-source-public"]').attributes()
-    ).toMatchObject({ 'aria-checked': 'false' })
+      wrapper.get('[data-testid="install-source-standalone"]').attributes('aria-checked')
+    ).toBe('false')
+    expect(
+      wrapper
+        .get('[data-testid="install-source-tabs"]')
+        .findAll('button')
+        .map((button) => button.text())
+    ).toEqual(['Public Builds', 'Managed Builds', 'Remote Connection', 'Portable'])
+    expect(wrapper.get('[data-testid="install-source-tabs"]').text()).not.toContain('RECOMMENDED')
+    expect(wrapper.find('[data-testid="workspace-install-source-public"]').exists()).toBe(false)
     expect(wrapper.find('.config-advanced').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="workspace-build-field"] label').text()).toBe('Release')
     const buildSelect = wrapper.getComponent(BaseSelect)
     expect(buildSelect.props('options')).toEqual([
       { value: 'ready', label: 'Ready Build' },
@@ -175,6 +229,32 @@ describe('InstallWizardModal workspace Builds', () => {
       { value: 'update', label: 'Updated Build' }
     ])
     expect(buildSelect.props('modelValue')).toBe('ready')
+  })
+
+  it('switches directly from Managed to a peer source tab', async () => {
+    ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'standalone', label: 'Standalone', fields: [] },
+      {
+        id: 'remote',
+        label: 'Remote Connection',
+        skipInstall: true,
+        fields: [{ id: 'url', label: 'Server URL', type: 'text' }]
+      }
+    ])
+    signInToWorkspace([{ id: 'ready', name: 'Ready Build', state: 'installable' }])
+    const wrapper = await openWorkspaceModal()
+
+    await wrapper.get('[data-testid="install-source-remote"]').trigger('click')
+    await flushPromises()
+
+    expect(
+      wrapper.get('[data-testid="workspace-install-source-managed"]').attributes('aria-checked')
+    ).toBe('false')
+    expect(wrapper.get('[data-testid="install-source-remote"]').attributes('aria-checked')).toBe(
+      'true'
+    )
+    expect(wrapper.find('[data-testid="workspace-build-field"]').exists()).toBe(false)
+    expect(wrapper.get('#source-fields').text()).toContain('Server URL')
   })
 
   it('shows Build metadata in the dropdown without a separate details panel', async () => {
@@ -228,7 +308,7 @@ describe('InstallWizardModal workspace Builds', () => {
     ])
   })
 
-  it('uses the existing local installer and template picker for Public builds', async () => {
+  it('uses the existing local installer and template picker for Standalone', async () => {
     signInToWorkspace([{ id: 'ready', name: 'Ready Build', state: 'installable' }])
     ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
@@ -243,10 +323,12 @@ describe('InstallWizardModal workspace Builds', () => {
     ])
     const wrapper = await openWorkspaceModal()
 
-    expect(wrapper.get('[data-testid="workspace-install-source-managed"]').text()).toBe('Managed')
-    expect(wrapper.get('[data-testid="workspace-install-source-public"]').text()).toBe('Public')
+    expect(wrapper.get('[data-testid="workspace-install-source-managed"]').text()).toBe(
+      'Managed Builds'
+    )
+    expect(wrapper.find('[data-testid="workspace-install-source-public"]').exists()).toBe(false)
 
-    await wrapper.get('[data-testid="workspace-install-source-public"]').trigger('click')
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
     await flushPromises()
 
     expect(wrapper.get('.brand-lead').text()).toBe('Set up a fresh ComfyUI environment.')
@@ -270,7 +352,7 @@ describe('InstallWizardModal workspace Builds', () => {
     expect(window.api.comfybuilder.installBuild).not.toHaveBeenCalled()
   })
 
-  it('assigns a Public install to the selected workspace', async () => {
+  it('assigns a Standalone install to the selected workspace', async () => {
     signInToWorkspace([{ id: 'ready', name: 'Ready Build', state: 'installable' }])
     ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
@@ -288,7 +370,7 @@ describe('InstallWizardModal workspace Builds', () => {
     })
     const wrapper = await openWorkspaceModal()
 
-    await wrapper.get('[data-testid="workspace-install-source-public"]').trigger('click')
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
     await flushPromises()
     await wrapper.get('.config-continue').trigger('click')
     await flushPromises()
@@ -300,6 +382,54 @@ describe('InstallWizardModal workspace Builds', () => {
       status: 'installing',
       workspaceId: 'w1'
     })
+  })
+
+  it('uses the server Personal workspace for Builds but persists the stable local context', async () => {
+    const status = {
+      signedIn: true,
+      workspaceId: 'server-personal-id',
+      workspaceType: 'team',
+      workspaceName: 'Personal workspace'
+    }
+    ;(window.api.comfybuilder.getAuthStatus as ReturnType<typeof vi.fn>).mockResolvedValue(status)
+    ;(window.api.comfybuilder.listBuilds as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'ready', name: 'Personal Build', state: 'installable' }
+    ])
+    ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: 'standalone',
+        label: 'Standalone',
+        fields: [{ id: 'variant', label: 'Hardware', type: 'select' }]
+      }
+    ])
+    ;(window.api.getFieldOptions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { value: 'cpu', label: 'CPU' }
+    ])
+    ;(window.api.addInstallation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      entry: { id: 'personal-public', name: 'ComfyUI' }
+    })
+    const wrapper = mountModal()
+    await flushPromises()
+
+    await (
+      wrapper.vm as unknown as { open: (opts: { workspaceId: string }) => Promise<void> }
+    ).open({ workspaceId: 'personal' })
+    await flushPromises()
+
+    expect(window.api.comfybuilder.switchWorkspace).not.toHaveBeenCalled()
+    expect(wrapper.getComponent(BaseSelect).props('options')).toEqual([
+      { value: 'ready', label: 'Personal Build' }
+    ])
+
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('.config-continue').trigger('click')
+    await flushPromises()
+
+    expect(window.api.addInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'personal' })
+    )
   })
 
   it('switches back to cached Managed builds without another catalog request', async () => {
@@ -322,7 +452,7 @@ describe('InstallWizardModal workspace Builds', () => {
     ])
     const wrapper = await openWorkspaceModal()
 
-    await wrapper.get('[data-testid="workspace-install-source-public"]').trigger('click')
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
     await flushPromises()
     expect(wrapper.getComponent(PathDiskInfo).props('estimatedSize')).toBe(2_250)
 
@@ -355,8 +485,8 @@ describe('InstallWizardModal workspace Builds', () => {
     })
     const wrapper = await openWorkspaceModal()
 
-    // Visit Public (loads standalone template options), then return to Managed.
-    await wrapper.get('[data-testid="workspace-install-source-public"]').trigger('click')
+    // Visit Standalone (loads template options), then return to Managed.
+    await wrapper.get('[data-testid="install-source-standalone"]').trigger('click')
     await flushPromises()
     await wrapper.get('[data-testid="workspace-install-source-managed"]').trigger('click')
     await flushPromises()
@@ -539,7 +669,9 @@ describe('InstallWizardModal workspace Builds', () => {
     const wrapper = await openWorkspaceModal()
 
     expect(wrapper.find('.config-advanced').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="workspace-build-targets"]').isVisible()).toBe(true)
+    const targetSection = wrapper.get('[data-testid="workspace-build-targets"]')
+    expect(targetSection.isVisible()).toBe(true)
+    expect(targetSection.get('label').text()).toBe('Hardware')
     const targetPicker = wrapper.getComponent(BrandVariantList)
     expect(targetPicker.props('options')).toEqual([
       {

--- a/src/renderer/src/views/InstallWizardModal.test.ts
+++ b/src/renderer/src/views/InstallWizardModal.test.ts
@@ -8,6 +8,7 @@ import InstallWizardModal from './InstallWizardModal.vue'
 import BaseSelect from '../components/ui/BaseSelect.vue'
 import BrandVariantList from '../components/BrandVariantList.vue'
 import PathDiskInfo from '../components/PathDiskInfo.vue'
+import { useModal } from '../composables/useModal'
 
 function makeI18n() {
   return createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -29,6 +30,7 @@ function mountModal() {
 }
 
 beforeEach(() => {
+  useModal().dismiss()
   window.api = {
     openPath: vi.fn().mockResolvedValue(undefined),
     browseFolder: vi.fn().mockResolvedValue('/home/user/Picked'),
@@ -134,6 +136,36 @@ describe('InstallWizardModal heading', () => {
       wrapper.get('[data-testid="workspace-install-source-managed"]').attributes('aria-checked')
     ).toBe('true')
     expect(wrapper.get('[data-testid="workspace-build-field"]').text()).toContain('Ready Build')
+  })
+
+  it('reports a workspace load failure when Managed Builds cannot resolve Personal', async () => {
+    ;(window.api.getSources as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'standalone', label: 'Standalone', fields: [] }
+    ])
+    ;(window.api.comfybuilder.signIn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      signedIn: true,
+      workspaceId: 'team-workspace',
+      workspaceType: 'team'
+    })
+    ;(window.api.comfybuilder.listWorkspaces as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('offline')
+    )
+    const wrapper = mountModal()
+    ;(wrapper.vm as unknown as { open: () => Promise<void> }).open()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="workspace-install-source-managed"]').trigger('click')
+    await flushPromises()
+
+    const modal = useModal()
+    expect(modal.state).toMatchObject({
+      visible: true,
+      type: 'alert',
+      title: 'Error',
+      message: "Couldn't load workspaces. Retry"
+    })
+    expect(window.api.comfybuilder.listBuilds).not.toHaveBeenCalled()
+    modal.dismiss()
   })
 })
 

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -604,6 +604,7 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   textFieldValues.value.clear()
 
   detectedGpu.value = t('newInstall.detectingGpu')
+  hardwareValidation = null
   hardwareWarning.value = ''
   resetDiskSpace()
   sourceError.value = ''
@@ -636,7 +637,11 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   }
 }
 
-async function initializeInstallMode(gen: number, refreshManagedBuilds = false): Promise<void> {
+async function initializeInstallMode(
+  gen: number,
+  refreshManagedBuilds = false,
+  source?: Source
+): Promise<void> {
   const installDir = await installDirPromise
   if (gen !== modeGeneration) return
   defaultInstPath.value = installDir ?? ''
@@ -645,7 +650,7 @@ async function initializeInstallMode(gen: number, refreshManagedBuilds = false):
   if (managedBuildMode.value) {
     await Promise.all([initializeManagedBuilds(gen, refreshManagedBuilds), loadSources()])
   } else {
-    await initializeLocalInstall(gen)
+    await initializeLocalInstall(gen, source)
   }
 }
 
@@ -676,7 +681,7 @@ async function initializeManagedBuilds(gen: number, refreshBuilds: boolean): Pro
   }
 }
 
-async function initializeLocalInstall(gen: number): Promise<void> {
+async function initializeLocalInstall(gen: number, requestedSource?: Source): Promise<void> {
   void window.api
     .getUniqueName(DEFAULT_INSTALL_NAME)
     .then((name) => {
@@ -704,14 +709,20 @@ async function initializeLocalInstall(gen: number): Promise<void> {
   await loadSources()
   if (gen !== modeGeneration || !localInstallMode.value) return
 
-  // Public Builds is the default local source.
+  const source = requestedSource ?? sources.value.find((source) => source.id === 'standalone')
+  if (!source) return
+
+  if (source.id !== 'standalone') {
+    await selectSourceCard(source)
+    return
+  }
+
   hardwareValidation = await window.api.validateHardware()
   if (gen !== modeGeneration || !localInstallMode.value) return
   hardwareWarning.value = hardwareValidation.warning ?? ''
-  const standalone = sources.value.find((source) => source.id === 'standalone')
-  if (standalone && hardwareValidation.supported) {
-    await selectSourceCard(standalone)
-  } else if (standalone) {
+  if (hardwareValidation.supported) {
+    await selectSourceCard(source)
+  } else {
     detectedGpu.value = hardwareValidation.error || t('newInstall.noGpuDetected')
   }
 }
@@ -764,10 +775,7 @@ async function selectSourceCard(source: Source): Promise<void> {
     const gen = ++modeGeneration
     initializing.value = true
     try {
-      await initializeInstallMode(gen)
-      if (gen === modeGeneration && currentSource.value?.id !== source.id) {
-        await selectSourceCard(source)
-      }
+      await initializeInstallMode(gen, false, source)
     } finally {
       if (gen === modeGeneration) initializing.value = false
     }
@@ -775,6 +783,10 @@ async function selectSourceCard(source: Source): Promise<void> {
   }
   if (currentSource.value?.id === source.id) return
 
+  if (source.id === 'standalone' && !hardwareValidation) {
+    hardwareValidation = await window.api.validateHardware()
+    hardwareWarning.value = hardwareValidation.warning ?? ''
+  }
   if (source.id === 'standalone' && hardwareValidation && !hardwareValidation.supported) {
     trackGuardrailBlocked('unsupported_hw', 'wizard', 'source_select')
     await modal.alert({
@@ -1248,12 +1260,10 @@ defineExpose({ open })
 </script>
 
 <template>
-  <BrandTakeoverLayout>
+  <BrandTakeoverLayout :scroll-content="step === 'configure'">
     <div v-if="step === 'configure'" ref="brandShellRef" class="config-shell">
       <h1 class="brand-title">{{ $t('newInstall.configureTitle') }}</h1>
-      <p class="brand-lead">
-        {{ $t(managedBuildMode ? 'newInstall.configureWorkspaceLead' : 'chooser.newInstallDesc') }}
-      </p>
+      <p class="brand-lead">{{ $t('chooser.newInstallDesc') }}</p>
       <div class="config-card">
         <div class="config-card__body">
           <div
@@ -1570,22 +1580,14 @@ defineExpose({ open })
           </TooltipWrap>
         </div>
 
-        <div class="config-card__footer">
+        <div v-if="cameFromLocalBranch" class="config-card__footer">
           <button
-            v-if="cameFromLocalBranch"
             type="button"
             class="brand-ghost config-back"
             data-testid="config-back-to-local-branch"
             @click="handleBackToLocalBranch"
           >
             {{ $t('common.back') }}
-          </button>
-          <button
-            class="brand-primary config-continue"
-            :disabled="!canContinue"
-            @click="handleConfigureContinue"
-          >
-            {{ $t('common.continue') }}
           </button>
         </div>
       </div>
@@ -1661,24 +1663,28 @@ defineExpose({ open })
         @back="emit('close')"
       />
     </template>
+    <template #footer>
+      <button
+        v-if="step === 'configure'"
+        class="brand-primary config-continue"
+        :disabled="!canContinue"
+        @click="handleConfigureContinue"
+      >
+        {{ $t('common.continue') }}
+      </button>
+    </template>
   </BrandTakeoverLayout>
 </template>
 
 <style scoped>
 .config-shell {
   align-self: stretch;
-  height: 100%;
-  max-height: 100%;
   width: 100%;
   max-width: 640px;
   margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   text-align: center;
-  padding-block: clamp(1.5rem, 4vh, 3rem);
-  min-height: 0;
+  padding-top: clamp(1.5rem, 4vh, 3rem);
+  padding-bottom: max(5rem, 8vh);
 }
 .config-shell > .brand-lead {
   margin: var(--takeover-gap-sm) 0 var(--takeover-gap-md);
@@ -1819,10 +1825,6 @@ defineExpose({ open })
 
 .config-card {
   width: 100%;
-  /* Capped at shell height so the card doesn't overflow the viewport when Advanced expands; body scrolls instead. */
-  max-height: 100%;
-  display: flex;
-  flex-direction: column;
   border: 1px solid var(--brand-surface-border);
   border-radius: 8px;
   background: var(--brand-surface-bg);
@@ -1832,19 +1834,10 @@ defineExpose({ open })
 }
 
 .config-card__body {
-  /* `flex: 1 1 auto` lets this body absorb leftover space and scroll internally once the card hits the shell cap, keeping the title centered. */
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
   padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 18px;
-  /* Hide scrollbar to prevent layout shift when content overflows. */
-  scrollbar-width: none;
-}
-.config-card__body::-webkit-scrollbar {
-  display: none;
 }
 
 .workspace-authorization-status {
@@ -1875,7 +1868,8 @@ defineExpose({ open })
   z-index: 2;
 }
 
-.config-field {
+.config-field,
+#source-fields > .field {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -2062,6 +2056,9 @@ defineExpose({ open })
   border-top: 0;
   padding-top: 0;
 }
+.config-advanced--direct .config-advanced__wrap {
+  display: block;
+}
 .config-advanced--direct.config-advanced.is-open .config-advanced__body {
   margin-top: 0;
 }
@@ -2083,6 +2080,10 @@ defineExpose({ open })
 }
 
 .config-continue {
+  position: absolute;
+  right: clamp(1.25rem, 2vw, 2rem);
+  bottom: clamp(1.25rem, 2vw, 2rem);
+  z-index: 2;
   min-width: 120px;
 }
 </style>

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -743,7 +743,13 @@ async function selectManagedInstallMode(): Promise<void> {
       authorizingWorkspace.value = false
     }
   }
-  if (!managedWorkspaceId.value) return
+  if (!managedWorkspaceId.value) {
+    await modal.alert({
+      title: t('chooser.errorTitle'),
+      message: t('devPlatform.workspace.loadError')
+    })
+    return
+  }
   workspaceInstallMode.value = 'managed'
   // Managed installs must not inherit source or template selections.
   resetSourceState(null)

--- a/src/renderer/src/views/InstallWizardModal.vue
+++ b/src/renderer/src/views/InstallWizardModal.vue
@@ -15,6 +15,7 @@ import type {
 } from '../types/ipc'
 import { stripVariantPrefix, sortedCardOptions } from '../lib/variants'
 import { DEFAULT_INSTALL_NAME } from '../../../shared/defaultInstallName'
+import { PERSONAL_WORKSPACE_ID, workspaceContextId } from '../../../shared/workspaces'
 import { emitTelemetryAction, toSizeBucket, toVariantBucket, toErrorBucket } from '../lib/telemetry'
 import {
   trackGuardrailBlocked,
@@ -78,17 +79,50 @@ const sourceError = ref('')
 const workspaceId = ref<string | null>(null)
 const selectedBuildId = ref('')
 const selectedBuildTargetId = ref('')
-const workspaceMode = computed(() => workspaceId.value !== null)
+/** Resolve the local Personal scope to its server workspace for managed operations. */
+const managedWorkspaceId = computed(() => {
+  if (!authStore.isSignedIn || !workspaceId.value) return null
+  if (workspaceId.value !== PERSONAL_WORKSPACE_ID) return workspaceId.value
+  if (workspaceContextId(authStore.status) === PERSONAL_WORKSPACE_ID) {
+    return authStore.status.workspaceId ?? null
+  }
+  return authStore.personalWorkspace?.id ?? null
+})
 const workspaceInstallMode = ref<'managed' | 'public'>('managed')
 const managedBuildMode = computed(
-  () => workspaceMode.value && workspaceInstallMode.value === 'managed'
+  () => managedWorkspaceId.value !== null && workspaceInstallMode.value === 'managed'
 )
-const localInstallMode = computed(
-  () => !workspaceMode.value || workspaceInstallMode.value === 'public'
-)
+const localInstallMode = computed(() => !managedBuildMode.value)
+
+type InstallSourceTab =
+  | { key: 'managed'; kind: 'managed' }
+  | { key: string; kind: 'source'; source: Source }
+
+const installSourceTabs = computed<InstallSourceTab[]>(() => {
+  const sourceOrder = new Map([
+    ['standalone', 0],
+    ['remote', 1],
+    ['portable', 2]
+  ])
+  const tabs: InstallSourceTab[] = [...sources.value]
+    .sort(
+      (a, b) =>
+        (sourceOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+        (sourceOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER)
+    )
+    .map((source) => ({ key: `source-${source.id}`, kind: 'source', source }))
+
+  const standaloneIndex = tabs.findIndex(
+    (tab) => tab.kind === 'source' && tab.source.id === 'standalone'
+  )
+  tabs.splice(standaloneIndex + 1, 0, { key: 'managed', kind: 'managed' })
+
+  return tabs
+})
 
 const workspaceBuilds = computed(() => {
-  if (!workspaceId.value || authStore.status.workspaceId !== workspaceId.value) return []
+  if (!managedWorkspaceId.value || authStore.status.workspaceId !== managedWorkspaceId.value)
+    return []
   return authStore.builds.filter(
     (build) => build.state === 'installable' || build.state === 'update-available'
   )
@@ -552,8 +586,8 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   loadGeneration++
   const gen = ++modeGeneration
   instName.value = ''
-  workspaceId.value = opts.workspaceId?.trim() || null
-  workspaceInstallMode.value = 'managed'
+  workspaceId.value = opts.workspaceId?.trim() || PERSONAL_WORKSPACE_ID
+  workspaceInstallMode.value = 'public'
   selectedBuildId.value = ''
   selectedBuildTargetId.value = ''
   cameFromLocalBranch.value = opts.cameFromLocalBranch === true
@@ -583,6 +617,19 @@ async function open(opts: OpenOpts = {}): Promise<void> {
   hasLocalInstall.value = false
 
   try {
+    await authStore.fetchStatus().catch(() => authStore.status)
+    if (!authStore.isSignedIn) {
+      workspaceId.value = PERSONAL_WORKSPACE_ID
+    } else {
+      workspaceInstallMode.value = 'managed'
+    }
+    if (
+      workspaceId.value === PERSONAL_WORKSPACE_ID &&
+      authStore.isSignedIn &&
+      !managedWorkspaceId.value
+    ) {
+      await authStore.fetchWorkspaces()
+    }
     await initializeInstallMode(gen, true)
   } finally {
     if (gen === modeGeneration) initializing.value = false
@@ -595,12 +642,15 @@ async function initializeInstallMode(gen: number, refreshManagedBuilds = false):
   defaultInstPath.value = installDir ?? ''
   instPath.value = defaultInstPath.value
 
-  if (managedBuildMode.value) await initializeManagedBuilds(gen, refreshManagedBuilds)
-  else await initializeLocalInstall(gen)
+  if (managedBuildMode.value) {
+    await Promise.all([initializeManagedBuilds(gen, refreshManagedBuilds), loadSources()])
+  } else {
+    await initializeLocalInstall(gen)
+  }
 }
 
 async function initializeManagedBuilds(gen: number, refreshBuilds: boolean): Promise<void> {
-  const targetWorkspaceId = workspaceId.value
+  const targetWorkspaceId = managedWorkspaceId.value
   if (!targetWorkspaceId) return
   try {
     let status = authStore.status
@@ -654,8 +704,7 @@ async function initializeLocalInstall(gen: number): Promise<void> {
   await loadSources()
   if (gen !== modeGeneration || !localInstallMode.value) return
 
-  // Pre-select Standalone (the recommended method); other sources remain
-  // reachable through the same Advanced controls used outside workspaces.
+  // Public Builds is the default local source.
   hardwareValidation = await window.api.validateHardware()
   if (gen !== modeGeneration || !localInstallMode.value) return
   hardwareWarning.value = hardwareValidation.warning ?? ''
@@ -667,20 +716,31 @@ async function initializeLocalInstall(gen: number): Promise<void> {
   }
 }
 
-async function selectWorkspaceInstallMode(mode: 'managed' | 'public'): Promise<void> {
-  if (!workspaceMode.value || workspaceInstallMode.value === mode) return
-  authorizingWorkspace.value = false
-  workspaceInstallMode.value = mode
-  // Clear source-scoped state from the previous mode so nothing carries over
-  // (e.g. a Public-tab visit leaving standalone template options loaded, which
-  // would surface the template picker on a managed install). Public mode
-  // re-selects Standalone in initializeInstallMode.
+async function selectManagedInstallMode(): Promise<void> {
+  if (authorizingWorkspace.value || managedBuildMode.value) return
+  let authenticatedNow = false
+  if (!authStore.isSignedIn) {
+    authorizingWorkspace.value = true
+    try {
+      const status = await authStore.signIn()
+      if (!status.signedIn) return
+      authenticatedNow = true
+      if (workspaceId.value === PERSONAL_WORKSPACE_ID) await authStore.fetchWorkspaces()
+    } catch {
+      return
+    } finally {
+      authorizingWorkspace.value = false
+    }
+  }
+  if (!managedWorkspaceId.value) return
+  workspaceInstallMode.value = 'managed'
+  // Managed installs must not inherit source or template selections.
   resetSourceState(null)
   suggestedName.value = ''
   const gen = ++modeGeneration
   initializing.value = true
   try {
-    await initializeInstallMode(gen)
+    await initializeInstallMode(gen, authenticatedNow)
   } finally {
     if (gen === modeGeneration) initializing.value = false
   }
@@ -697,6 +757,22 @@ async function loadSources(): Promise<void> {
 }
 
 async function selectSourceCard(source: Source): Promise<void> {
+  if (managedBuildMode.value) {
+    workspaceInstallMode.value = 'public'
+    resetSourceState(null)
+    suggestedName.value = ''
+    const gen = ++modeGeneration
+    initializing.value = true
+    try {
+      await initializeInstallMode(gen)
+      if (gen === modeGeneration && currentSource.value?.id !== source.id) {
+        await selectSourceCard(source)
+      }
+    } finally {
+      if (gen === modeGeneration) initializing.value = false
+    }
+    return
+  }
   if (currentSource.value?.id === source.id) return
 
   if (source.id === 'standalone' && hardwareValidation && !hardwareValidation.supported) {
@@ -925,8 +1001,8 @@ function handleOpenInstPath(): void {
 }
 
 function openBuildsPage(): void {
-  if (!workspaceId.value) return
-  void window.api.comfybuilder.openBuildsPage(workspaceId.value).catch(() => {})
+  if (!managedWorkspaceId.value) return
+  void window.api.comfybuilder.openBuildsPage(managedWorkspaceId.value).catch(() => {})
 }
 
 async function validateSelectedInstallRoot(): Promise<boolean> {
@@ -1207,39 +1283,45 @@ defineExpose({ open })
           </div>
 
           <div
-            v-if="workspaceMode"
-            class="config-field"
-            data-testid="workspace-install-source-field"
+            v-if="sources.length > 0"
+            class="config-method-row"
+            role="radiogroup"
+            :aria-label="$t('newInstall.chooseMethod')"
+            data-testid="install-source-tabs"
           >
-            <span id="workspace-install-source-label" class="config-label">
-              {{ $t('newInstall.buildSourceLabel') }}
-            </span>
-            <div
-              class="workspace-install-source"
-              role="radiogroup"
-              aria-labelledby="workspace-install-source-label"
-            >
+            <template v-for="tab in installSourceTabs" :key="tab.key">
               <button
+                v-if="tab.kind === 'managed'"
                 type="button"
                 role="radio"
                 data-testid="workspace-install-source-managed"
-                :aria-checked="workspaceInstallMode === 'managed'"
-                :class="{ 'is-selected': workspaceInstallMode === 'managed' }"
-                @click="selectWorkspaceInstallMode('managed')"
+                :aria-checked="managedBuildMode"
+                :disabled="authorizingWorkspace"
+                :class="['brand-pill', { 'brand-pill--selected': managedBuildMode }]"
+                @click="selectManagedInstallMode"
               >
                 {{ $t('newInstall.managedBuilds') }}
               </button>
               <button
+                v-else
                 type="button"
                 role="radio"
-                data-testid="workspace-install-source-public"
-                :aria-checked="workspaceInstallMode === 'public'"
-                :class="{ 'is-selected': workspaceInstallMode === 'public' }"
-                @click="selectWorkspaceInstallMode('public')"
+                :data-testid="`install-source-${tab.source.id}`"
+                :aria-checked="!managedBuildMode && currentSource?.id === tab.source.id"
+                :disabled="authorizingWorkspace"
+                :class="[
+                  'brand-pill',
+                  {
+                    'brand-pill--selected': !managedBuildMode && currentSource?.id === tab.source.id
+                  }
+                ]"
+                @click="selectSourceCard(tab.source)"
               >
-                {{ $t('newInstall.publicBuilds') }}
+                {{
+                  tab.source.id === 'standalone' ? $t('newInstall.publicBuilds') : tab.source.label
+                }}
               </button>
-            </div>
+            </template>
           </div>
 
           <div v-if="managedBuildMode" class="config-field" data-testid="workspace-build-field">
@@ -1317,27 +1399,6 @@ defineExpose({ open })
           <div v-if="!managedBuildMode" class="config-advanced config-advanced--direct is-open">
             <div class="config-advanced__wrap">
               <div class="config-advanced__body">
-                <div
-                  v-if="sources.length > 1"
-                  class="config-method-row"
-                  role="radiogroup"
-                  :aria-label="$t('newInstall.chooseMethod')"
-                >
-                  <button
-                    v-for="s in sources"
-                    :key="s.id"
-                    type="button"
-                    role="radio"
-                    :aria-checked="currentSource?.id === s.id"
-                    :class="['brand-pill', { 'brand-pill--selected': currentSource?.id === s.id }]"
-                    @click="selectSourceCard(s)"
-                  >
-                    <span>{{ s.label }}</span>
-                    <span v-if="s.id === 'standalone'" class="brand-tag-recommended">
-                      {{ $t('newInstall.recommended') }}
-                    </span>
-                  </button>
-                </div>
                 <div v-if="sourceError" class="wizard-error">{{ sourceError }}</div>
                 <div v-if="currentSource" id="source-fields">
                   <div
@@ -1843,36 +1904,6 @@ defineExpose({ open })
   color: var(--neutral-200);
 }
 
-.workspace-install-source {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3px;
-  padding: 3px;
-  border: 1px solid var(--brand-surface-border);
-  border-radius: 7px;
-  background: var(--brand-surface-bg);
-}
-.workspace-install-source button {
-  min-width: 0;
-  padding: 7px 12px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-}
-.workspace-install-source button:hover,
-.workspace-install-source button.is-selected {
-  background: var(--brand-surface-bg-hover);
-  color: var(--neutral-100);
-}
-.workspace-install-source button:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 1px;
-}
-
 .workspace-build-label-row {
   display: flex;
   align-items: center;
@@ -2035,8 +2066,15 @@ defineExpose({ open })
   margin-top: 0;
 }
 
-/* Install-method chips: pill picker inside Advanced for swapping source without
- * leaving the brand chrome. Chips use the shared `.brand-pill` in main.css. */
+#source-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+#source-fields > .field {
+  margin-top: 0;
+}
+
 .config-method-row {
   display: flex;
   flex-wrap: wrap;

--- a/src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.test.ts
+++ b/src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.test.ts
@@ -22,7 +22,6 @@ const messages = {
     devPlatform: {
       workspace: {
         personalLabel: 'Personal',
-        unmanagedLabel: 'No workspace',
         switchLabel: 'Workspace',
         currentFallback: 'Current workspace',
         loadError: "Couldn't load workspaces. Retry"
@@ -31,7 +30,7 @@ const messages = {
   }
 }
 
-function mountSelector(modelValue: string | null = 'w1') {
+function mountSelector(modelValue = 'w1') {
   return mount(DevPlatformWorkspaceSelector, {
     props: { modelValue },
     global: {
@@ -131,13 +130,51 @@ describe('DevPlatformWorkspaceSelector', () => {
     ).toBe('team')
   })
 
-  it('uses an empty neutral avatar when No workspace is selected', async () => {
-    const wrapper = mountSelector(null)
+  it('uses the Personal workspace as the local selection', async () => {
+    const wrapper = mountSelector('personal')
     await flushPromises()
 
     const avatar = wrapper.get('[data-testid="devplatform-workspace-selector"] .dp-avatar')
-    expect(avatar.classes()).toContain('dp-avatar--neutral')
-    expect(avatar.text()).toBe('')
+    expect(avatar.classes()).not.toContain('dp-avatar--neutral')
+    expect(avatar.text()).toBe('P')
+  })
+
+  it('normalizes a server Personal workspace name even when its type is stale', async () => {
+    api.getAuthStatus.mockResolvedValue({
+      signedIn: true,
+      workspaceType: 'team',
+      workspaceId: 'server-personal',
+      workspaceName: 'Personal workspace'
+    })
+    api.listWorkspaces.mockResolvedValue([
+      {
+        id: 'server-personal',
+        name: 'Personal workspace',
+        type: 'team',
+        role: 'owner'
+      }
+    ])
+    const wrapper = mountSelector('server-personal')
+    await flushPromises()
+
+    expect(wrapper.get('.workspace-selector__name').text()).toBe('Personal')
+    await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
+    expect(wrapper.findAll('.workspace-selector__item')).toHaveLength(1)
+    expect(wrapper.get('.workspace-selector__item-name').text()).toBe('Personal')
+    expect(wrapper.text()).not.toContain('Personal workspace')
+  })
+
+  it('offers only Personal when signed out', async () => {
+    api.getAuthStatus.mockResolvedValue({ signedIn: false })
+    const wrapper = mountSelector('personal')
+    await flushPromises()
+
+    await wrapper.get('[data-testid="devplatform-workspace-selector"]').trigger('click')
+    expect(wrapper.findAll('.workspace-selector__item')).toHaveLength(1)
+    expect(wrapper.get('[data-testid="devplatform-workspace-personal"]').text()).toContain(
+      'Personal'
+    )
+    expect(api.listWorkspaces).not.toHaveBeenCalled()
   })
 
   it('closes without switching when the active workspace is selected', async () => {
@@ -163,17 +200,15 @@ describe('DevPlatformWorkspaceSelector', () => {
     expect(wrapper.find('[data-testid="devplatform-workspace-menu"]').exists()).toBe(false)
   })
 
-  it('selects No workspace without changing the authenticated workspace', async () => {
+  it('selects Personal without changing the authenticated workspace', async () => {
     const wrapper = mountSelector()
     await flushPromises()
     await wrapper.find('[data-testid="devplatform-workspace-selector"]').trigger('click')
-    const noWorkspace = wrapper.find('[data-testid="devplatform-workspace-unmanaged"]')
-    expect(noWorkspace.text()).toContain('No workspace')
-    expect(noWorkspace.get('.dp-avatar').classes()).toContain('dp-avatar--neutral')
-    expect(noWorkspace.get('.dp-avatar').text()).toBe('')
-    await noWorkspace.trigger('click')
+    const personal = wrapper.get('[data-testid="devplatform-workspace-personal"]')
+    expect(personal.text()).toContain('Personal')
+    await personal.trigger('click')
 
     expect(api.switchWorkspace).not.toHaveBeenCalled()
-    expect(wrapper.emitted('update:modelValue')).toEqual([[null]])
+    expect(wrapper.emitted('update:modelValue')).toEqual([['personal']])
   })
 })

--- a/src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.vue
+++ b/src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-/** Local dashboard scope selector for unmanaged installs and authenticated workspaces. */
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Check, ChevronDown } from 'lucide-vue-next'
 import DevPlatformAvatar from './DevPlatformAvatar.vue'
 import { usePopoverDismiss } from '../../composables/usePopoverDismiss'
 import { useAuthStore } from '../../stores/authStore'
+import { isPersonalWorkspace, PERSONAL_WORKSPACE_ID } from '../../../../shared/workspaces'
 
 const props = defineProps<{
-  modelValue: string | null
+  modelValue: string
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [workspaceId: string | null]
+  'update:modelValue': [workspaceId: string]
 }>()
 
 const { t } = useI18n()
@@ -30,13 +30,29 @@ const {
 } = usePopoverDismiss({ rootRef, faceRef })
 
 function workspaceLabel(workspace: { name: string; type: string }): string {
-  return workspace.type === 'team' ? workspace.name : t('devPlatform.workspace.personalLabel')
+  return isPersonalWorkspace(workspace) || workspace.type !== 'team'
+    ? t('devPlatform.workspace.personalLabel')
+    : workspace.name
 }
 
+const teamWorkspaces = computed(() =>
+  store.isSignedIn ? store.workspaces.filter((workspace) => !isPersonalWorkspace(workspace)) : []
+)
+
 const currentWorkspaceName = computed(() => {
-  if (currentWorkspaceId.value === null) return t('devPlatform.workspace.unmanagedLabel')
+  if (currentWorkspaceId.value === PERSONAL_WORKSPACE_ID) {
+    return t('devPlatform.workspace.personalLabel')
+  }
   const current = store.workspaces.find((workspace) => workspace.id === currentWorkspaceId.value)
   if (current) return workspaceLabel(current)
+  if (
+    isPersonalWorkspace({
+      name: store.status.workspaceName,
+      type: store.status.workspaceType
+    })
+  ) {
+    return t('devPlatform.workspace.personalLabel')
+  }
   if (store.status.workspaceType !== 'team') return t('devPlatform.workspace.personalLabel')
   if (store.status.workspaceName) return store.status.workspaceName
   return t('devPlatform.workspace.currentFallback')
@@ -69,11 +85,6 @@ function onSelectWorkspace(workspaceId: string): void {
   emit('update:modelValue', workspaceId)
   closeMenu()
 }
-
-function onSelectUnmanaged(): void {
-  emit('update:modelValue', null)
-  closeMenu()
-}
 </script>
 
 <template>
@@ -88,7 +99,7 @@ function onSelectUnmanaged(): void {
       :aria-label="$t('devPlatform.workspace.switchLabel')"
       @click="toggleMenu"
     >
-      <DevPlatformAvatar :name="currentWorkspaceName" :neutral="currentWorkspaceId === null" />
+      <DevPlatformAvatar :name="currentWorkspaceName" />
       <span class="workspace-selector__name">{{ currentWorkspaceName }}</span>
       <ChevronDown
         :size="14"
@@ -124,18 +135,18 @@ function onSelectUnmanaged(): void {
       <button
         type="button"
         class="workspace-selector__item"
-        :aria-pressed="currentWorkspaceId === null"
-        data-testid="devplatform-workspace-unmanaged"
-        @click="onSelectUnmanaged"
+        :aria-pressed="currentWorkspaceId === PERSONAL_WORKSPACE_ID"
+        data-testid="devplatform-workspace-personal"
+        @click="onSelectWorkspace(PERSONAL_WORKSPACE_ID)"
       >
-        <DevPlatformAvatar :name="$t('devPlatform.workspace.unmanagedLabel')" neutral />
+        <DevPlatformAvatar :name="$t('devPlatform.workspace.personalLabel')" />
         <span class="workspace-selector__identity">
           <span class="workspace-selector__item-name">{{
-            $t('devPlatform.workspace.unmanagedLabel')
+            $t('devPlatform.workspace.personalLabel')
           }}</span>
         </span>
         <Check
-          v-if="currentWorkspaceId === null"
+          v-if="currentWorkspaceId === PERSONAL_WORKSPACE_ID"
           :size="15"
           class="workspace-selector__check"
           aria-hidden="true"
@@ -143,7 +154,7 @@ function onSelectUnmanaged(): void {
       </button>
 
       <button
-        v-for="workspace in store.workspaces"
+        v-for="workspace in teamWorkspaces"
         :key="workspace.id"
         type="button"
         class="workspace-selector__item"

--- a/src/shared/workspaces.ts
+++ b/src/shared/workspaces.ts
@@ -1,0 +1,21 @@
+/** Stable local identity for the workspace that exists without an account. */
+export const PERSONAL_WORKSPACE_ID = 'personal'
+
+/** Persisted dashboard scope used by every New Instance entry point. */
+export const DASHBOARD_WORKSPACE_SETTING = 'dashboardWorkspaceId'
+
+export function isPersonalWorkspace(workspace: { name?: string; type?: string }): boolean {
+  return (
+    workspace.type === 'personal' || workspace.name?.trim().toLowerCase() === 'personal workspace'
+  )
+}
+
+export function workspaceContextId(workspace: {
+  workspaceId?: string
+  workspaceName?: string
+  workspaceType?: string
+}): string {
+  return isPersonalWorkspace({ name: workspace.workspaceName, type: workspace.workspaceType })
+    ? PERSONAL_WORKSPACE_ID
+    : workspace.workspaceId || PERSONAL_WORKSPACE_ID
+}


### PR DESCRIPTION
## Summary

- Make the dashboard and every New Instance entry point use an explicit workspace context, including signed-out Personal instances.
- Merge the server Personal workspace into the stable local Personal identity so instances remain visible after logout.
- Flatten the creation source picker into Public Builds, Managed Builds, Remote Connection, and Portable, with authentication triggered when signed-out users select Managed Builds.
- Align workspace labels, selector sizing, build terminology, tab defaults, and field spacing across authentication states.

## Test coverage

- Added coverage for Personal workspace migration, signed-out persistence, menu and dashboard routing, source-tab ordering/defaults, managed authentication, stale server workspace metadata, and consistent labels.
- Verified with 227 targeted Vitest tests, Windows chooser E2E coverage, full typecheck/build, ESLint, and Prettier checks.

## Change breakdown

Total changed lines: **811** (610 added, 201 deleted).

### Product code and localization

- **12 files**
- **316 added, 164 deleted**
- **480 changed lines (59.2%)**
- Paths:
  - `locales/en.json`
  - `locales/zh.json`
  - `src/main/installations.ts`
  - `src/main/lib/ipc/registerDevPlatformHandlers.ts`
  - `src/main/settings.ts`
  - `src/renderer/src/panel/useChooserHandoff.ts`
  - `src/renderer/src/panel/usePanelOverlays.ts`
  - `src/renderer/src/stores/authStore.ts`
  - `src/renderer/src/views/ChooserView.vue`
  - `src/renderer/src/views/InstallWizardModal.vue`
  - `src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.vue`
  - `src/shared/workspaces.ts`

### Test code

- **7 files**
- **294 added, 37 deleted**
- **331 changed lines (40.8%)**
- Paths:
  - `e2e/chooser.test.ts`
  - `src/main/installations.test.ts`
  - `src/main/lib/ipc/registerDevPlatformHandlers.test.ts`
  - `src/renderer/src/panel/PanelApp.test.ts`
  - `src/renderer/src/views/ChooserView.test.ts`
  - `src/renderer/src/views/InstallWizardModal.test.ts`
  - `src/renderer/src/views/devplatform/DevPlatformWorkspaceSelector.test.ts`
