### PR TITLE
fix(dashboard): center instance card grid on wide screens

### DIFF
--- a/src/renderer/src/views/chooser/ChooserFamilyGrid.vue
+++ b/src/renderer/src/views/chooser/ChooserFamilyGrid.vue
@@ -113,7 +113,7 @@ function unlockTileSize(el: Element): void {
    * the grid reserves blank tracks across the full width, leaving 1-3 cards
    * stuck at the left edge. Fixed tracks wrap honestly. */
   grid-template-columns: repeat(auto-fit, 280px);
-  justify-content: start;
+  justify-content: safe center;
   gap: 16px;
   align-content: start;
 }


### PR DESCRIPTION
Fixes #1520

### Problem

The Dashboard instance-card row (`.chooser-family-grid`) is a grid with fixed-width tracks (`repeat(auto-fit, 280px)`) and `justify-content: start`, so on wide windows the whole track group hugs the left edge while the logo and search box above are centered. Details, screenshots and DevTools traces in #1520.

### Fix

Center the track group with an overflow-safe fallback:

- `justify-content: start` → `justify-content: safe center`

With `safe center`, narrow windows keep the current left-aligned behavior when the tracks overflow, so only wide layouts change.

### Verification

- Reproduced on Comfy Desktop v1.0.47 (Windows 11 build 26200, 1920×1080); traced via `--remote-debugging-port=9222` + DevTools.
- Applying `justify-content: center` live in DevTools centers the cards as expected (screenshots in #1520).