### PR TITLE
fix(telemetry): Datadog RUM never starts a session in packaged builds

### DIFF
--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -371,6 +371,8 @@ async function initializeProviders(): Promise<void> {
           import.meta.env.VITE_DATADOG_RUM_SESSION_SAMPLE_RATE,
           100
         ),
+        // `createHostWindow.ts` `loadTitleBarUrl` uses `file://` packaged, where Chromium ignores cookies.
+        sessionPersistence: 'local-storage',
         // Session replay is intentionally not configured. Datadog defaults
         // to off when the field is omitted; reintroduce only as a deliberate
         // code change in a release.

--- a/src/renderer/src/lib/rendererBootstrap.ts
+++ b/src/renderer/src/lib/rendererBootstrap.ts
@@ -376,9 +376,9 @@ async function initializeProviders(): Promise<void> {
         // Session replay is intentionally not configured. Datadog defaults
         // to off when the field is omitted; reintroduce only as a deliberate
         // code change in a release.
-        trackResources: true,
-        trackLongTasks: true,
-        trackUserInteractions: true
+        trackResources: false,
+        trackLongTasks: false,
+        trackUserInteractions: false
       })
       isDatadogInitialized = true
       // Tag every RUM event with the renderer surface so queries can


### PR DESCRIPTION
## The bug

Datadog RUM has never delivered data from a **packaged** Desktop build — for any user, since RUM was introduced (#102, March). Dev builds are unaffected, which is why nobody noticed: everyone who checked was on a dev build, watching real events arrive.

Root cause is a two-part interaction:

1. `datadogRum.init()` in `rendererBootstrap.ts` doesn't set `sessionPersistence`, so the SDK defaults to **cookie-only** session storage.
2. Packaged builds load the renderers via `loadFile()` (`createHostWindow.ts` → `loadTitleBarUrl`), i.e. a `file://` origin — where Chromium silently no-ops cookie writes. Dev builds load from Vite over `http://localhost:5173`, where cookies work.

No cookie → no session → `getInternalContext()` returns `null` → the SDK never queues or sends anything. No error is surfaced anywhere; it just silently does nothing.

Supporting evidence (queries, session-volume history, retention caveats) is in an internal doc — ask Simon.

## The fix

**Commit 1** — `sessionPersistence: 'local-storage'`. `localStorage` works fine on the packaged `file://` origin (verified empirically; cookies verifiably do not).

**Commit 2** — `trackResources/trackLongTasks/trackUserInteractions: false`, deliberately separate so it can be dropped in review. Rationale: with sessions now working for the first time, leaving autocapture on at `sessionSampleRate: 100` would switch on views/resources/long-tasks/interaction capture for **every consented user at once** — a Datadog volume/cost step-change nobody has consciously decided to take. This commit scopes DD to the explicit mirrored failure events (its stated purpose: alerting, not analysis). If we *want* full autocapture, drop this commit — but as its own decision.

## Validation — end-to-end confirmed

✅ **A packaged build of this branch delivered RUM data to real Datadog, indexed and queryable** — the first packaged-origin (`view.url: file://…`) RUM events this org has received: 1 session, 2 views, 3 custom actions (2026-09-12, tagged `env:simon-local version:rum-fix-validation`; anyone with DD access can run that query). The renderer's `fetch` to the intake returned HTTP 202, confirmed at the JS layer.

✅ Session bootstrap: `DD_RUM.getInternalContext()` returns a session id on this branch; `null` without commit 1.

⚠️ Two caveats for reviewers, in the interest of honesty:
- Across earlier headless test iterations, delivery was **intermittent** — some runs with a live session produced no intake traffic within their observation window, and the run-to-run difference was not pinned down. Ruled out as causes: renderer timer throttling (timer fidelity measured at 1000.0ms ± 0.3), consent, sampling, CSP, `beforeSend`, offline state. Real-desktop conditions are expected to be more stable than the headless rig, but that expectation is unproven.
- Electron's main-process `session.defaultSession.webRequest` hooks do **not** observe this renderer's fetch traffic (false negative) — relevant to anyone debugging this in future; observe at the JS layer or in DD itself.

## Impact

This un-blocks the Datadog mirror for **every existing tap** (`executionTap`, `hardwareTap`) and the pending assets tap (#1488) — none of which have ever had their mirrored events reach Datadog from a real user's machine.

Worth knowing for reviewers: no Datadog monitor currently references any `comfy.desktop.*` event, so landing this makes data *available* but alerting also needs monitors actually created — a follow-up ops task, not part of this PR.